### PR TITLE
Fix sign images output

### DIFF
--- a/.github/sign-images
+++ b/.github/sign-images
@@ -1,16 +1,26 @@
 #!/bin/bash
 
-exec >> /tmp/sign_images.log
-exec 2>&1
+# This connects stdout+stderr to the log file but leaves fd3 connected to the console
+# To log to both use | tee /dev/fd/3 which sends the data to fd3 AND to tee fd1 which is connected to the log file
+# You can also use 1>&3 to send it to console only
+exec 3>&1 1>/tmp/sign_images.log 2>&1
 
 event="$1"
 payload="$2"
 
 if [ "$event" == "image.post.build" ]; then
   image=$(echo "$payload" | jq -r .data | jq -r .ImageName )
-  if docker trust sign $image; then
-    echo "$image signed"
+  if docker trust sign "$image" > /dev/null 2>&1; then
+    jq --arg key0 "state" --arg value0 "$image signed" \
+     --arg key1   "data"  --arg value1 "" \
+     --arg key2   "error" --arg value2 "" \
+     '. | .[$key0]=$value0 | .[$key1]=$value1 | .[$key2]=$value2' \
+    <<<'{}' | tee /dev/fd/3
   else
-    echo "$image signing failed"
+     jq --arg key0 "state" --arg value0 "$image signing failed" \
+     --arg key1    "data"  --arg value1 "" \
+     --arg key2    "error" --arg value2  "$image signing failed" \
+     '. | .[$key0]=$value0 | .[$key1]=$value1 | .[$key2]=$value2' \
+    <<<'{}' | tee /dev/fd/3
   fi
 fi


### PR DESCRIPTION
We were not repecting the luet api for plugin output as it expects us to
return json and we were returning whatever we wanted

Fixed this by returning json as the output so luet can parse it as
expected

This fixes publishing 

Signed-off-by: Itxaka <igarcia@suse.com>