### PR TITLE
Check for root when running 'make build'

### DIFF
--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -37,6 +37,10 @@ PUBLISH_ARGS?=
 
 .PHONY: build
 build: luet
+ifneq ($(shell id -u), 0)
+	@echo "Please run 'make build' as root"
+	exit 1
+endif
 	@echo "PACKAGES >$(PACKAGES)<"
 	$(LUET) build $(BUILD_ARGS) \
 	--values $(ROOT_DIR)/values/$(FLAVOR).yaml \


### PR DESCRIPTION
luet needs to be root for rootfs extraction and chown() during build.

Fixes #143

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>