### PR TITLE
fail if no upload artifacts are available

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,7 +98,7 @@ jobs:
       with:
         name: sign-${{ matrix.flavor }}
         path: /tmp/sign_images.log
-        if-no-files-found: error
+        if-no-files-found: warn
 
   iso:
     runs-on: ubuntu-latest
@@ -321,7 +321,7 @@ jobs:
       with:
         name: sign-${{ matrix.flavor }}
         path: /tmp/sign_images.log
-        if-no-files-found: error
+        if-no-files-found: warn
 
   github-release:
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,11 +92,13 @@ jobs:
       with:
         name: build-${{ matrix.flavor }}
         path: build
+        if-no-files-found: error
     - name: Upload signing logs
       uses: actions/upload-artifact@v2
       with:
         name: sign-${{ matrix.flavor }}
         path: /tmp/sign_images.log
+        if-no-files-found: error
 
   iso:
     runs-on: ubuntu-latest
@@ -142,11 +144,13 @@ jobs:
         path: |
           *.iso
           *.sha256
+        if-no-files-found: error
     - uses: actions/upload-artifact@v2
       if: always()
       with:
         name: luet-build-${{ matrix.flavor }}.log
         path: isowork/*.log
+        if-no-files-found: error
 
   qemu:
       runs-on: ubuntu-latest
@@ -179,11 +183,13 @@ jobs:
           name: cOS-${{ matrix.flavor }}.qcow
           path: |
             packer/*.tar.gz
+          if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-${{ matrix.flavor }}-QEMU.box
           path: |
             packer/*.box
+          if-no-files-found: error
   vbox:
       runs-on: macos-10.15
       needs: iso
@@ -211,11 +217,13 @@ jobs:
           name: cOS-${{ matrix.flavor }}.ova
           path: |
             packer/*.tar.gz
+          if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-${{ matrix.flavor }}-vbox.box
           path: |
             packer/*.box
+          if-no-files-found: error
   tests:
       runs-on: macos-10.15
       needs: vbox
@@ -313,6 +321,7 @@ jobs:
       with:
         name: sign-${{ matrix.flavor }}
         path: /tmp/sign_images.log
+        if-no-files-found: error
 
   github-release:
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Checks like https://github.com/kkaempf/cOS-toolkit/runs/2466672342?check_suite_focus=true show that _later_ steps fail if a _previous_ step didn't generate files for upload.

Make `upload-artifact` fail if no files are found. See https://github.com/actions/upload-artifact