### PR TITLE
Add major packages needed to run longhorn and k3s

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -19,7 +19,7 @@ cos-build() {
 cos-build-vagrant() {
   iso=$(ls $PWD/*.iso)
   pushd packer > /dev/null
-  packer build -var "iso=$iso" -var='sleep=30s' -var='vagrant=true' -only virtualbox-iso images.json
+  packer build -var "iso=$iso" -var='sleep=30s' -var='feature=vagrant' -only virtualbox-iso images.json
   popd > /dev/null
 }
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -203,7 +203,7 @@ jobs:
 
       - name: Build QEMU Image 🔧
         run: |
-          PACKER_ARGS="-var='accellerator=none' -var='sleep=5m' -var='vagrant=true' -only qemu" make packer
+          PACKER_ARGS="-var='accellerator=none' -var='sleep=5m' -var='feature=vagrant' -only qemu" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-${{ matrix.flavor }}-QEMU.box
@@ -260,7 +260,7 @@ jobs:
           brew install hashicorp/tap/packer
       - name: Build VBox Image 🔧
         run: |
-          PACKER_ARGS="-var='sleep=5m' -var='vagrant=true' -only virtualbox-iso" make packer
+          PACKER_ARGS="-var='sleep=5m' -var='feature=vagrant' -only virtualbox-iso" make packer
           ls packer
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -225,10 +225,10 @@ jobs:
         with:
           name: cOS-${{ matrix.flavor }}.iso.zip
 
-      - name: Install deps
-        run: |
-          brew tap hashicorp/tap
-          brew install hashicorp/tap/packer
+      # - name: Install deps
+      #   run: |
+      #     brew tap hashicorp/tap
+      #     brew install hashicorp/tap/packer
       - name: Build VBox Image 🔧
         run: |
           PACKER_ARGS="-var='sleep=5m' -only virtualbox-iso" make packer
@@ -254,10 +254,10 @@ jobs:
         with:
           name: cOS-${{ matrix.flavor }}.iso.zip
 
-      - name: Install deps
-        run: |
-          brew tap hashicorp/tap
-          brew install hashicorp/tap/packer
+      # - name: Install deps
+      #   run: |
+      #     brew tap hashicorp/tap
+      #     brew install hashicorp/tap/packer
       - name: Build VBox Image 🔧
         run: |
           PACKER_ARGS="-var='sleep=5m' -var='feature=vagrant' -only virtualbox-iso" make packer

--- a/Makefile
+++ b/Makefile
@@ -151,4 +151,5 @@ test-clean:
 	vagrant box remove cos || true
 
 test: test-clean tests/Vagrantfile prepare-test
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./smoke ./upgrades ./features
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./recovery

--- a/README.md
+++ b/README.md
@@ -137,6 +137,34 @@ This stage is executed when network is available
 
 This stage is executed `5m` after boot and periodically each `60m`.
 
+## cOS runtime features
+
+cOS ships default cloud-init configurations files that are available under `/system/features` for example purposes, and to quickly enable testing features.
+
+Features can be enabled/disabled with `cos-feature`. For example, after install, to enable `k3s` it's sufficient to type `cos-feature enable k3s` and reboot.
+
+See `cos-feature list` for the available features.
+
+
+```
+$> cos-feature list
+
+====================
+cOS features list
+
+To enable, run: cos-feature enable <feature>
+To disable, run: cos-feature disable <feature>
+====================
+
+- carrier
+- harvester
+- k3s
+- vagrant (enabled)
+...
+```
+
+You are encouraged to copy them over to `/usr/local/cloud-config` or `/oem` and customize them as you see fit.
+
 ## OEM customizations
 
 It is possible to install a custom cloud-init file during install with `--config` to `cos-installer` or, it's possible to add more files manually to the `/oem` folder after installation.

--- a/packages/base/definition.yaml
+++ b/packages/base/definition.yaml
@@ -1,6 +1,6 @@
 name: "base"
 category: "distro"
-version: "0.3.4"
+version: "0.3.5"
 
 hidden: true # No need to make it installable for now
 

--- a/packages/cos-features/build.yaml
+++ b/packages/cos-features/build.yaml
@@ -1,0 +1,9 @@
+requires:
+- name: "yip"
+  category: "system"
+  version: ">=0"
+steps:
+- mkdir -p /system/features
+- cp -rfv features/*.yaml /system/features
+- cp -rfv cos-feature.sh /usr/bin/cos-feature
+- chmod +x /usr/bin/cos-feature

--- a/packages/cos-features/cos-feature.sh
+++ b/packages/cos-features/cos-feature.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -e
+
+OEMDIR=/oem
+FEATURESDIR=/system/features
+
+usage()
+{
+    echo "Usage: cos-feature [list|enable|disable] <feature>"
+    echo ""
+    echo "Example: cos-feature enable k3s"
+    echo ""
+    echo "To list available features, run: cos-feature list"
+    echo "To enable, run: cos-feature enable <feature>"
+    echo "To disable, run: cos-feature disable <feature>"
+    echo ""
+    exit 1
+}
+
+list() {
+  echo ""
+  echo "===================="
+  echo "cOS features list"
+  echo ""
+  echo "To enable, run: cos-feature enable <feature>"
+  echo "To disable, run: cos-feature disable <feature>"
+  echo "===================="
+  echo ""
+  for i in $FEATURESDIR/*.yaml; do
+    f=$(basename $i .yaml)
+    if [ -L "$OEMDIR/features/${f}.yaml" ]; then
+      enabled="(enabled)"
+    fi
+    echo "- $f $enabled"
+  done
+
+}
+
+enable() {
+  for i in $@; do
+    if [ ! -e "$FEATURESDIR/$i.yaml" ]; then
+      echo "Feature not present"
+      exit 1
+    fi
+    if [ ! -d "$OEMDIR/features" ]; then
+      mkdir $OEMDIR/features
+    fi
+    ln -s $FEATURESDIR/$i.yaml $OEMDIR/features/$i.yaml
+    echo "$i enabled"
+  done
+}
+
+disable() {
+  for i in $@; do
+    if [ -L "$OEMDIR/features/$i.yaml" ]; then
+      rm $OEMDIR/features/$i.yaml
+      echo "Feature $i disabled"
+    else
+      echo "Feature $i not enabled"
+    fi
+  done
+}
+
+while [ "$#" -gt 0 ]; do
+    case $1 in
+        list)
+            shift 1
+            list
+            ;;
+        enable)
+            shift 1
+            enable $@
+            ;;
+        disable)
+            shift 1
+            disable $@
+            ;;
+        -h)
+            usage
+            ;;
+        --help)
+            usage
+            ;;
+        *)
+            if [ "$#" -gt 2 ]; then
+                usage
+            fi
+            INTERACTIVE=true
+            break
+            ;;
+    esac
+done

--- a/packages/cos-features/cos-feature.sh
+++ b/packages/cos-features/cos-feature.sh
@@ -46,6 +46,10 @@ enable() {
     if [ ! -d "$OEMDIR/features" ]; then
       mkdir $OEMDIR/features
     fi
+    if [ -L "$OEMDIR/features/$i.yaml" ]; then
+      echo "Feature $i enabled already"
+      continue
+    fi
     ln -s $FEATURESDIR/$i.yaml $OEMDIR/features/$i.yaml
     echo "$i enabled"
   done

--- a/packages/cos-features/definition.yaml
+++ b/packages/cos-features/definition.yaml
@@ -1,0 +1,3 @@
+name: cos-features
+category: system
+version: "0.3.1"

--- a/packages/cos-features/features/carrier.yaml
+++ b/packages/cos-features/features/carrier.yaml
@@ -1,0 +1,37 @@
+stages:
+   network:
+     - name: "Setup k3s"
+       directories:
+       - path: "/usr/local/bin"
+         permissions: 0755
+         owner: 0
+         group: 0
+       commands:
+       - |
+            curl -sfL https://get.k3s.io | \
+            INSTALL_K3S_VERSION="v1.20.4+k3s1" \
+            INSTALL_K3S_EXEC="--data-dir /usr/local/rancher/k3s" \
+            sh -
+     - name: "Setup Longhorn"
+       commands:
+       - |
+          curl https://raw.githubusercontent.com/longhorn/longhorn/v1.1.0/deploy/longhorn.yaml | \
+          sed -e 's/#- name: KUBELET_ROOT_DIR/- name: KUBELET_ROOT_DIR/g' -e 's$#  value: /var/lib/rancher/k3s/agent/kubelet$  value: /var/lib/kubelet$g'  | \
+          sed -e 's|default-data-path:|default-data-path: /usr/local/rancher/longhorn|g' | \
+          k3s --data-dir /usr/local/rancher/k3s kubectl apply -f -
+     - name: "Setup helm"
+       commands:
+       - |
+          if [ ! -e "/usr/local/bin/helm" ]; then
+            curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+          fi
+     - name: "Setup carrier"
+       commands:
+       - |
+          export IMG_SHA256="b6b345c0a8e700aad02d1dd1a46585e7e40a9a8b2b3947a51f3b45efce30340a"
+          curl -fSL "https://github.com/SUSE/carrier/releases/download/v0.0.4/carrier-linux-amd64" -o "/usr/local/bin/carrier" \
+          && echo "${IMG_SHA256}  /usr/local/bin/carrier" | sha256sum -c - \
+          && chmod a+x "/usr/local/bin/carrier"
+
+          KUBECONFIG=/etc/rancher/k3s/k3s.yaml CARRIER_CONFIG=/usr/local/carrier.yaml carrier install
+name: "Opinionated platform that runs on Kubernetes, that takes you from App to URL in one step."

--- a/packages/cos-features/features/harvester.yaml
+++ b/packages/cos-features/features/harvester.yaml
@@ -1,0 +1,43 @@
+stages:
+   network:
+     - name: "Setup k3s"
+       directories:
+       - path: "/usr/local/bin"
+         permissions: 0755
+         owner: 0
+         group: 0
+       - path: "/run/harvester"
+         permissions: 0755
+         owner: 0
+         group: 0
+       commands:
+       - |
+            curl -sfL https://get.k3s.io | \
+            INSTALL_K3S_VERSION="v1.20.4+k3s1" \
+            INSTALL_K3S_EXEC="--data-dir /usr/local/rancher/k3s" \
+            sh -
+       systemctl:
+        start:
+        - iscsid
+     - name: "Setup Longhorn"
+       commands:
+       - |
+          curl https://raw.githubusercontent.com/longhorn/longhorn/v1.1.0/deploy/longhorn.yaml | \
+          sed -e 's/#- name: KUBELET_ROOT_DIR/- name: KUBELET_ROOT_DIR/g' -e 's$#  value: /var/lib/rancher/k3s/agent/kubelet$  value: /var/lib/kubelet$g'  | \
+          sed -e 's|default-data-path:|default-data-path: /usr/local/rancher/longhorn|g' | \
+          k3s --data-dir /usr/local/rancher/k3s kubectl apply -f -
+       commands:
+       - |
+          if [ ! -e "/usr/local/bin/helm" ]; then
+            curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+          fi
+     - name: "Harvester"
+       commands:
+       - |
+            export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+            curl -L https://github.com/rancher/harvester/archive/refs/heads/master.tar.gz | tar -xz -C /run/harvester && \
+            cd /run/harvester/**/deploy/charts && \
+            k3s --data-dir /usr/local/rancher-k3s kubectl create ns harvester-system && \
+            helm install harvester harvester --namespace harvester-system --set minio.persistence.storageClass=longhorn
+
+name: "Rancher Harvester is an open source hyper-converged infrastructure (HCI) software built on Kubernetes. It is an open source alternative to vSphere and Nutanix."

--- a/packages/cos-features/features/harvester.yaml
+++ b/packages/cos-features/features/harvester.yaml
@@ -6,10 +6,6 @@ stages:
          permissions: 0755
          owner: 0
          group: 0
-       - path: "/run/harvester"
-         permissions: 0755
-         owner: 0
-         group: 0
        commands:
        - |
             curl -sfL https://get.k3s.io | \
@@ -32,6 +28,11 @@ stages:
             curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           fi
      - name: "Harvester"
+       directories:
+       - path: "/run/harvester"
+         permissions: 0755
+         owner: 0
+         group: 0
        commands:
        - |
             export KUBECONFIG=/etc/rancher/k3s/k3s.yaml

--- a/packages/cos-features/features/k3s.yaml
+++ b/packages/cos-features/features/k3s.yaml
@@ -1,0 +1,22 @@
+stages:
+   network:
+     - name: "Setup k3s"
+       directories:
+       - path: "/usr/local/bin"
+         permissions: 0755
+         owner: 0
+         group: 0
+       commands:
+       - |
+            curl -sfL https://get.k3s.io | \
+            INSTALL_K3S_VERSION="v1.20.4+k3s1" \
+            INSTALL_K3S_EXEC="--data-dir /usr/local/rancher/k3s" \
+            sh -
+     - name: "Setup Longhorn"
+       commands:
+       - |
+          curl https://raw.githubusercontent.com/longhorn/longhorn/v1.1.0/deploy/longhorn.yaml | \
+          sed -e 's/#- name: KUBELET_ROOT_DIR/- name: KUBELET_ROOT_DIR/g' -e 's$#  value: /var/lib/rancher/k3s/agent/kubelet$  value: /var/lib/kubelet$g'  | \
+          sed -e 's|default-data-path:|default-data-path: /usr/local/rancher/longhorn|g' | \
+          k3s --data-dir /usr/local/rancher/k3s kubectl apply -f -
+name: "Lightweight Kubernetes. Production ready, easy to install, half the memory, all in a binary less than 100 MB."

--- a/packages/cos-features/features/vagrant.yaml
+++ b/packages/cos-features/features/vagrant.yaml
@@ -1,0 +1,23 @@
+stages:
+   network:
+     - name: "Setup users"
+       ensure_entities:
+       - path: /etc/passwd
+         entity: |
+            kind: "user"
+            username: "vagrant"
+            password: "x"
+            homedir: "/run/tmp/vagrant"
+            shell: "/bin/bash"
+       - path: /etc/shadow
+         entity: |
+            kind: "shadow"
+            username: "vagrant"
+            password: ""
+       commands:
+       - mkdir -p /run/tmp/vagrant
+     - name: "Setup pubkey"
+       authorized_keys:
+        vagrant:
+        - https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub
+name: "Setup for the vagrant user"

--- a/packages/cos/build.yaml
+++ b/packages/cos/build.yaml
@@ -17,6 +17,9 @@ requires:
 - name: "immutable-rootfs"
   category: "system"
   version: ">=0"
+- name: cos-features
+  category: system
+  version: ">=0"
 
 steps:
 - sed -i 's/:VERSION:/{{.Values.version}}/g' setup.yaml
@@ -82,8 +85,8 @@ excludes:
 - ^/var/lib/YaST2
 
 # Perl
-- ^/usr/bin/perl.*
-- ^/usr/lib/perl.*
+# - ^/usr/bin/perl.*
+# - ^/usr/lib/perl.*
 
 # Wget - we are only shipping curl
 - ^/etc/wgetrc

--- a/packages/cos/definition.yaml
+++ b/packages/cos/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos"
 category: "system"
-version: 0.4.36
+version: "0.4.38"
 brand_name: "cOS"

--- a/packages/cos/definition.yaml
+++ b/packages/cos/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos"
 category: "system"
-version: "0.4.38"
+version: "0.4.39"
 brand_name: "cOS"

--- a/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
+++ b/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
@@ -21,7 +21,7 @@ install() {
     declare moddir=${moddir}
     declare systemdutildir=${systemdutildir}
     inst_multiple \
-        mount mountpoint yip cos-setup sort
+        mount mountpoint yip cos-setup sort rmdir
     inst_hook cmdline 30 "${moddir}/parse-cos-overlay.sh"
     inst_hook initqueue/finished 30 "${moddir}/cos-wait-oem.sh"
     inst_hook pre-pivot 10 "${moddir}/cos-mount-layout.sh"

--- a/packages/immutable-rootfs/build.yaml
+++ b/packages/immutable-rootfs/build.yaml
@@ -11,10 +11,10 @@ steps:
 # Mount /tmp as tmpfs by default as set by systemd itself
 - cp /usr/share/systemd/tmp.mount /etc/systemd/system
 {{end}}
-- cp -r 30cos-immutable-rootfs /usr/lib/dracut/modules.d 
+- cp -r 30cos-immutable-rootfs /usr/lib/dracut/modules.d
 - |
     kernel=$(ls /lib/modules | head -n1) && \
-    dracut --verbose --no-hostonly --no-hostonly-cmdline --xz \
+    dracut --verbose --no-hostonly --omit multipath --no-hostonly-cmdline --xz \
         -f "/boot/initrd-${kernel}" --add " dmsquash-live cos-immutable-rootfs " \
         "${kernel}" && \
     ln -sf "initrd-${kernel}" /boot/initrd

--- a/packages/immutable-rootfs/definition.yaml
+++ b/packages/immutable-rootfs/definition.yaml
@@ -1,3 +1,3 @@
 name: "immutable-rootfs"
 category: "system"
-version: "0.0.17"
+version: "0.0.19"

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.6.30"
+version: "0.6.32"

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.6.29"
+version: "0.6.30"

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -120,6 +120,8 @@ do_format()
     partprobe ${DEVICE} 2>/dev/null || true
     sleep 2
 
+    dmsetup remove_all 2>/dev/null || true
+
     PREFIX=${DEVICE}
     if [ ! -e ${PREFIX}${STATE_NUM} ]; then
         PREFIX=${DEVICE}p

--- a/packages/installer/upgrade.sh
+++ b/packages/installer/upgrade.sh
@@ -175,6 +175,9 @@ cleanup2()
         umount ${TARGET}/usr/local || true
         umount ${TARGET}/ || true
     fi
+    if [ -n "$UPGRADE_RECOVERY" ] && [ $UPGRADE_RECOVERY == true ]; then
+	umount ${STATEDIR} || true
+    fi
 }
 
 cleanup()

--- a/packages/installer/upgrade.sh
+++ b/packages/installer/upgrade.sh
@@ -77,8 +77,8 @@ prepare_target() {
     mkdir -p ${STATEDIR}/cOS || true
     rm -rf ${STATEDIR}/cOS/transition.img || true
     dd if=/dev/zero of=${STATEDIR}/cOS/transition.img bs=1M count=3240
-    mkfs.ext4 ${STATEDIR}/cOS/transition.img
-    mount -t ext4 -o loop ${STATEDIR}/cOS/transition.img $TARGET
+    mkfs.ext2 ${STATEDIR}/cOS/transition.img
+    mount -t ext2 -o loop ${STATEDIR}/cOS/transition.img $TARGET
 }
 
 mount_image() {

--- a/packer/images.json
+++ b/packer/images.json
@@ -1,15 +1,15 @@
-{                                   
-    "builders": [                                                                                     
-      {                                                             
+{
+    "builders": [
+      {
         "boot_wait": "{{user `sleep`}}",
-        "disk_size": "{{user `disk_size`}}",                                                                                                                                                                                                   
-        "guest_additions_mode": "disable",                   
-        "guest_os_type": "cOS",                        
-        "headless": true,                                                                                               
+        "disk_size": "{{user `disk_size`}}",
+        "guest_additions_mode": "disable",
+        "guest_os_type": "cOS",
+        "headless": true,
         "iso_url": "{{user `iso`}}",
         "iso_checksum": "none",
-        "shutdown_command": "shutdown -hP now",     
-        "ssh_password": "{{user `root_password`}}",  
+        "shutdown_command": "shutdown -hP now",
+        "ssh_password": "{{user `root_password`}}",
         "ssh_username": "{{user `root_username`}}",
         "format": "ova",
         "ssh_timeout": "1m",
@@ -74,7 +74,7 @@
      {
         "inline": [
           "INTERACTIVE=false cos-installer --config /90_custom.yaml /dev/sda",
-          "if [ {{user `vagrant`}} == true ]; then mount /dev/disk/by-label/COS_OEM /oem; cp -rf /vagrant.yaml /oem/vagrant.yaml; fi"
+          "if [ -n \"{{user `feature`}}\" ]; then mount /dev/disk/by-label/COS_OEM /oem; cos-feature enable {{user `feature`}}; fi"
         ],
         "pause_after": "30s",
         "type": "shell"
@@ -90,7 +90,6 @@
       "iso": "",
       "sleep": "30s",
       "accellerator": "kvm",
-      "vagrant": "false"
+      "feature": ""
     }
   }
-      

--- a/tests/features/feature_test.go
+++ b/tests/features/feature_test.go
@@ -1,0 +1,56 @@
+package cos_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/cOS/tests/sut"
+)
+
+var _ = Describe("cOS Feature tests", func() {
+	var s *sut.SUT
+	BeforeEach(func() {
+		s = sut.NewSUT()
+		s.EventuallyConnects(360)
+	})
+
+	Context("After install", func() {
+		It("can enable a persistent k3s install", func() {
+			out, err := s.Command("cos-feature enable k3s")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).Should(ContainSubstring("k3s enabled"))
+
+			s.Reboot()
+
+			out, err = s.Command("cos-feature list")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).Should(ContainSubstring("k3s (enabled)"))
+
+			Eventually(func() string {
+				out, _ := s.Command("k3s --data-dir /usr/local/rancher/k3s/ kubectl get pods -A")
+				return out
+
+			}, time.Duration(time.Duration(400)*time.Second), time.Duration(5*time.Second)).Should(ContainSubstring("local-path-provisioner"))
+
+			out, err = s.Command("k3s --data-dir /usr/local/rancher/k3s/ kubectl create deployment test-sut-deployment --image nginx")
+			Expect(err).ToNot(HaveOccurred())
+
+			s.Reboot()
+			Eventually(func() string {
+				out, _ := s.Command("k3s --data-dir /usr/local/rancher/k3s/ kubectl get pods -A")
+				return out
+
+			}, time.Duration(time.Duration(900)*time.Second), time.Duration(5*time.Second)).Should(ContainSubstring("test-sut-deployment"))
+
+			out, err = s.Command("cos-feature disable k3s")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).Should(ContainSubstring("k3s disabled"))
+			s.Reboot()
+
+			out, err = s.Command("cos-feature disable k3s")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).Should(ContainSubstring("Feature k3s not enabled"))
+		})
+	})
+})

--- a/tests/features/tests_suite_test.go
+++ b/tests/features/tests_suite_test.go
@@ -1,0 +1,13 @@
+package cos_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "cOS Features test Suite")
+}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,4 +1,4 @@
-module github.com/mudler/cOS/tests
+module github.com/rancher-sandbox/cOS/tests
 
 go 1.14
 

--- a/tests/recovery/recovery_test.go
+++ b/tests/recovery/recovery_test.go
@@ -1,0 +1,80 @@
+package cos_test
+
+import (
+	"github.com/rancher-sandbox/cOS/tests/sut"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("cOS Recovery upgrade tests", func() {
+	var s *sut.SUT
+	BeforeEach(func() {
+		s = sut.NewSUT()
+		s.EventuallyConnects()
+	})
+
+	Context("upgrading recovery", func() {
+
+		When("specific images", func() {
+			It("upgrades to a specific image and reset back to the installed version", func() {
+				out, err := s.Command("source /etc/os-release && echo $VERSION")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).ToNot(Equal(""))
+
+				version := out
+				By("upgrading to raccos/releases-opensuse:cos-system-0.4.35-1")
+				out, err = s.Command("cos-upgrade --recovery --docker-image raccos/releases-opensuse:cos-system-0.4.35-1")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
+				Expect(out).Should(ContainSubstring("Upgrading recovery partition"))
+
+				By("booting into recovery to check the OS version")
+				err = s.ChangeBoot(sut.Recovery)
+				Expect(err).ToNot(HaveOccurred())
+
+				s.Reboot()
+
+				out, err = s.Command("source /etc/os-release && echo $VERSION")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).ToNot(Equal(""))
+				Expect(out).ToNot(Equal(version))
+				Expect(out).To(Equal("0.4.35+1\n"))
+
+				By("setting back to active and rebooting")
+				err = s.ChangeBoot(sut.Active)
+				Expect(err).ToNot(HaveOccurred())
+
+				s.Reboot()
+			})
+		})
+
+		When("upgrade channel", func() {
+			It("upgrades to latest image", func() {
+				By("upgrading recovery and reboot")
+				out, err := s.Command("cos-upgrade --recovery")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
+				Expect(out).Should(ContainSubstring("Upgrading recovery partition"))
+
+				err = s.ChangeBoot(sut.Recovery)
+				Expect(err).ToNot(HaveOccurred())
+
+				s.Reboot()
+
+				By("checking recovery version")
+				out, err = s.Command("source /etc/os-release && echo $VERSION")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).ToNot(Equal(""))
+				Expect(out).ToNot(Equal("0.4.35+1\n"))
+
+				By("switch back to active and reboot")
+				err = s.ChangeBoot(sut.Active)
+				Expect(err).ToNot(HaveOccurred())
+
+				s.Reboot()
+			})
+		})
+
+	})
+})

