### PR TITLE
Cleanup Makefile

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -277,7 +277,7 @@ jobs:
           go get -u github.com/onsi/gomega/...
           PATH=$PATH:$GOPATH/bin
           make test-clean
-          make tests/Vagrantfile
+          make vagrantfile
           make prepare-test
           make ${{ matrix.test }}
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ifneq ($(shell id -u), 0)
 endif
 	curl https://get.mocaccino.org/luet/get_luet_root.sh |  sh
 	luet install -y repository/mocaccino-extra-stable
-	luet install -y utils/jq utils/yq system/luet-devkit
+	luet install -y utils/jq utils/yq extension/makeiso
 endif
 
 clean: clean_build clean_iso clean_run clean_test

--- a/Makefile
+++ b/Makefile
@@ -1,167 +1,63 @@
-BACKEND?=docker
-CONCURRENCY?=1
+#
+# cOS-toolkit Makefile
+#
+#
 
-
+#----------------------- global variables -----------------------
+#
+# Path to luet binary
+#
 export LUET?=$(shell which luet)
-export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-COMPRESSION?=zstd
-ISO_SPEC?=$(ROOT_DIR)/iso/cOS.yaml
-CLEAN?=false
-export TREE?=$(ROOT_DIR)/packages
-
-BUILD_ARGS?=--pull --no-spinner --only-target-package --live-output
-
-VALIDATE_OPTIONS?=-s
-FLAVOR?=opensuse
-DESTINATION?=$(ROOT_DIR)/build
-REPO_CACHE?=raccos/$(FLAVOR)
-FINAL_REPO?=raccos/releases-$(FLAVOR)
-
-PACKAGES?=$(shell yq r -j $(ISO_SPEC) 'packages.[*]' | jq -r '.[]' | sort -u)
 HAS_LUET := $(shell command -v luet 2> /dev/null)
-QEMU?=qemu-kvm
-QEMU_ARGS?=-bios /usr/share/qemu/ovmf-x86_64.bin
-QEMU_MEMORY?=2048
-PACKER_ARGS?=
-PUBLISH_ARGS?=
-GINKGO_ARGS?=-progress -v --failFast -flakeAttempts 3 -r
-ISO?=$(ROOT_DIR)/$(shell ls *.iso)
 
-export REPO_CACHE
-ifneq ($(strip $(REPO_CACHE)),)
-	BUILD_ARGS+=--image-repository $(REPO_CACHE)
-endif
+#
+# Directory of Makefile
+#
+export ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+#
+# OS flavor to build
+#
+FLAVOR?=opensuse
+
+#
+# folder for build artefacts
+#
+DESTINATION?=$(ROOT_DIR)/build
+
+#
+# yaml specification of build targets
+#
+export ISO_SPEC?=$(ROOT_DIR)/iso/cOS.yaml
+
+#----------------------- end global variables -----------------------
+
+
+#----------------------- default target -----------------------
 
 all: deps build
 
-deps:
+#----------------------- includes -----------------------
+
+include make/Makefile.build
+include make/Makefile.iso
+include make/Makefile.run
+include make/Makefile.test
+
+#----------------------- targets -----------------------
+
+deps: luet
+
+luet:
 ifndef HAS_LUET
 ifneq ($(shell id -u), 0)
-	@echo "You must be root to perform this action."
+	@echo "'luet' is missing ($(LUET)) and you must be root to install it."
 	exit 1
 endif
 	curl https://get.mocaccino.org/luet/get_luet_root.sh |  sh
 	luet install -y repository/mocaccino-extra-stable
-	luet install -y utils/jq utils/yq extension/makeiso
+	luet install -y utils/jq utils/yq system/luet-devkit
 endif
 
