### PR TITLE
ci: quote git author name in autobump workflow

### DIFF
--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -7,9 +7,9 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     env:
-      GIT_AUTHOR_NAME: cOS-cibot [bot]
+      GIT_AUTHOR_NAME: "cOS-cibot [bot]"
       GIT_AUTHOR_EMAIL: cOScibot@gmail.com
-      GIT_COMMITTER_NAME: cOS-cibot [bot]
+      GIT_COMMITTER_NAME: "cOS-cibot [bot]"
       GIT_COMMITTER_EMAIL: cOScibot@gmail.com
       WORK_BRANCH: bumps
       AUTO_GIT: true


### PR DESCRIPTION
@Itxaka I think this caused "[bot]" to not apply... :sweat_smile:  let's see