### PR TITLE
Build all packages by default

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
         run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
       - name: Set Push options
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        run: echo "BUILD_ARGS=--push --no-spinner --live-output --only-target-package --pull" >> $GITHUB_ENV
+        run: echo "BUILD_ARGS=--push --no-spinner --live-output --pull" >> $GITHUB_ENV
 
       - name: Install deps
         run: |

--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -24,7 +24,7 @@ COMPRESSION?=zstd
 # Arguments for luet build
 #
 
-BUILD_ARGS?=--pull --no-spinner --only-target-package --live-output
+BUILD_ARGS?=--pull --no-spinner --live-output
 
 _VALIDATE_OPTIONS?=-s
 


### PR DESCRIPTION
This is required in order for derivatives to build against cOS.
Otherwise derivatives cannot resolve all the deptree - metadata files
contains also the values used to build the package artifact.

See also: https://github.com/rancher-sandbox/cOS-toolkit/pull/204#issuecomment-847081431

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>