### PR TITLE
Add golang checksum hook

### DIFF
--- a/packages/golang/definition.yaml
+++ b/packages/golang/definition.yaml
@@ -12,4 +12,6 @@ labels:
   autobump.version_hook: |
     curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
   package.version: "1.16.4"
+  autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-{{.Values.arch}}.tar.gz.sha256"
+  package.checksum: "7154e88f5a8047aad4b80ebace58a059e36e7e2e4eb3b383127a28c711b4ff59"
 arch: "amd64"


### PR DESCRIPTION
The support has been added with: https://github.com/Luet-lab/extensions/commit/39b72f0a2b3fc188458e10483e4d9d6b7f46a529 (devkit 0.10.2). 
Specs with a `autobump.checksum_hook` field will be executed as a script to fetch the checksum which is then annotated in `labels.package.checksum`. It supports the templating syntax as usual, allowing to dynamically fetch checksums by package versions. 

The checksum should be accessible with: `{{ ( index .Values.labels "package.checksum" ) }}` from the `build.yaml` file

To test it locally, run `luet autobump-github` (with the devkit @ version 0.10.2)

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>