### PR TITLE
Fix testing for command dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@
 #
 # Path to luet binary
 #
-export LUET?=$(shell which luet)
-HAS_LUET := $(shell command -v luet 2> /dev/null)
+export LUET?=$(shell which luet 2> /dev/null)
+ifeq ("$(LUET)","")
+LUET="/usr/bin/luet"
+endif
 
 #
 # Directory of Makefile
@@ -46,14 +48,13 @@ include make/Makefile.test
 
 #----------------------- targets -----------------------
 
-deps: luet
+deps: $(LUET)
 
-luet:
-ifndef HAS_LUET
+$(LUET):
 ifneq ($(shell id -u), 0)
 	@echo "'luet' is missing ($(LUET)) and you must be root to install it."
-	exit 1
-endif
+	@exit 1
+else
 	curl https://get.mocaccino.org/luet/get_luet_root.sh |  sh
 	luet install -y repository/mocaccino-extra-stable
 	luet install -y utils/jq utils/yq extension/makeiso

--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -39,7 +39,7 @@ export TREE?=$(ROOT_DIR)/packages
 PUBLISH_ARGS?=
 
 .PHONY: build
-build: luet
+build: $(LUET)
 ifneq ($(shell id -u), 0)
 	@echo "Please run 'make $@' as root"
 	@exit 1
@@ -54,24 +54,13 @@ endif
 	--destination $(DESTINATION) \
         $(PACKAGES)
 
-create-repo: luet
-	$(LUET) create-repo --tree "$(TREE)" \
-    --output $(DESTINATION) \
-    --packages $(DESTINATION) \
-    --name "cOS" \
-    --descr "cOS $(FLAVOR)" \
-    --urls "" \
-    --tree-compression $(COMPRESSION) \
-    --tree-filename tree.tar \
-    --meta-compression $(COMPRESSION) \
-    --type http
 
 #
 # Push to Docker registry
 # 
 #
 
-publish-repo: luet
+publish-repo: $(LUET)
 ifneq ($(shell id -u), 0)
 	@echo "Please run 'make $@' as root"
 	@exit 1
@@ -92,13 +81,13 @@ endif
 # Start local server at port 8000
 #
 
-serve-repo: luet
+serve-repo: $(LUET)
 	LUET_NOLOCK=true $(LUET) serve-repo --port 8000 --dir $(DESTINATION)
 
-autobump: luet
+autobump: $(LUET)
 	TREE_DIR=$(ROOT_DIR) $(LUET) autobump-github
 
-validate: luet
+validate: $(LUET)
 	$(LUET) tree validate --tree $(TREE) $(_VALIDATE_OPTIONS)
 
 #

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -14,6 +14,11 @@ ifneq ($(strip $(REPO_CACHE)),)
 	BUILD_ARGS+=--image-repository $(REPO_CACHE)
 endif
 
+MKSQUASHFS?=$(shell which mksquashfs 2> /dev/null)
+ifeq ("$(MKSQUASHFS)","")
+MKSQUASHFS="/usr/bin/mksquashfs"
+endif
+
 #
 # remove iso artifacts
 #
@@ -29,10 +34,27 @@ $(DESTINATION):
 # build ISO from repository
 #
 
-local-iso: create-repo
+$(MKSQUASHFS):
+	@echo "'mksquashfs' not found, install 'squashfs' package."
+	@exit 1
+
+create-repo: luet
+	@echo ">$(MKSQUASHFS)<"
+	$(LUET) create-repo --tree "$(TREE)" \
+    --output $(DESTINATION) \
+    --packages $(DESTINATION) \
+    --name "cOS" \
+    --descr "cOS $(FLAVOR)" \
+    --urls "" \
+    --tree-compression $(COMPRESSION) \
+    --tree-filename tree.tar \
+    --meta-compression $(COMPRESSION) \
+    --type http
+
+local-iso: $(MKSQUASHFS) create-repo
 	$(LUET) makeiso -- $(ISO_SPEC) --local $(DESTINATION)
 
