### PR TITLE
Enable GRUB fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,19 @@ test-clean:
 	cd $(ROOT_DIR)/tests && vagrant destroy || true
 	vagrant box remove cos || true
 
-test: test-clean tests/Vagrantfile prepare-test
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./smoke ./upgrades ./features
+test-fallback:
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./fallback
+
+test-features:
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./features
+
+test-upgrades:
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades
+
+test-smoke:
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./smoke
+
+test-recovery:
 	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./recovery
+
+test: test-clean tests/Vagrantfile prepare-test test-smoke test-upgrades test-features test-fallback test-recovery

--- a/packages/cos/definition.yaml
+++ b/packages/cos/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos"
 category: "system"
-version: "0.4.39"
+version: "0.4.4"
 brand_name: "cOS"

--- a/packages/cos/setup.yaml
+++ b/packages/cos/setup.yaml
@@ -30,9 +30,9 @@ stages:
       - path: /boot/grub2/grub.cfg
         content: |
             set timeout=10
-            set default=cos
+            set default="${saved_entry}"
 
-            set fallback=fallback
+            set fallback="0 1 2"
             set gfxmode=auto
             set gfxpayload=keep
             insmod all_video

--- a/tests/fallback/fallback_test.go
+++ b/tests/fallback/fallback_test.go
@@ -1,0 +1,50 @@
+package cos_test
+
+import (
+	"github.com/rancher-sandbox/cOS/tests/sut"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("cOS booting fallback tests", func() {
+	var s *sut.SUT
+	BeforeEach(func() {
+		s = sut.NewSUT()
+		s.EventuallyConnects()
+	})
+	AfterEach(func() {
+		s.Reset()
+	})
+	Context("GRUB cannot mount image", func() {
+		When("COS_ACTIVE image was corrupted", func() {
+			It("fallbacks by booting into passive", func() {
+				Expect(s.BootFrom()).To(Equal(sut.Active))
+
+				_, err := s.Command("mount -o rw,remount /run/initramfs/isoscan")
+				Expect(err).ToNot(HaveOccurred())
+				_, err = s.Command("rm -rf /run/initramfs/isoscan/cOS/active.img")
+				Expect(err).ToNot(HaveOccurred())
+
+				s.Reboot()
+
+				Expect(s.BootFrom()).To(Equal(sut.Passive))
+			})
+		})
+		When("COS_ACTIVE and COS_PASSIVE images are corrupted", func() {
+			It("fallbacks by booting into recovery", func() {
+				Expect(s.BootFrom()).To(Equal(sut.Active))
+
+				_, err := s.Command("mount -o rw,remount /run/initramfs/isoscan")
+				Expect(err).ToNot(HaveOccurred())
+				_, err = s.Command("rm -rf /run/initramfs/isoscan/cOS/active.img")
+				Expect(err).ToNot(HaveOccurred())
+				_, err = s.Command("rm -rf /run/initramfs/isoscan/cOS/passive.img")
+				Expect(err).ToNot(HaveOccurred())
+				s.Reboot()
+
+				Expect(s.BootFrom()).To(Equal(sut.Recovery))
+			})
+		})
+	})
+})

--- a/tests/fallback/tests_suite_test.go
+++ b/tests/fallback/tests_suite_test.go
@@ -1,0 +1,13 @@
+package cos_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "cOS Fallback test Suite")
+}


### PR DESCRIPTION
Also adds a test suite for fallback tests and re-organizes Makefile
accordingly.

I'll create a separate follow-up for the systemd story

Fixes #69