### PR TITLE
Re-enable tests using published signed images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -254,9 +254,7 @@ jobs:
     strategy:
       matrix:
         flavor: ["opensuse"]
-        # Temporarily disable signed images test, since is tied to DCT and we are considering dropping it.
-        #test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned"]
-        test: ["test-features", "test-smoke", "test-fallback", "test-upgrades-images-unsigned"]
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned"]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -3,7 +3,7 @@
 #
 #
 
-GINKGO_ARGS?=-progress -v --failFast -flakeAttempts 3 -r
+GINKGO_ARGS?=-progress -v --failFast -flakeAttempts 2 -r
 
 GINKGO?=$(shell which ginkgo 2> /dev/null)
 ifeq ("$(GINKGO)","")

--- a/packages/cos/definition.yaml
+++ b/packages/cos/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos"
 category: "system"
-version: 0.5.1+2
+version: "0.5.1+3"
 brand_name: "cOS"

--- a/tests/recovery/recovery_test.go
+++ b/tests/recovery/recovery_test.go
@@ -23,8 +23,8 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 				Expect(out).ToNot(Equal(""))
 
 				version := out
-				By("upgrading to raccos/releases-opensuse:cos-system-0.5.0")
-				out, err = s.Command("cos-upgrade --recovery --docker-image raccos/releases-opensuse:cos-system-0.5.0")
+				By("upgrading to quay.io/costoolkit/releases-opensuse:cos-system-0.5.1")
+				out, err = s.Command("cos-upgrade --no-verify --recovery --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.1")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
 				Expect(out).Should(ContainSubstring("Upgrading recovery partition"))
@@ -34,25 +34,27 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				s.Reboot()
+				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Recovery))
 
 				out, err = s.Command("source /etc/os-release && echo $VERSION")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
 				Expect(out).ToNot(Equal(version))
-				Expect(out).To(Equal("0.5.0\n"))
+				Expect(out).To(Equal("0.5.1\n"))
 
 				By("setting back to active and rebooting")
 				err = s.ChangeBoot(sut.Active)
 				Expect(err).ToNot(HaveOccurred())
 
 				s.Reboot()
+				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
 			})
 		})
 
 		When("upgrade channel", func() {
 			It("upgrades to latest image", func() {
 				By("upgrading recovery and reboot")
-				out, err := s.Command("cos-upgrade --recovery")
+				out, err := s.Command("cos-upgrade --no-verify --recovery")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
 				Expect(out).Should(ContainSubstring("Upgrading recovery partition"))
@@ -66,13 +68,14 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 				out, err = s.Command("source /etc/os-release && echo $VERSION")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
-				Expect(out).ToNot(Equal("0.5.0\n"))
+				Expect(out).ToNot(Equal("0.5.1\n"))
 
 				By("switch back to active and reboot")
 				err = s.ChangeBoot(sut.Active)
 				Expect(err).ToNot(HaveOccurred())
 
 				s.Reboot()
+				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
 			})
 		})
 

--- a/tests/upgrades-images-signed/upgrade_test.go
+++ b/tests/upgrades-images-signed/upgrade_test.go
@@ -18,71 +18,12 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 		s.Reset()
 	})
 	Context("After install", func() {
-		When("images are signed", func() {
-			It("upgrades to a specific image and reset back to the installed version", func() {
-				out, err := s.Command("source /etc/os-release && echo $VERSION")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).ToNot(Equal(""))
-
-				version := out
-				By("upgrading to an old signed image")
-				out, err = s.Command("cos-upgrade --verify --docker-image raccos/releases-opensuse:cos-system-0.4.32")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
-				Expect(out).Should(ContainSubstring("Booting from: active.img"))
-
-				By("rebooting and checking out the version")
-				s.Reboot()
-
-				out, err = s.Command("source /etc/os-release && echo $VERSION")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).ToNot(Equal(""))
-				Expect(out).ToNot(Equal(version))
-				Expect(out).To(Equal("0.4.32\n"))
-			})
-			// TODO(itxaka): Is this basically the same test as the one below??
-			It("fails to upgrade if verify is enabled on an unsigned version", func() {
+		When("upgrading", func() {
+			It("fails if verify is enabled on an unsigned version", func() {
 				// Using releases-amd64 as those images are not signed
-				out, err := s.Command("cos-upgrade --verify --docker-image raccos/releases-amd64:cos-system-0.4.18")
+				out, err := s.Command("cos-upgrade --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.1")
 				Expect(err).To(HaveOccurred())
-				Expect(out).Should(ContainSubstring("No valid trust data"))
-			})
-			It("fails to upgrade if verify is enabled on an unsigned upgrade channel", func() {
-				out, err := s.Command("sed -i 's|raccos/releases-.*|raccos/releases-amd64\"|g' /etc/luet/luet.yaml && cos-upgrade --verify")
-				Expect(out).Should(ContainSubstring("does not have trust data"))
-				Expect(err).To(HaveOccurred())
-			})
-			It("upgrades to an signed image with --verify and can reset back to the installed state", func() {
-				out, err := s.Command("source /etc/os-release && echo $VERSION")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).ToNot(Equal(""))
-
-				version := out
-
-				By("running cos-upgrade with --verify and an signed image")
-				out, err = s.Command("cos-upgrade --verify --docker-image raccos/releases-opensuse:cos-system-0.4.9-9")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
-				Expect(out).Should(ContainSubstring("to /usr/local/tmp/rootfs"))
-				Expect(out).Should(ContainSubstring("Booting from: active.img"))
-
-				By("rebooting and checking out the version")
-				s.Reboot()
-
-				out, err = s.Command("source /etc/os-release && echo $VERSION")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).ToNot(Equal(""))
-				Expect(out).ToNot(Equal(version))
-				Expect(out).To(Equal("0.4.31\n"))
-
-				By("rollbacking state")
-				s.Reset()
-
-				out, err = s.Command("source /etc/os-release && echo $VERSION")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).ToNot(Equal(""))
-				Expect(out).ToNot(Equal("0.4.9-9\n"))
-				Expect(out).To(Equal(version))
+				Expect(out).Should(ContainSubstring("failed verifying image"))
 			})
 		})
 	})


### PR DESCRIPTION
This commit re-adds to the CI tests that make use of published signed
images. It also adds few additional checks on tests to ensure reboots
are booting to the expected system and no fallback boot happened.

Upgrade tests have been slightly simplify to avoid some reboots and
resets while keeping the fundamental functionality tests.

Finally, it also bumps a new system/cos release to it can be used in
tests.

Signed-off-by: David Cassany <dcassany@suse.com>