### PR TITLE
ci: upload images in the same job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -171,45 +171,17 @@ jobs:
 
       - name: Build QEMU Image 🔧
         run: |
-          PACKER_ARGS="-var='accellerator=none' -var='sleep=5m' -only qemu" make packer
+          PACKER_ARGS="-var='accellerator=none' -var='feature=vagrant' -var='sleep=5m' -only qemu" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-${{ matrix.flavor }}.qcow
           path: |
             packer/*.tar.gz
-
-  qemu-vagrant:
-      runs-on: ubuntu-latest
-      needs: iso
-
-      strategy:
-        matrix:
-          include:
-            - flavor: "opensuse"
-#            - flavor: "fedora"
-      steps:
-      - uses: actions/checkout@v2
-      - name: Download ISO
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-${{ matrix.flavor }}.iso.zip
-
-      - name: Install deps
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu qemu-system qemu-kvm
-          sudo -E make deps
-          sudo luet install -y utils/packer
-
-      - name: Build QEMU Image 🔧
-        run: |
-          PACKER_ARGS="-var='accellerator=none' -var='sleep=5m' -var='feature=vagrant' -only qemu" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-${{ matrix.flavor }}-QEMU.box
           path: |
             packer/*.box
-
   vbox:
       runs-on: macos-10.15
       needs: iso
@@ -231,47 +203,20 @@ jobs:
       #     brew install hashicorp/tap/packer
       - name: Build VBox Image 🔧
         run: |
-          PACKER_ARGS="-var='sleep=5m' -only virtualbox-iso" make packer
-          ls packer
+          PACKER_ARGS="-var='sleep=5m' -var='feature=vagrant' -only virtualbox-iso" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-${{ matrix.flavor }}.ova
           path: |
             packer/*.tar.gz
-
-  vbox-vagrant:
-      runs-on: macos-10.15
-      needs: iso
-      strategy:
-        matrix:
-          include:
-            - flavor: "opensuse"
-#            - flavor: "fedora"
-      steps:
-      - uses: actions/checkout@v2
-      - name: Download ISO
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-${{ matrix.flavor }}.iso.zip
-
-      # - name: Install deps
-      #   run: |
-      #     brew tap hashicorp/tap
-      #     brew install hashicorp/tap/packer
-      - name: Build VBox Image 🔧
-        run: |
-          PACKER_ARGS="-var='sleep=5m' -var='feature=vagrant' -only virtualbox-iso" make packer
-          ls packer
-
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-${{ matrix.flavor }}-vbox.box
           path: |
             packer/*.box
-
   tests:
       runs-on: macos-10.15
-      needs: vbox-vagrant
+      needs: vbox
       strategy:
         matrix:
           include:


### PR DESCRIPTION
There is no need to run a separate job for generating the vagrant
images once we have generated a provider images. The post processors
work based off the output from the builders so vagrant creates a box
file based of the qemu/vbox image and compress just compressed the
qemu/vbox image

They are both generated at the same time so we can use that to our
advantage and upload the artifacts at the same time

Signed-off-by: Itxaka <igarcia@suse.com>