### PR TITLE
system/cos cleanups

### DIFF
--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -41,8 +41,9 @@ ifneq ($(shell id -u), 0)
 	@echo "Please run 'make $@' as root"
 	@exit 1
 endif
+	# Buildkit is necessary due to https://github.com/moby/moby/issues/37965
 	@echo "PACKAGES >$(PACKAGES)<"
-	$(LUET) build $(BUILD_ARGS) \
+	DOCKER_BUILDKIT=1 $(LUET) build $(BUILD_ARGS) \
 	--values $(ROOT_DIR)/values/$(FLAVOR).yaml \
 	--tree=$(TREE) \
 	--backend $(BACKEND) \

--- a/packages/cos-features/build.yaml
+++ b/packages/cos-features/build.yaml
@@ -1,6 +1,6 @@
 requires:
-- name: "yip"
-  category: "toolchain"
+- name: "base"
+  category: "distro"
   version: ">=0"
 steps:
 - mkdir -p /system/features

--- a/packages/cos-features/definition.yaml
+++ b/packages/cos-features/definition.yaml
@@ -1,3 +1,7 @@
 name: cos-features
 category: system
-version: 0.3.1+14
+version: 0.3.1+15
+requires:
+- name: "yip"
+  category: "toolchain"
+  version: ">=0.8.4"

--- a/packages/cos-setup/build.yaml
+++ b/packages/cos-setup/build.yaml
@@ -1,6 +1,6 @@
 requires:
-- name: "yip"
-  category: "toolchain"
+- name: "base"
+  category: "distro"
   version: ">=0"
 steps:
 - mkdir -p /lib/systemd/system

--- a/packages/cos-setup/definition.yaml
+++ b/packages/cos-setup/definition.yaml
@@ -1,3 +1,7 @@
 name: cos-setup
 category: system
-version: 0.2.10+13
+version: 0.2.11
+requires:
+- name: "yip"
+  category: "toolchain"
+  version: ">=0.8.4"

--- a/packages/cos/build.yaml
+++ b/packages/cos/build.yaml
@@ -1,20 +1,11 @@
 # Refer to https://luet-lab.github.io/docs/docs/concepts/packages/specfile/#build-specs
 # for the syntax format
 requires:
-- name: "luet"
-  category: "toolchain"
-  version: ">=0"
-- name: "luet-mtree"
-  category: "toolchain"
-  version: ">=0"
 - name: "cos-setup"
   category: "system"
   version: ">=0"
 - name: "installer"
   category: "utils"
-  version: ">=0"
-- category: "toolchain"
-  name: "yip"
   version: ">=0"
 - name: "cloud-config"
   category: "system"
@@ -31,6 +22,27 @@ requires:
 - name: "selinux-policies"
   category: "system"
   version: ">=0"
+
+# https://luet-lab.github.io/docs/docs/concepts/packages/specfile/#copy
+copy:
+- package: 
+    category: "toolchain"
+    name: "yip"
+    version: ">=0"
+  source: "/usr/bin/yip"
+  destination: "/usr/bin/yip"
+- package: 
+    category: "toolchain"
+    name: "luet"
+    version: ">=0"
+  source: "/usr/bin/luet"
+  destination: "/usr/bin/luet"
+- package: 
+    category: "toolchain"
+    name: "luet-mtree"
+    version: ">=0"
+  source: "/usr/bin/luet-mtree"
+  destination: "/usr/bin/luet-mtree"
 
 # Templated package https://luet-lab.github.io/docs/docs/concepts/packages/templates/
 steps:
@@ -71,46 +83,13 @@ excludes:
 - ^/etc/zypp
 - ^/usr/bin/rpm.*
 - ^/var/lib/rpm
-
-# Build deps that got thrown-in by zypper
-# XXX: To keep until https://github.com/mudler/luet/issues/190 is solved out
-# or we either create another luet repository for runtime deps
-# When we can copy from tree packages single file, there is no need
-# to depend directly on golang
-- ^/usr/share/bison
-- ^/usr/share/automake
-- ^/usr/share/autoconf
-- ^/usr/share/aclocal
-- ^/usr/share/texinfo
-- ^/usr/share/libtool
-
-- texinfo.mo
-- git.mo
-- flex.mo
-- ^/usr/libexec/git
-- ^/usr/lib64/pkgconfig
-- ^/usr/lib64/ldscripts
-- ^/usr/lib64/gcc
-- ^/usr/bin/git.*
-- ^/usr/bin/gcc.*
-- ^/usr/bin/flex.*
-- ^/usr/bin/autom.*
-- ^/usr/bin/autoconf.*
-- ^/usr/bin/bison.*
-- ^/usr/bin/libtool.*
-- ^/usr/x86_64-suse-linux
-- ^/usr/lib64/rpm-plugins
+- ^/usr/lib64/rpm-plugins 
 # Yast
 - ^/var/lib/YaST2
 
 # Perl
 # - ^/usr/bin/perl.*
 # - ^/usr/lib/perl.*
-
-# Wget - we are only shipping curl
-- ^/etc/wgetrc
-- ^/usr/share/licenses/wget/COPYING
-- ^/usr/bin/wget
 
 # General
 - ^/usr/include
@@ -124,6 +103,3 @@ excludes:
 - ^/usr/local/share
 - ^/usr/local/src
 - ^/usr/local/games
-
-# Some golang package leftovers
-- ^/root/.cache

--- a/packages/immutable-rootfs/build.yaml
+++ b/packages/immutable-rootfs/build.yaml
@@ -2,9 +2,20 @@ requires:
 - name: "base"
   category: "distro"
   version: ">=0"
+# cos-setup is required in module-setup and embedded in the initramfs
 - name: "cos-setup"
   category: "system"
   version: ">=0"
+
+copy:
+# yip is required in module-setup and embedded in the initramfs. 
+# We don't put it in requires to avoid pulling golang sublayers
+- package: 
+    category: "toolchain"
+    name: "yip"
+    version: ">=0"
+  source: "/usr/bin/yip"
+  destination: "/usr/bin/yip"
 
 steps:
 {{ if .Values.distribution }}

--- a/packages/toolchain/luet-mtree/build.yaml
+++ b/packages/toolchain/luet-mtree/build.yaml
@@ -1,7 +1,4 @@
 requires:
-  - name: "luet"
-    category: "toolchain"
-    version: ">=0"
   - name: "golang"
     category: "build"
     version: ">=0"


### PR DESCRIPTION
Since luet `0.15.0` is released it's available the [copy](https://luet-lab.github.io/docs/docs/concepts/packages/specfile/#copy) keyword, in this way it's easy to disjoin packages that doesn't need to share a common base, and moreover we can drop some of the workaround that we had in the specfiles