### PR TITLE
Move opensuse base to 15.3

### DIFF
--- a/packages/base/definition.yaml
+++ b/packages/base/definition.yaml
@@ -1,6 +1,6 @@
 name: "base"
 category: "distro"
-version: "0.3.5"
+version: "0.3.6"
 
 hidden: true # No need to make it installable for now
 labels:

--- a/packages/cos/definition.yaml
+++ b/packages/cos/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos"
 category: "system"
-version: 0.4.5
+version: 0.4.6
 brand_name: "cOS"

--- a/packages/livecd/syslinux/build.yaml
+++ b/packages/livecd/syslinux/build.yaml
@@ -9,14 +9,18 @@ prelude:
 {{else if .Values.is_fedora}}
 - dnf install -y wget
 {{end}}
-- wget http://kernel.org/pub/linux/utils/boot/syslinux/syslinux-{{.Values.version}}.tar.xz
-- mkdir -p /syslinux
-- tar -xvf syslinux-{{.Values.version}}.tar.xz -C /syslinux
+- |
+   PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
+   wget http://kernel.org/pub/linux/utils/boot/syslinux/syslinux-$PACKAGE_VERSION.tar.xz && \
+   mkdir -p /syslinux && \
+   tar -xvf syslinux-{{.Values.version}}.tar.xz -C /syslinux
 steps:
-- mkdir -p /output/boot/syslinux
-- mv /syslinux/syslinux-{{.Values.version}}/bios/core/isolinux.bin /output/boot/syslinux
-- mv /syslinux/syslinux-{{.Values.version}}/bios/com32/elflink/ldlinux/ldlinux.c32 /output/boot/syslinux
-- mv /syslinux/syslinux-{{.Values.version}}/bios/mbr/isohdpfx.bin /output/boot/syslinux
+- |
+   mkdir -p /output/boot/syslinux && \
+   PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
+   mv /syslinux/syslinux-$PACKAGE_VERSION/bios/core/isolinux.bin /output/boot/syslinux && \
+   mv /syslinux/syslinux-$PACKAGE_VERSION/bios/com32/elflink/ldlinux/ldlinux.c32 /output/boot/syslinux && \
+   mv /syslinux/syslinux-$PACKAGE_VERSION/bios/mbr/isohdpfx.bin /output/boot/syslinux
 package_dir: /output
 
 requires:

--- a/packages/livecd/systemd-boot/build.yaml
+++ b/packages/livecd/systemd-boot/build.yaml
@@ -11,9 +11,9 @@ prelude:
 {{else if .Values.is_fedora}}
 - dnf install -y wget
 {{end}}
-- wget https://github.com/ivandavidov/systemd-boot/releases/download/systemd-boot_26-May-2018/systemd-boot_26-May-2018.tar.xz
+- wget https://github.com/ivandavidov/systemd-boot/releases/download/systemd-boot_{{.Values.package_version}}/systemd-boot_{{.Values.package_version}}.tar.xz
 - mkdir -p /systemd-boot
-- tar -xvf systemd-boot_26-May-2018.tar.xz -C /systemd-boot
+- tar -xvf systemd-boot_{{.Values.package_version}}.tar.xz -C /systemd-boot
 steps:
 - mkdir -p /EFI/BOOT
 - cp /systemd-boot/systemd-boot*/uefi_root/EFI/BOOT/BOOTx64.EFI /EFI/BOOT

--- a/packages/livecd/systemd-boot/definition.yaml
+++ b/packages/livecd/systemd-boot/definition.yaml
@@ -1,3 +1,4 @@
 category: "live"
 name: "systemd-boot"
 version: "26"
+package_version: "26-May-2018"

--- a/values/opensuse.yaml
+++ b/values/opensuse.yaml
@@ -1,4 +1,4 @@
-image: opensuse/leap:15.2
+image: opensuse/leap:15.3
 is_opensuse: true
 
 leap_packages: >-


### PR DESCRIPTION
This bumps the default base image to 15.3, and updates the livecd specs to unlock automatic bumps