### PR TITLE
Bump luet-mtree to 0.0.4 for mtree generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Install deps
         run: |
           sudo -E make deps
-          wget -qO- https://github.com/Itxaka/luet-mtree/releases/download/v0.0.3/luet-mtree-v0.0.3-Linux-x86_64.tar.gz | tar xvz --
+          wget -qO- https://github.com/Itxaka/luet-mtree/releases/download/v0.0.4/luet-mtree-v0.0.4-Linux-x86_64.tar.gz | tar xvz --
           sudo cp luet-mtree /usr/bin/luet-mtree
 
       - name: Validate 🌳


### PR DESCRIPTION
Resolves some issues with keywords and doesnt use temp dirs anymore

Signed-off-by: Itxaka <igarcia@suse.com>