### PR TITLE
ci: set --only-target-package on PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,6 +93,14 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         run: echo "BUILD_ARGS=--push --no-spinner --live-output --pull" >> $GITHUB_ENV
 
+      - name: "Set PR options"
+        if: ${{ github.event_name == 'pull_request' }}
+        run: echo "BUILD_ARGS=--no-spinner --only-target-package --live-output --pull" >> $GITHUB_ENV
+
+      - name: "Set Branches options"
+        if: ${{ github.event_name == 'push' && github.ref != 'refs/heads/master' }}
+        run: echo "BUILD_ARGS=--no-spinner --only-target-package --live-output --pull" >> $GITHUB_ENV
+
       - name: Install deps
         run: |
           sudo -E make deps


### PR DESCRIPTION
This should bring PR build times to normal, while master needs to go to the full cycle

@Itxaka @davidcassany on master we need to build all of them in order to get pushed all the metadata, otherwise it's not possible to have reproducible builds (they carry build metadata such as the interpolation values). For PRs and branches we don't need that, and brings back to normal build times :slightly_smiling_face: 