### PR TITLE
ci: Remove the 5 min wait for all packer builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Build QEMU Image 🔧
         run: |
-          PACKER_ARGS="-var='accellerator=none' -var='sleep=5m' -only qemu" make packer
+          PACKER_ARGS="-var='accellerator=none' -timestamp-ui -only qemu" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-${{ matrix.flavor }}.qcow
@@ -203,7 +203,7 @@ jobs:
 
       - name: Build QEMU Image 🔧
         run: |
-          PACKER_ARGS="-var='accellerator=none' -var='sleep=5m' -var='feature=vagrant' -only qemu" make packer
+          PACKER_ARGS="-var='accellerator=none' -var='feature=vagrant' -timestamp-ui -only qemu" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-${{ matrix.flavor }}-QEMU.box
@@ -231,7 +231,7 @@ jobs:
       #     brew install hashicorp/tap/packer
       - name: Build VBox Image 🔧
         run: |
-          PACKER_ARGS="-var='sleep=5m' -only virtualbox-iso" make packer
+          PACKER_ARGS="-timestamp-ui -only virtualbox-iso" make packer
           ls packer
       - uses: actions/upload-artifact@v2
         with:
@@ -260,7 +260,7 @@ jobs:
       #     brew install hashicorp/tap/packer
       - name: Build VBox Image 🔧
         run: |
-          PACKER_ARGS="-var='sleep=5m' -var='feature=vagrant' -only virtualbox-iso" make packer
+          PACKER_ARGS="-var='feature=vagrant' -timestamp-ui -only virtualbox-iso" make packer
           ls packer
 
       - uses: actions/upload-artifact@v2

--- a/packer/images.json
+++ b/packer/images.json
@@ -12,7 +12,7 @@
         "ssh_password": "{{user `root_password`}}",
         "ssh_username": "{{user `root_username`}}",
         "format": "ova",
-        "ssh_timeout": "1m",
+        "ssh_timeout": "5m",
         "ssh_handshake_attempts": "20",
         "type": "virtualbox-iso",
         "vm_name": "cOS"
@@ -34,7 +34,7 @@
         ],
         "shutdown_command": "shutdown -hP now",
         "ssh_password": "{{user `root_password`}}",
-        "ssh_timeout": "1m",
+        "ssh_timeout": "5m",
         "ssh_handshake_attempts": "20",
         "ssh_username": "{{user `root_username`}}",
         "type": "qemu",


### PR DESCRIPTION
We should use the defautl 30 seconds and use the ssh_timeout
so packer tries to connect asap instead of plainly waiting 5 minutes

Signed-off-by: Itxaka <igarcia@suse.com>