### PR TITLE
Change cibot name to avoid DCO

### DIFF
--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -7,7 +7,7 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     env:
-      GIT_AUTHOR_NAME: cOS-cibot
+      GIT_AUTHOR_NAME: cOS-cibot [bot]
       GIT_AUTHOR_EMAIL: cOScibot@gmail.com
       GIT_COMMITTER_NAME: cOS-cibot
       GIT_COMMITTER_EMAIL: cOScibot@gmail.com


### PR DESCRIPTION
DCO will be skipped if the author name contains [bot]

Signed-off-by: Itxaka <igarcia@suse.com>