### PR TITLE
Use makeiso to generate ISO instead of geniso-isospec

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -9,11 +9,7 @@ cos-build() {
 
 docker run \
  -e FLAVOR=$flavor \
- -ti --privileged=true \
- --device=/dev/loop-control:/dev/loop-control \
- --device=/dev/loop0:/dev/loop0 \
- --cap-add SYS_ADMIN \
- --rm \
+ -ti --rm \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -v $PWD:/cOS \
  cos-builder

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,41 @@ on:
     tags:
       - v*
 jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+       include:
+         - flavor: "opensuse"
+         - flavor: "fedora"
+         - flavor: "ubuntu"
+    env:
+      FLAVOR: ${{ matrix.flavor }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - run: |
+        git fetch --prune --unshallow
+
+    - name: setup-docker
+      uses: docker-practice/actions-setup-docker@master
+
+    # We patch docker to use all the HD available in GH action free runners
+    - name: Patch Docker Daemon data-root
+      run: |
+        DOCKER_DATA_ROOT='/mnt/var/lib/docker'
+        DOCKER_DAEMON_JSON='/etc/docker/daemon.json'
+        sudo mkdir -p "${DOCKER_DATA_ROOT}"
+        jq --arg dataroot "${DOCKER_DATA_ROOT}" '. + {"data-root": $dataroot}' "${DOCKER_DAEMON_JSON}" > "/tmp/docker.json.tmp"
+        sudo mv "/tmp/docker.json.tmp" "${DOCKER_DAEMON_JSON}"
+        sudo systemctl restart docker
+
+    - name: Build  🔧
+      shell: 'script -q -e -c "bash {0}"'
+      run: |
+        source .envrc
+        cos-build $FLAVOR
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -119,7 +154,7 @@ jobs:
     - name: Install deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y xorriso squashfs-tools dosfstools
+        sudo apt-get install -y xorriso squashfs-tools
         sudo -E make deps
 
     - name: Build ISO from local build 🔧
@@ -145,12 +180,6 @@ jobs:
           *.iso
           *.sha256
         if-no-files-found: error
-    - uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        name: luet-build-${{ matrix.flavor }}.log
-        path: isowork/*.log
-        if-no-files-found: warn
 
   qemu:
       runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
 FROM opensuse/leap
 
-RUN zypper in -y docker curl squashfs xorriso dosfstools make
-
-RUN curl https://get.mocaccino.org/luet/get_luet_root.sh |  sh
 ENV LUET_NOLOCK=true
 
-RUN luet install -y repository/mocaccino-extra-stable
-RUN luet install -y utils/jq utils/yq system/luet-devkit container/img
-
-RUN zypper in -y which
+RUN zypper in -y docker curl squashfs xorriso make which
 
 COPY . /cOS
 WORKDIR /cOS
+
+RUN make deps
 
 ENTRYPOINT ["/usr/bin/make"]
 CMD ["build", "local-iso"]

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -22,8 +22,6 @@ Those are not required for building - you can disable image push (`--push`) from
 
 ## Building locally
 
-### Build cOS With docker
-
 cOS has a docker image which can be used to build cOS locally in order to generate the cOS packages and the cOS iso from your checkout.
 
 From your git folder:
@@ -42,52 +40,129 @@ $> cos-build
 
 ### Requirements for local build
 
-- Luet installed locally (You can install it with `curl https://get.mocaccino.org/luet/get_luet_root.sh | sudo sh` )
+To get requirements installed locally, run:
 
-#### Building packages
+```bash
+$> make deps
+```
 
-- Docker/or img for building packages locally
+or you need:
 
-#### Building ISO
+- [luet](https://github.com/mudler/luet)
+- [luet-makeiso](https://github.com/mudler/luet-makeiso)
+- `squashfs-tools`
+- `xorriso`
+- `yq` (version `3.x`)  (optional)
+- `jq` (optional)
 
-- Luet-devkit (If you manually installed luet add the [official luet-repo](https://github.com/Luet-lab/luet-repo) first. Install it with `luet install -y system/luet-devkit`)
-- squashfs/xorriso/dosfstools for building ISO ( from your OS )
-- yq and jq (`luet install -y repository/mocaccino-extra-stable && luet install -y utils/yq utils/yq`)
+_Note_: Running `make` deps will install only `luet`, `luet-makeiso`, `yq` and `jq`. `squashfs-tools` and `xorriso` needs to be provided by the OS.
 
-#### Build all packages locally
+### Manually install dependencies
+
+To install luet locally, you can also run as root:
+```bash
+$> curl https://get.mocaccino.org/luet/get_luet_root.sh | sh
+```
+or either build from source (see [luet](https://github.com/mudler/luet)).
+
+The Luet official repository that are being installed by the script above are:
+- [official Luet repository](https://github.com/Luet-lab/luet-repo)
+- [mocaccino-extra repository](https://github.com/mocaccinoOS/mocaccino-extra) (installable afterwards also with `luet install -y repository/mocaccino-extra-stable`) that contains the `yq` and `jq` versions that are used by the CI. 
+
+
+#### luet-makeiso
+
+Available in the [official Luet repository](https://github.com/Luet-lab/luet-repo). After installing `luet` with the curl command above, is sufficient to:
+
+```bash
+$> luet install -y extension/makeiso
+```
+
+to install it locally, otherwise grab the binary from [luet-makeiso](https://github.com/mudler/luet-makeiso) releases.
+
+#### yq and jq
+`yq` (version `3.x`) and `jq` are used to retrieve the list of packages to build in order to produce the final ISOs. Those are not strictly required, see the Note above. 
+
+Install the `mocaccino-extra` repository:
+
+```bash
+$> luet install -y repository/mocaccino-extra-stable
+```
+
+They are installable with:
+
+```bash
+$> luet install -y utils/yq utils/yq
+```
+
+_Note_: `yq` and `jq` are just used to generate the list of packages to build, and you don't need to have them installed if you manually specify the packages to be compiled.
+
+### Build all packages locally
 
 ```
-make build
+$> make build
 ```
 
 To clean from previous runs, run `make clean`.
 
+_Note_: The makefile uses `yq` and `jq` to retrieve the packages to build from the iso specfile. If you don't have `jq` and `yq` installed, you must pass by the packages manually with `PACKAGES` (e.g. `PACKAGES="system/cos live/systemd-boot live/boot live/syslinux`).
+
 You might want to build packages running as `root` or `sudo -E` if you intend to preserve file permissions in the resulting packages (mainly for `xattrs`, and so on).
 
-#### Build ISO
+### Build ISO
 
 If using opensuse, first install the required deps:
 
 ```
-zypper in -y squashfs xorriso dosfstools
+$> zypper in -y squashfs xorriso dosfstools
 ```
 
 and then, simply run
 
 ```
-make local-iso
+$> make local-iso
 ```
 
-#### Testing ISO changes
+### Testing ISO changes
 
 To test changes against a specific set of packages, you can for example:
 
 ```bash
 
-make PACKAGES="live/init"  build local-iso
+$> make PACKAGES="live/init"  build local-iso
 
 ```
 
 root is required because we want to keep permissions on the output packages (not really required for experimenting).
 
-Note: Remind to bump `definition.yaml` files where necessary, otherwise it would generate packages from existing images
+### Run with qemu
+
+After you have the iso locally, run
+
+```bash
+
+$> QEMU=qemu-system-x86_64 make run-qemu
+
+```
+
+### Run tests
+
+Requires: Virtualbox or libvirt, vagrant, packer
+
+We have a test suite which runs over SSH.
+
+To create the vagrant image:
+
+```bash
+
+$> PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso" make packer
+
+```
+
+To run the tests:
+
+```bash
+
+$> make test
+
+```

--- a/iso/cOS.yaml
+++ b/iso/cOS.yaml
@@ -12,9 +12,7 @@ initramfs:
   kernel_file: "vmlinuz"
   rootfs_file: "initrd"
 
-overlay: "true"
+overlay: true
 image_prefix: "cOS-0."
-image_date: "true"
+image_date: true
 label: "COS_LIVE"
-luet:
-  config: build/conf.yaml


### PR DESCRIPTION
[luet-makeiso](https://github.com/mudler/luet-makeiso) is a golang binary having almost all needed to build the ISO (that I'll be happy to move to our own org once things are settled).
The only host requirement is mksquashfs and xorriso - until then that's the only
requirement.

`makeiso` is way more extensible with the new Golang structure, and
easier to embed into pipelines, definetly much more than the current extension. 

We now just use `jq` and `yq` to build the package list to build, and to generate the repository when running a build against the remote repositories, so derivatives don't need to install that anymore

Related to #27