### PR TITLE
Append the mtree checksums to metadata

### DIFF
--- a/.github/append_manifests.py
+++ b/.github/append_manifests.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import yaml
+import sys
+
+
+def main():
+    if len(sys.argv) != 4:
+        print("This utility gets a yaml file, a content file and a key and inserts the content from the content"
+              "file into the yaml file at the given key")
+        print("Missing arguments: [YAML FILE] [CONTENT FILE] [KEY TO ADD THE CONTENT AT]")
+        exit(1)
+
+    with open(sys.argv[1], "r") as stream:
+        yaml_file = yaml.safe_load(stream)
+
+    with open(sys.argv[2], "r") as mtree:
+        yaml_file[sys.argv[3]] = mtree.readlines()
+
+    with open(sys.argv[1], "w") as outfile:
+        outfile.write(yaml.dump(yaml_file))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,15 +122,20 @@ jobs:
         run: |
           sudo -E make build
           ls -liah $PWD/build
-
-      - name: Create repo
-        run: |
-          sudo -E make create-repo
       - name: Generate manifests
         run: |
           for f in build/*tar*; do
             sudo -E luet mtree -- generate $f -o "$f.mtree"
           done
+      - name: Append manifests to metadata
+        run: |
+          for f in build/*mtree; do
+            BASE_NAME=`basename -s .package.tar.zst.mtree $f`
+            sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
+          done
+      - name: Create repo
+        run: |
+          sudo -E make create-repo
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
During build time after generating the mtree checksums we can easily
integrate those in the metadata so they are automatically pushed and
downloaded on upgrade

Signed-off-by: Itxaka <igarcia@suse.com>