--- a/tests/recovery/tests_suite_test.go
+++ b/tests/recovery/tests_suite_test.go
@@ -1,0 +1,13 @@
+package cos_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "cOS Recovery test Suite")
+}

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -3,25 +3,41 @@ package cos_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/cOS/tests/sut"
 )
 
 var _ = Describe("cOS Smoke tests", func() {
-	var s *SUT
+	var s *sut.SUT
 	BeforeEach(func() {
-		s = NewSUT("", "", "")
+		s = sut.NewSUT()
 		s.EventuallyConnects()
 	})
 
 	Context("After install", func() {
 		It("can boot into passive", func() {
-			s.ChangeBoot(Passive)
+			s.ChangeBoot(sut.Passive)
+			By("rebooting into passive")
 			s.Reboot()
 
-			Expect(s.BootFrom()).To(Equal(Passive))
+			Expect(s.BootFrom()).To(Equal(sut.Passive))
 
-			s.ChangeBoot(Active)
+			By("switching back to active")
+			s.ChangeBoot(sut.Active)
 			s.Reboot()
-			Expect(s.BootFrom()).To(Equal(Active))
+			Expect(s.BootFrom()).To(Equal(sut.Active))
+		})
+
+		It("can boot into recovery", func() {
+			s.ChangeBoot(sut.Recovery)
+			By("rebooting into recovery")
+			s.Reboot()
+
+			Expect(s.BootFrom()).To(Equal(sut.Recovery))
+
+			By("switching back to active")
+			s.ChangeBoot(sut.Active)
+			s.Reboot()
+			Expect(s.BootFrom()).To(Equal(sut.Active))
 		})
 
 		It("is booting from COS_ACTIVE", func() {
@@ -62,7 +78,7 @@ var _ = Describe("cOS Smoke tests", func() {
 		})
 
 		It("is booting from active partition", func() {
-			Expect(s.BootFrom()).To(Equal(Active))
+			Expect(s.BootFrom()).To(Equal(sut.Active))
 		})
 	})
 })

--- a/tests/smoke/tests_suite_test.go
+++ b/tests/smoke/tests_suite_test.go
@@ -1,0 +1,13 @@
+package cos_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "cOS Smoke test Suite")
+}

