### PR TITLE
Fix output for sign images

### DIFF
--- a/.github/sign-images
+++ b/.github/sign-images
@@ -3,11 +3,12 @@
 # This connects stdout+stderr to the log file but leaves fd3 connected to the console
 # To log to both use | tee /dev/fd/3 which sends the data to fd3 AND to tee fd1 which is connected to the log file
 # You can also use 1>&3 to send it to console only
-exec 3>&1 1>/tmp/sign_images.log 2>&1
+exec 3>&1 1>>/tmp/sign_images.log 2>&1
 
 event="$1"
 payload="$2"
 
+echo "$(date) Start with event: $event and payload $payload"
 if [ "$event" == "image.post.build" ]; then
   image=$(echo "$payload" | jq -r .data | jq -r .ImageName )
   if docker trust sign "$image" > /dev/null 2>&1; then
@@ -23,4 +24,7 @@ if [ "$event" == "image.post.build" ]; then
      '. | .[$key0]=$value0 | .[$key1]=$value1 | .[$key2]=$value2' \
     <<<'{}' | tee /dev/fd/3
   fi
+else
+  echo "{}" | tee /dev/fd/3
 fi
+echo "$(date) End with event: $event"


### PR DESCRIPTION
Fix output when dealing with a different event than image.post.build
Append to the output log
Add start/end lines to the log

Signed-off-by: Itxaka <igarcia@suse.com>