### PR TITLE
ci: Separate tests to run them in parallel

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -274,9 +274,8 @@ jobs:
       needs: vbox-vagrant
       strategy:
         matrix:
-          include:
-            - flavor: "opensuse"
-#            - flavor: "fedora"
+          flavor: ["opensuse"]
+          test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned"]
       steps:
       - name: Install Go
         uses: actions/setup-go@v2
@@ -293,7 +292,10 @@ jobs:
           go get -u github.com/onsi/ginkgo/ginkgo
           go get -u github.com/onsi/gomega/...
           PATH=$PATH:$GOPATH/bin
-          make test
+          make test-clean
+          make tests/Vagrantfile
+          make prepare-test
+          make ${{ matrix.test }}
 
   publish:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,11 @@ test-fallback:
 test-features:
 	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./features
 
-test-upgrades:
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades
+test-upgrades-images-signed:
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades-images-signed
+
+test-upgrades-images-unsigned:
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades-images-unsigned
 
 test-smoke:
 	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./smoke
@@ -165,4 +168,4 @@ test-smoke:
 test-recovery:
 	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./recovery
 
-test: test-clean tests/Vagrantfile prepare-test test-smoke test-upgrades test-features test-fallback test-recovery
+test: test-clean tests/Vagrantfile prepare-test test-smoke test-upgrades-images-signed test-upgrades-images-unsigned test-features test-fallback test-recovery

--- a/tests/upgrades-images-signed/tests_suite_test.go
+++ b/tests/upgrades-images-signed/tests_suite_test.go
@@ -1,0 +1,13 @@
+package cos_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "cOS Upgrate test Suite - Images signed")
+}

--- a/tests/upgrades-images-signed/upgrade_test.go
+++ b/tests/upgrades-images-signed/upgrade_test.go
@@ -1,0 +1,56 @@
+package cos_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/cOS/tests/sut"
+)
+
+var _ = Describe("cOS Upgrade tests - Images signed", func() {
+	var s *sut.SUT
+
+	BeforeEach(func() {
+		s = sut.NewSUT()
+		s.EventuallyConnects(360)
+	})
+
+	AfterEach(func() {
+		s.Reset()
+	})
+	Context("After install", func() {
+		When("images are signed", func() {
+			It("upgrades to latest available (master) and reset", func() {
+				out, err := s.Command("cos-upgrade")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
+				Expect(out).Should(ContainSubstring("Booting from: active.img"))
+				By("rebooting")
+				s.Reboot()
+				Expect(s.BootFrom()).To(Equal(sut.Active))
+			})
+
+			It("upgrades to a specific image and reset back to the installed version", func() {
+				out, err := s.Command("source /etc/os-release && echo $VERSION")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).ToNot(Equal(""))
+
+				version := out
+				By("upgrading to an old signed image")
+				out, err = s.Command("cos-upgrade --docker-image raccos/releases-opensuse:cos-system-0.4.32")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
+				Expect(out).Should(ContainSubstring("to /usr/local/tmp/rootfs"))
+				Expect(out).Should(ContainSubstring("Booting from: active.img"))
+
+				By("rebooting and checking out the version")
+				s.Reboot()
+
+				out, err = s.Command("source /etc/os-release && echo $VERSION")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).ToNot(Equal(""))
+				Expect(out).ToNot(Equal(version))
+				Expect(out).To(Equal("0.4.32\n"))
+			})
+		})
+	})
+})

--- a/tests/upgrades-images-unsigned/tests_suite_test.go
+++ b/tests/upgrades-images-unsigned/tests_suite_test.go
@@ -9,5 +9,5 @@ import (
 
 func TestTests(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "cOS Upgrate test Suite")
+	RunSpecs(t, "cOS Upgrate test Suite - Images unsugned")
 }

--- a/tests/upgrades-images-unsigned/upgrade_test.go
+++ b/tests/upgrades-images-unsigned/upgrade_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rancher-sandbox/cOS/tests/sut"
 )
 
-var _ = Describe("cOS Upgrade tests", func() {
+var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 	var s *sut.SUT
 
 	BeforeEach(func() {
@@ -18,7 +18,6 @@ var _ = Describe("cOS Upgrade tests", func() {
 		s.Reset()
 	})
 	Context("After install", func() {
-
 		When("images are not signed", func() {
 			It("fails to upgrade to a version which is not signed", func() {
 				out, err := s.Command("cos-upgrade --docker-image raccos/releases-opensuse:cos-system-0.4.31")
@@ -81,41 +80,6 @@ var _ = Describe("cOS Upgrade tests", func() {
 				Expect(out).ToNot(Equal(""))
 				Expect(out).ToNot(Equal("0.4.31\n"))
 				Expect(out).To(Equal(version))
-			})
-		})
-
-		When("images are signed", func() {
-			It("upgrades to latest available (master) and reset", func() {
-				out, err := s.Command("cos-upgrade")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
-				Expect(out).Should(ContainSubstring("Booting from: active.img"))
-				By("rebooting")
-				s.Reboot()
-				Expect(s.BootFrom()).To(Equal(sut.Active))
-			})
-
-			It("upgrades to a specific image and reset back to the installed version", func() {
-				out, err := s.Command("source /etc/os-release && echo $VERSION")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).ToNot(Equal(""))
-
-				version := out
-				By("upgrading to an old signed image")
-				out, err = s.Command("cos-upgrade --docker-image raccos/releases-opensuse:cos-system-0.4.32")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
-				Expect(out).Should(ContainSubstring("to /usr/local/tmp/rootfs"))
-				Expect(out).Should(ContainSubstring("Booting from: active.img"))
-
-				By("rebooting and checking out the version")
-				s.Reboot()
-
-				out, err = s.Command("source /etc/os-release && echo $VERSION")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).ToNot(Equal(""))
-				Expect(out).ToNot(Equal(version))
-				Expect(out).To(Equal("0.4.32\n"))
 			})
 		})
 	})


### PR DESCRIPTION
Instead of running the test all at the same time, we can
separate them using a matrix so they run in parallel

This patch also separates the upgrade tests into using
signed and unsigned images so we can also run those in
parallel, as they are the ones taking most of the time

Signed-off-by: Itxaka <igarcia@suse.com>