### PR TITLE
ci: mark related packages for automatic revbump

### DIFF
--- a/packages/toolchain/luet-mtree/definition.yaml
+++ b/packages/toolchain/luet-mtree/definition.yaml
@@ -5,3 +5,4 @@ labels:
   github.repo: "luet-mtree"
   github.owner: "itxaka"
   autobump.revdeps: "true"
+  autobump.revbump_related: "system/cos"

--- a/packages/toolchain/luet/definition.yaml
+++ b/packages/toolchain/luet/definition.yaml
@@ -6,3 +6,4 @@ labels:
   github.repo: "luet"
   github.owner: "mudler"
   autobump.revdeps: "true"
+  autobump.revbump_related: "system/cos"

--- a/packages/toolchain/yip/definition.yaml
+++ b/packages/toolchain/yip/definition.yaml
@@ -5,3 +5,4 @@ labels:
   github.repo: "yip"
   github.owner: "mudler"
   autobump.revdeps: "true"
+  autobump.revbump_related: "system/cos"


### PR DESCRIPTION
This should help the bot to catch up deps that are not much obvious (`join` and `copy` keyword aren't supported yet by it)