### PR TITLE
Fix vagrant with libvirt provider

### DIFF
--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -9,6 +9,8 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provider :libvirt do |libvirt|
+    config.vm.guest = :linux
+    config.vm.synced_folder ".", "/vagrant", disabled: true
     libvirt.driver = "kvm"
   end
     


### PR DESCRIPTION
Makes vagrant launch cos properly under the libvirt provider.
config.vm.guest = :linux -> We need to set the type of os
config.vm.synced_folder ".", "/vagrant", disabled: true -> disable the
automatic synced folder as it fails to mount (read only filesystem)

Signed-off-by: Itxaka <igarcia@suse.com>