### PR TITLE
condensed output for mtree checksums

### DIFF
--- a/.github/append_manifests.py
+++ b/.github/append_manifests.py
@@ -15,8 +15,7 @@ def main():
         yaml_file = yaml.safe_load(stream)
 
     with open(sys.argv[2], "r") as mtree:
-        yaml_file[sys.argv[3]] = mtree.readlines()
-
+        yaml_file[sys.argv[3]] = mtree.read()
     with open(sys.argv[1], "w") as outfile:
         outfile.write(yaml.dump(yaml_file))
 


### PR DESCRIPTION
Read all into one line so its easier to manipulate afterwards and also
saves space when storing it as a big blob instead of one item per line

Required for #185 

Signed-off-by: Itxaka <igarcia@suse.com>