### PR TITLE
make: set back --only-target-package as BUILD_ARGS default

### DIFF
--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -24,7 +24,7 @@ COMPRESSION?=zstd
 # Arguments for luet build
 #
 
-BUILD_ARGS?=--pull --no-spinner --live-output
+BUILD_ARGS?=--pull --no-spinner --only-target-package --live-output
 
 REPO_CACHE?=quay.io/costoolkit/build-cache
 


### PR DESCRIPTION
Now that CI has been split into different BUILD_ARGS there is no need
for keeping this default. With --only-target-package we save a lot of
disk space if we don't need metadata for all of the packages built.

Fixes: #209

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>