-clean:
-	 rm -rf $(DESTINATION) $(ROOT_DIR)/.qemu $(ROOT_DIR)/*.iso $(ROOT_DIR)/*.sha256
-
-.PHONY: build
-build:
-	$(LUET) build $(BUILD_ARGS) \
-	--values $(ROOT_DIR)/values/$(FLAVOR).yaml \
-	--tree=$(TREE) $(PACKAGES) \
-	--backend $(BACKEND) \
-	--concurrency $(CONCURRENCY) \
-	--compression $(COMPRESSION) \
-	--destination $(DESTINATION)
-
-create-repo:
-	$(LUET) create-repo --tree "$(TREE)" \
-    --output $(DESTINATION) \
-    --packages $(DESTINATION) \
-    --name "cOS" \
-    --descr "cOS $(FLAVOR)" \
-    --urls "" \
-    --tree-compression $(COMPRESSION) \
-    --tree-filename tree.tar \
-    --meta-compression $(COMPRESSION) \
-    --type http
-
-publish-repo:
-	$(LUET) create-repo $(PUBLISH_ARGS) --tree "$(TREE)" \
-    --output $(FINAL_REPO) \
-    --packages $(DESTINATION) \
-    --name "cOS" \
-    --descr "cOS $(FLAVOR)" \
-    --urls "" \
-    --tree-compression $(COMPRESSION) \
-    --tree-filename tree.tar \
-    --meta-compression $(COMPRESSION) \
-    --push-images \
-    --type docker
-
-serve-repo:
-	LUET_NOLOCK=true $(LUET) serve-repo --port 8000 --dir $(DESTINATION)
-
-autobump:
-	TREE_DIR=$(ROOT_DIR) $(LUET) autobump-github
-
-validate:
-	$(LUET) tree validate --tree $(TREE) $(VALIDATE_OPTIONS)
-
-# ISO
-
-$(DESTINATION):
-	mkdir $(DESTINATION)
-
-local-iso: create-repo
-	$(LUET) makeiso -- $(ISO_SPEC) --local $(DESTINATION)
-
-iso:
-	cp -rf $(ISO_SPEC) $(ISO_SPEC).remote
-	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].name' 'cOS'
-	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].enable' true
-	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].type' 'docker'
-	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].urls[0]' $(FINAL_REPO)
-	$(LUET) makeiso $(ISO_SPEC).remote
-
-# QEMU
-
-$(ROOT_DIR)/.qemu:
-	mkdir -p $(ROOT_DIR)/.qemu
-
-$(ROOT_DIR)/.qemu/drive.img: $(ROOT_DIR)/.qemu
-	qemu-img create -f qcow2 $(ROOT_DIR)/.qemu/drive.img 16g
-
-run-qemu: $(ROOT_DIR)/.qemu/drive.img
-	$(QEMU) \
-	-m $(QEMU_MEMORY) \
-	-cdrom $(ISO) \
-	-nographic \
-	-serial mon:stdio \
-	-rtc base=utc,clock=rt \
-	-chardev socket,path=$(ROOT_DIR)/.qemu/qga.sock,server,nowait,id=qga0 \
-	-device virtio-serial \
-	-hda $(ROOT_DIR)/.qemu/drive.img $(QEMU_ARGS)
-
-# Packer
-
-.PHONY: packer
-packer:
-	cd $(ROOT_DIR)/packer && packer build -var "iso=$(ISO)" $(PACKER_ARGS) images.json
-
-# Tests
-
-prepare-test:
-	vagrant box add cos packer/*.box
-	cd $(ROOT_DIR)/tests && vagrant up || true
-
-tests/Vagrantfile:
-	cd $(ROOT_DIR)/tests && vagrant init cos
-
-test-clean:
-	cd $(ROOT_DIR)/tests && vagrant destroy || true
-	vagrant box remove cos || true
-
-test-fallback:
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./fallback
-
-test-features:
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./features
-
-test-upgrades-images-signed:
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades-images-signed
-
-test-upgrades-images-unsigned:
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades-images-unsigned
-
-test-smoke:
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./smoke
-
-test-recovery:
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./recovery
-
-test: test-clean tests/Vagrantfile prepare-test test-smoke test-upgrades-images-signed test-upgrades-images-unsigned test-features test-fallback test-recovery
+clean: clean_build clean_iso clean_run clean_test
+	rm -rf $(ROOT_DIR)/*.sha256

--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -1,0 +1,70 @@
+#
+# cOS-toolkit Makefile.build
+#
+#
+
+
+#
+# Arguments for luet build
+#
+
+_BUILD_ARGS?=--pull --no-spinner --only-target-package --live-output
+
+_VALIDATE_OPTIONS?=-s
+_FINAL_REPO?=raccos/releases-$(FLAVOR)
+
+PACKAGES?=$(shell yq r -j $(ISO_SPEC) 'packages.[*]' | jq -r '.[]' | sort -u)
+
+export TREE?=$(ROOT_DIR)/packages
+
+PACKER_ARGS?=
+PUBLISH_ARGS?=
+
+.PHONY: build
+build: luet
+	@echo "PACKAGES >$(PACKAGES)<"
+	$(LUET) build $(_BUILD_ARGS) \
+	--values $(ROOT_DIR)/values/$(FLAVOR).yaml \
+	--tree=$(TREE) \
+	--backend $(BACKEND) \
+	--concurrency $(CONCURRENCY) \
+	--compression $(COMPRESSION) \
+	--destination $(DESTINATION) \
+        $(PACKAGES)
+
+create-repo: luet
+	$(LUET) create-repo --tree "$(TREE)" \
+    --output $(DESTINATION) \
+    --packages $(DESTINATION) \
+    --name "cOS" \
+    --descr "cOS $(FLAVOR)" \
+    --urls "" \
+    --tree-compression $(COMPRESSION) \
+    --tree-filename tree.tar \
+    --meta-compression $(COMPRESSION) \
+    --type http
+
+publish-repo: luet
+	$(LUET) create-repo $(PUBLISH_ARGS) --tree "$(TREE)" \
+    --output $(_FINAL_REPO) \
+    --packages $(DESTINATION) \
+    --name "cOS" \
+    --descr "cOS $(FLAVOR)" \
+    --urls "" \
+    --tree-compression $(COMPRESSION) \
+    --tree-filename tree.tar \
+    --meta-compression $(COMPRESSION) \
+    --push-images \
+    --type docker
+
+serve-repo: luet
+	LUET_NOLOCK=true $(LUET) serve-repo --port 8000 --dir $(DESTINATION)
+
+autobump: luet
+	TREE_DIR=$(ROOT_DIR) $(LUET) autobump-github
+
+validate: luet
+	$(LUET) tree validate --tree $(TREE) $(_VALIDATE_OPTIONS)
+
+clean_build:
+	rm -rf $(DESTINATION)

--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -3,6 +3,22 @@
 #
 #
 
+#
+# Backend to use for "luet build"
+# Values "docker" or "podman"
+#
+BACKEND?=docker
+
+#
+# Concurrent downloads in luet
+#
+CONCURRENCY?=1
+
+#
+# Compression scheme for build artefacts
+#
+COMPRESSION?=zstd
+
 
 #
 # Arguments for luet build
@@ -17,7 +33,6 @@ PACKAGES?=$(shell yq r -j $(ISO_SPEC) 'packages.[*]' | jq -r '.[]' | sort -u)
 
 export TREE?=$(ROOT_DIR)/packages
 
-PACKER_ARGS?=
 PUBLISH_ARGS?=
 
 .PHONY: build

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -1,0 +1,40 @@
+#
+# cOS-toolkit Makefile.iso
+#
+#
+
+
+VALIDATE_OPTIONS?=-s
+REPO_CACHE?=raccos/$(FLAVOR)
+
+PACKER_ARGS?=
+PUBLISH_ARGS?=
+GINKGO_ARGS?=-progress -v --failFast -flakeAttempts 3 -r
+ISO?=$(ROOT_DIR)/$(shell ls *.iso)
+
+export REPO_CACHE
+ifneq ($(strip $(REPO_CACHE)),)
+	BUILD_ARGS+=--image-repository $(REPO_CACHE)
+endif
+
+
+clean_iso:
+	 rm -rf $(ROOT_DIR)/*.iso
+
+$(DESTINATION):
+	mkdir $(DESTINATION)
+
+$(DESTINATION)/conf.yaml: $(DESTINATION)
+	touch $(ROOT_DIR)/build/conf.yaml
+	yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].name' 'cOS'
+	yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].enable' true
+
+local-iso: create-repo $(DESTINATION)/conf.yaml
+	yq w -i $(DESTINATION)/conf.yaml 'repositories[0].urls[0]' $(DESTINATION)
+	yq w -i $(DESTINATION)/conf.yaml 'repositories[0].type' 'disk'
+	$(LUET) geniso-isospec $(ISO_SPEC)
+
+iso: $(DESTINATION)/conf.yaml
+	yq w -i $(DESTINATION)/conf.yaml 'repositories[0].type' 'docker'
+	yq w -i $(DESTINATION)/conf.yaml 'repositories[0].urls[0]' $(FINAL_REPO)
+	$(LUET) geniso-isospec $(ISO_SPEC)

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -7,6 +7,8 @@ REPO_CACHE?=raccos/$(FLAVOR)
 
 ISO?=$(ROOT_DIR)/$(shell ls *.iso)
 
+PACKER_ARGS?=
+
 export REPO_CACHE
 ifneq ($(strip $(REPO_CACHE)),)
 	BUILD_ARGS+=--image-repository $(REPO_CACHE)
@@ -34,3 +36,9 @@ iso: $(DESTINATION)/conf.yaml
 	yq w -i $(DESTINATION)/conf.yaml 'repositories[0].type' 'docker'
 	yq w -i $(DESTINATION)/conf.yaml 'repositories[0].urls[0]' $(FINAL_REPO)
 	$(LUET) geniso-isospec $(ISO_SPEC)
+
+# Packer
+
+.PHONY: packer
+packer:
+	cd $(ROOT_DIR)/packer && packer build -var "iso=$(ISO)" $(PACKER_ARGS) images.json

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -22,20 +22,16 @@ clean_iso:
 $(DESTINATION):
 	mkdir $(DESTINATION)
 
-$(DESTINATION)/conf.yaml: $(DESTINATION)
-	touch $(ROOT_DIR)/build/conf.yaml
-	yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].name' 'cOS'
-	yq w -i $(ROOT_DIR)/build/conf.yaml 'repositories[0].enable' true
+local-iso: create-repo
+	$(LUET) makeiso -- $(ISO_SPEC) --local $(DESTINATION)
 
-local-iso: create-repo $(DESTINATION)/conf.yaml
-	yq w -i $(DESTINATION)/conf.yaml 'repositories[0].urls[0]' $(DESTINATION)
-	yq w -i $(DESTINATION)/conf.yaml 'repositories[0].type' 'disk'
-	$(LUET) geniso-isospec $(ISO_SPEC)
-
-iso: $(DESTINATION)/conf.yaml
-	yq w -i $(DESTINATION)/conf.yaml 'repositories[0].type' 'docker'
-	yq w -i $(DESTINATION)/conf.yaml 'repositories[0].urls[0]' $(FINAL_REPO)
-	$(LUET) geniso-isospec $(ISO_SPEC)
+iso:
+	cp -rf $(ISO_SPEC) $(ISO_SPEC).remote
+	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].name' 'cOS'
+	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].enable' true
+	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].type' 'docker'
+	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].urls[0]' $(FINAL_REPO)
+	$(LUET) makeiso $(ISO_SPEC).remote
 
 # Packer
 

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -3,13 +3,8 @@
 #
 #
 
-
-VALIDATE_OPTIONS?=-s
 REPO_CACHE?=raccos/$(FLAVOR)
 
-PACKER_ARGS?=
-PUBLISH_ARGS?=
-GINKGO_ARGS?=-progress -v --failFast -flakeAttempts 3 -r
 ISO?=$(ROOT_DIR)/$(shell ls *.iso)
 
 export REPO_CACHE
@@ -19,7 +14,8 @@ endif
 
 
 clean_iso:
-	 rm -rf $(ROOT_DIR)/*.iso
+	rm -rf $(ROOT_DIR)/*.iso
+	sudo rm -rf isowork
 
 $(DESTINATION):
 	mkdir $(DESTINATION)

--- a/make/Makefile.run
+++ b/make/Makefile.run
@@ -1,0 +1,31 @@
+#
+# cOS-toolkit Makefile.run
+#
+#
+
+
+QEMU?=qemu-kvm
+QEMU_ARGS?=-bios /usr/share/qemu/ovmf-x86_64.bin
+QEMU_MEMORY?=2048
+
+clean_run:
+	rm -rf $(ROOT_DIR)/.qemu
+
+# QEMU
+
+$(ROOT_DIR)/.qemu:
+	mkdir -p $(ROOT_DIR)/.qemu
+
+$(ROOT_DIR)/.qemu/drive.img: $(ROOT_DIR)/.qemu
+	qemu-img create -f qcow2 $(ROOT_DIR)/.qemu/drive.img 16g
+
+run-qemu: $(ROOT_DIR)/.qemu/drive.img
+	$(QEMU) \
+	-m $(QEMU_MEMORY) \
+	-cdrom $(ISO) \
+	-nographic \
+	-serial mon:stdio \
+	-rtc base=utc,clock=rt \
+	-chardev socket,path=$(ROOT_DIR)/.qemu/qga.sock,server,nowait,id=qga0 \
+	-device virtio-serial \
+	-hda $(ROOT_DIR)/.qemu/drive.img $(QEMU_ARGS)

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -9,7 +9,7 @@ HAVE_VAGRANT := $(shell command -v vagrant 2> /dev/null)
 
 HAVE_GINKGO := $(shell command -v ginkgo 2> /dev/null)
 
-test: test-clean tests/Vagrantfile prepare-test test-smoke test-upgrades-signed test-upgrades-unsigned test-features test-fallback test-recovery
+test: test-clean vagrantfile prepare-test test-smoke test-upgrades-signed test-upgrades-unsigned test-features test-fallback test-recovery
 
 clean_test: test-clean
 
@@ -17,13 +17,14 @@ prepare-test: vagrant
 	vagrant box add cos packer/*.box
 	cd $(ROOT_DIR)/tests && vagrant up || true
 
-tests/Vagrantfile: vagrant
+vagrantfile: tests/Vagrantfile vagrant
 	cd $(ROOT_DIR)/tests && vagrant init cos
 
 test-clean:
 	(cd $(ROOT_DIR)/tests && vagrant destroy) 2> /dev/null || true
 	(vagrant box remove cos) 2> /dev/null || true
 
+.PHONY: vagrant
 vagrant:
 ifndef HAVE_VAGRANT
 	@echo "'vagrant' not found."

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -5,32 +5,30 @@
 
 GINKGO_ARGS?=-progress -v --failFast -flakeAttempts 3 -r
 
-HAVE_VAGRANT := $(shell command -v vagrant 2> /dev/null)
-
 HAVE_GINKGO := $(shell command -v ginkgo 2> /dev/null)
+
+VAGRANT=$(shell which vagrant)
 
 test: test-clean vagrantfile prepare-test test-smoke test-upgrades-signed test-upgrades-unsigned test-features test-fallback test-recovery
 
 clean_test: test-clean
 
-prepare-test: vagrant
+prepare-test: $(VAGRANT)
 	vagrant box add cos packer/*.box
 	cd $(ROOT_DIR)/tests && vagrant up || true
 
-vagrantfile: tests/Vagrantfile vagrant
+vagrantfile: $(ROOT_DIR)/tests/Vagrantfile $(VAGRANT)
+
+$(ROOT_DIR)/tests/Vagrantfile: $(VAGRANT)
 	cd $(ROOT_DIR)/tests && vagrant init cos
 
 test-clean:
 	(cd $(ROOT_DIR)/tests && vagrant destroy) 2> /dev/null || true
 	(vagrant box remove cos) 2> /dev/null || true
 
-.PHONY: vagrant
-vagrant:
-ifndef HAVE_VAGRANT
+$(VAGRANT):
 	@echo "'vagrant' not found."
 	exit 1
-endif
-
 
 test-fallback: ginkgo
 	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./fallback

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -1,0 +1,53 @@
+#
+# cOS-toolkit Makefile.test
+#
+#
+
+GINKGO_ARGS?=-progress -v --failFast -flakeAttempts 3 -r
+
+HAVE_VAGRANT := $(shell command -v vagrant 2> /dev/null)
+
+HAVE_GINKGO := $(shell command -v ginkgo 2> /dev/null)
+
+test: test-clean tests/Vagrantfile prepare-test test-smoke test-upgrades test-features test-fallback test-recovery
+
+clean_test: test-clean
+
+prepare-test: vagrant
+	vagrant box add cos packer/*.box
+	cd $(ROOT_DIR)/tests && vagrant up || true
+
+tests/Vagrantfile: vagrant
+	cd $(ROOT_DIR)/tests && vagrant init cos
+
+test-clean: vagrant
+	cd $(ROOT_DIR)/tests && vagrant destroy || true
+	vagrant box remove cos || true
+
+vagrant:
+ifndef HAVE_VAGRANT
+	@echo "'vagrant' not found."
+	exit 1
+endif
+
+
+test-fallback: ginkgo
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./fallback
+
+test-features: ginkgo
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./features
+
+test-upgrades: ginkgo
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades
+
+test-smoke: ginkgo
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./smoke
+
+test-recovery: ginkgo
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./recovery
+
+ginkgo:
+ifndef HAVE_GINKGO
+	@echo "'ginkgo' not found."
+	exit 1
+endif

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -9,7 +9,7 @@ HAVE_VAGRANT := $(shell command -v vagrant 2> /dev/null)
 
 HAVE_GINKGO := $(shell command -v ginkgo 2> /dev/null)
 
-test: test-clean tests/Vagrantfile prepare-test test-smoke test-upgrades test-features test-fallback test-recovery
+test: test-clean tests/Vagrantfile prepare-test test-smoke test-upgrades-signed test-upgrades-unsigned test-features test-fallback test-recovery
 
 clean_test: test-clean
 
@@ -20,9 +20,9 @@ prepare-test: vagrant
 tests/Vagrantfile: vagrant
 	cd $(ROOT_DIR)/tests && vagrant init cos
 
-test-clean: vagrant
-	cd $(ROOT_DIR)/tests && vagrant destroy || true
-	vagrant box remove cos || true
+test-clean:
+	(cd $(ROOT_DIR)/tests && vagrant destroy) 2> /dev/null || true
+	(vagrant box remove cos) 2> /dev/null || true
 
 vagrant:
 ifndef HAVE_VAGRANT
@@ -37,8 +37,11 @@ test-fallback: ginkgo
 test-features: ginkgo
 	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./features
 
-test-upgrades: ginkgo
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades
+test-upgrades-images-signed: ginkgo
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades-images-signed
+
+test-upgrades-images-unsigned: ginkgo
+	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades-images-unsigned
 
 test-smoke: ginkgo
 	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./smoke


### PR DESCRIPTION
This PR splits the Makefile into `build`, `iso`, `run`, and `test` parts and defines variables only where needed.

Part of #32, also fixes #128