### PR TITLE
Bump luet-mtree to 0.0.3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Install deps
         run: |
           sudo -E make deps
-          wget -qO- https://github.com/Itxaka/luet-mtree/releases/download/v0.0.2/luet-mtree-v0.0.2-Linux-x86_64.tar.gz | tar xvz --
+          wget -qO- https://github.com/Itxaka/luet-mtree/releases/download/v0.0.3/luet-mtree-v0.0.3-Linux-x86_64.tar.gz | tar xvz --
           sudo cp luet-mtree /usr/bin/luet-mtree
 
       - name: Validate 🌳

--- a/packages/toolchain/luet-mtree/definition.yaml
+++ b/packages/toolchain/luet-mtree/definition.yaml
@@ -1,6 +1,6 @@
 name: "luet-mtree"
 category: "toolchain"
-version: 0.0.2+7
+version: "0.0.3"
 labels:
   github.repo: "luet-mtree"
   github.owner: "itxaka"


### PR DESCRIPTION
Now it ignores empty files, uses less keywords by default allowing more
control on what keywords to use

Signed-off-by: Itxaka <igarcia@suse.com>