-iso:
+iso: $(MKSQUASHFS)
 	cp -rf $(ISO_SPEC) $(ISO_SPEC).remote
 	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].name' 'cOS'
 	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].enable' true

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -38,7 +38,7 @@ $(MKSQUASHFS):
 	@echo "'mksquashfs' not found, install 'squashfs' package."
 	@exit 1
 
-create-repo: luet
+create-repo: $(LUET)
 	@echo ">$(MKSQUASHFS)<"
 	$(LUET) create-repo --tree "$(TREE)" \
     --output $(DESTINATION) \
@@ -54,7 +54,7 @@ create-repo: luet
 local-iso: $(MKSQUASHFS) create-repo
 	$(LUET) makeiso -- $(ISO_SPEC) --local $(DESTINATION)
 
-iso: $(MKSQUASHFS)
+iso: $(MKSQUASHFS) $(LUET)
 	cp -rf $(ISO_SPEC) $(ISO_SPEC).remote
 	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].name' 'cOS'
 	yq w -i $(ISO_SPEC).remote 'luet.repositories[0].enable' true

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -38,8 +38,7 @@ $(MKSQUASHFS):
 	@echo "'mksquashfs' not found, install 'squashfs' package."
 	@exit 1
 
-create-repo: $(LUET)
-	@echo ">$(MKSQUASHFS)<"
+create-repo: $(LUET) $(DESTINATION)
 	$(LUET) create-repo --tree "$(TREE)" \
     --output $(DESTINATION) \
     --packages $(DESTINATION) \

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -6,7 +6,7 @@
 GINKGO_ARGS?=-progress -v --failFast -flakeAttempts 3 -r
 
 GINKGO?=$(shell which ginkgo 2> /dev/null)
-ifeq ("$()","")
+ifeq ("$(GINKGO)","")
 GINKGO="/usr/bin/ginkgo"
 endif
 

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -5,9 +5,15 @@
 
 GINKGO_ARGS?=-progress -v --failFast -flakeAttempts 3 -r
 
-HAVE_GINKGO := $(shell command -v ginkgo 2> /dev/null)
+GINKGO?=$(shell which ginkgo 2> /dev/null)
+ifeq ("$()","")
+GINKGO="/usr/bin/ginkgo"
+endif
 
-VAGRANT=$(shell which vagrant)
+VAGRANT?=$(shell which vagrant 2> /dev/null)
+ifeq ("$(VAGRANT)","")
+VAGRANT="/usr/bin/vagrant"
+endif
 
 test: test-clean vagrantfile prepare-test test-smoke test-upgrades-signed test-upgrades-unsigned test-features test-fallback test-recovery
 
@@ -34,26 +40,24 @@ $(VAGRANT):
 	@echo "'vagrant' not found."
 	@exit 1
 
-test-fallback: ginkgo
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./fallback
+test-fallback: $(GINKGO)
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) ./fallback
 
-test-features: ginkgo
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./features
+test-features: $(GINKGO)
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) ./features
 
-test-upgrades-images-signed: ginkgo
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades-images-signed
+test-upgrades-images-signed: $(GINKGO)
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) ./upgrades-images-signed
 
-test-upgrades-images-unsigned: ginkgo
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./upgrades-images-unsigned
+test-upgrades-images-unsigned: $(GINKGO)
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) ./upgrades-images-unsigned
 
-test-smoke: ginkgo
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./smoke
+test-smoke: $(GINKGO)
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) ./smoke
 
-test-recovery: ginkgo
-	cd $(ROOT_DIR)/tests && ginkgo $(GINKGO_ARGS) ./recovery
+test-recovery: $(GINKGO)
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) ./recovery
 
-ginkgo:
-ifndef HAVE_GINKGO
+$(GINKGO):
 	@echo "'ginkgo' not found."
 	@exit 1
-endif


### PR DESCRIPTION
The old way (using the output of 'which' as a target) was essentially
a no-op.

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>