### PR TITLE
cos: keep /usr/include. some programs might require it

### DIFF
--- a/packages/cos/build.yaml
+++ b/packages/cos/build.yaml
@@ -87,12 +87,6 @@ excludes:
 # Yast
 - ^/var/lib/YaST2
 
-# Perl
-# - ^/usr/bin/perl.*
-# - ^/usr/lib/perl.*
-
-# General
-- ^/usr/include
 #- ^/usr/local
 - ^/usr/local/bin
 - ^/usr/local/go


### PR DESCRIPTION
Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>