--- a/tests/sut/sut.go
+++ b/tests/sut/sut.go
@@ -1,4 +1,4 @@
-package cos_test
+package sut
 
 import (
 	"fmt"
@@ -26,18 +26,19 @@ type SUT struct {
 	Password string
 }
 
-func NewSUT(Host, Username, Password string) *SUT {
+func NewSUT() *SUT {
+
 	user := os.Getenv("COS_USER")
-	if Username == "" {
+	if user == "" {
 		user = "root"
 	}
 	pass := os.Getenv("COS_PASS")
-	if Password == "" {
+	if pass == "" {
 		pass = "cos"
 	}
 
 	host := os.Getenv("COS_HOST")
-	if Host == "" {
+	if host == "" {
 		host = "127.0.0.1:2222"
 	}
 	return &SUT{
@@ -148,7 +149,7 @@ func (s *SUT) command(cmd string, timeout bool) (string, error) {
 func (s *SUT) Reboot() {
 	s.command("reboot", true)
 	time.Sleep(10 * time.Second)
-	s.EventuallyConnects()
+	s.EventuallyConnects(180)
 }
 
 func (s *SUT) connectToHost(timeout bool) (*ssh.Client, error) {

--- a/tests/upgrades/tests_suite_test.go
+++ b/tests/upgrades/tests_suite_test.go
@@ -1,0 +1,13 @@
+package cos_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "cOS Upgrate test Suite")
+}

--- a/values/opensuse.yaml
+++ b/values/opensuse.yaml
@@ -7,5 +7,17 @@ leap_packages: >-
     grub2-x86_64-efi
     iproute2
     squashfs
-
+    conntrack-tools
+    findutils
+    haveged
+    lsscsi
+    lvm2
+    mdadm
+    multipath-tools
+    nfs-utils
+    open-iscsi
+    open-vm-tools
+    python-azure-agent
+    qemu-guest-agent
+    rng-tools
 kernel_package: kernel-default


### PR DESCRIPTION
This PR addresses few points:


- Adds required packages to run k3s/longhorn (Fixes #30 ). The ISO size it's not even that much bigger, now it's around 400MB (~100MB)
- Adds a very simple cli (`cos-feature`) to enable/disable pre-defined cloud configs shipped with cOS. It can be used to quickly enable k3s/longhorn/harvester locally for testing/development. I've moved the vagrant user setup there, so can be also enabled easier from CI
- Splits the tests to separate test suites. This makes the flow more easier to follow and easier to catch errors on the CI. It also adds a simple test suite to test k3s after install and the recovery test suite
- Moves the image format to ext2 in place of ext4. During this change subset, I've found out that the tests flakiness were caused by the installation which was not working correctly all the times. A journal process was left behind and prevents the loopmount to be detached, causing an unclean journaling when the machine gets reboot after install. For now until we address #31 I wouldn't mind to switch to ext2 as we don't use the images for rw access anyway.
