### PR TITLE
Add k9s and nerdctl utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ DESTINATION?=$(ROOT_DIR)/build
 #
 # yaml specification of build targets
 #
-export ISO_SPEC?=$(ROOT_DIR)/iso/cOS.yaml
+export MANIFEST?=$(ROOT_DIR)/manifest.yaml
 
 #----------------------- end global variables -----------------------
 

--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -39,7 +39,7 @@ _VALIDATE_OPTIONS?=-s
 #
 # extract packages from yaml spec
 #
-PACKAGES?=$(shell yq r -j $(ISO_SPEC) 'packages.[*]' | jq -r '.[]' | sort -u)
+PACKAGES?=$(shell yq r -j $(MANIFEST) | jq -r '.packages[],.build | .[]' | sort -u)
 
 PUBLISH_ARGS?=
 

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -53,7 +53,7 @@ local-iso: $(LUET) $(MAKEISO) $(DESTINATION) $(MKSQUASHFS) $(DESTINATION)/tree.t
 ifneq ("$(ISO)","")
 	@echo "'$(ISO) exists, run 'make clean_iso' folled by 'make $@' to recreate"
 else
-	$(LUET) makeiso -- $(ISO_SPEC) --local $(DESTINATION)
+	$(LUET) makeiso -- $(MANIFEST) --local $(DESTINATION)
 endif
 
 .PHONY: iso
@@ -61,12 +61,12 @@ iso: $(LUET) $(YQ) $(MAKEISO) $(MKSQUASHFS)
 ifneq ("$(ISO)","")
 	@echo "'$(ISO) exists, run 'make clean_iso' folled by 'make $@' to recreate"
 else
-	cp -rf $(ISO_SPEC) $(ISO_SPEC).remote
-	$(YQ) w -i $(ISO_SPEC).remote 'luet.repositories[0].name' 'cOS'
-	$(YQ) w -i $(ISO_SPEC).remote 'luet.repositories[0].enable' true
-	$(YQ) w -i $(ISO_SPEC).remote 'luet.repositories[0].type' 'docker'
-	$(YQ) w -i $(ISO_SPEC).remote 'luet.repositories[0].urls[0]' $(FINAL_REPO)
-	$(LUET) makeiso $(ISO_SPEC).remote
+	cp -rf $(MANIFEST) $(MANIFEST).remote
+	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].name' 'cOS'
+	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].enable' true
+	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].type' 'docker'
+	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].urls[0]' $(FINAL_REPO)
+	$(LUET) makeiso $(MANIFEST).remote
 endif
 
 # Packer

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -16,3 +16,8 @@ overlay: true
 image_prefix: "cOS-0."
 image_date: true
 label: "COS_LIVE"
+
+# Additional packages to build
+build:
+ - utils/nerdctl
+ - utils/k9s

--- a/packages/utils/k9s/build.yaml
+++ b/packages/utils/k9s/build.yaml
@@ -1,0 +1,16 @@
+requires:
+- name: "base"
+  category: "distro"
+  version: ">=0"
+
+prelude:
+- |
+   PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
+   curl -L https://github.com/derailed/k9s/releases/download/v$PACKAGE_VERSION/{{.Values.name}}_v${PACKAGE_VERSION}_{{.Values.platform}}_{{.Values.arch}}.tar.gz -o {{.Values.name}}_v$PACKAGE_VERSION-{{.Values.platform}}-{{.Values.arch}}.tar.gz && \
+   echo "{{ ( index .Values.labels "package.checksum" ) }}  {{.Values.name}}_v$PACKAGE_VERSION-{{.Values.platform}}-{{.Values.arch}}.tar.gz" | sha256sum -c
+
+steps:
+- |
+   PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
+   tar xvzf {{.Values.name}}_v$PACKAGE_VERSION-{{.Values.platform}}-{{.Values.arch}}.tar.gz -C /usr/bin k9s
+- chmod +x /usr/bin/k9s

--- a/packages/utils/k9s/definition.yaml
+++ b/packages/utils/k9s/definition.yaml
@@ -1,0 +1,12 @@
+name: "k9s"
+category: "utils"
+version: "0.24.10"
+
+arch: x86_64
+platform: Linux
+labels:
+  github.repo: "k9s"
+  github.owner: "derailed"
+  autobump.revdeps: "true"
+  autobump.checksum_hook: "curl -L -s https://github.com/containerd/nerdctl/releases/download/v{{.Values.labels.package.version}}/checksums.txt | grep {{.Values.name}}-{{.Values.labels.package.version}}-{{.Values.platform}}-{{.Values.arch}} | awk '{ print $1 }'"
+  package.checksum: "bf1fbcf145b8e021b675bae009183e7028afbce52fc44c37f6a0dd2982152c21"

--- a/packages/utils/nerdctl/build.yaml
+++ b/packages/utils/nerdctl/build.yaml
@@ -1,0 +1,16 @@
+requires:
+- name: "base"
+  category: "distro"
+  version: ">=0"
+
+prelude:
+- |
+   PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
+   curl -L https://github.com/containerd/nerdctl/releases/download/v$PACKAGE_VERSION/{{.Values.name}}-$PACKAGE_VERSION-{{.Values.platform}}-{{.Values.arch}}.tar.gz -o {{.Values.name}}-$PACKAGE_VERSION-{{.Values.platform}}-{{.Values.arch}}.tar.gz && \
+   echo "{{ ( index .Values.labels "package.checksum" ) }}  {{.Values.name}}-$PACKAGE_VERSION-{{.Values.platform}}-{{.Values.arch}}.tar.gz" | sha256sum -c
+
+steps:
+- |
+  PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
+  tar xvzf {{.Values.name}}-$PACKAGE_VERSION-{{.Values.platform}}-{{.Values.arch}}.tar.gz -C /usr/bin nerdctl
+- chmod +x /usr/bin/nerdctl

--- a/packages/utils/nerdctl/definition.yaml
+++ b/packages/utils/nerdctl/definition.yaml
@@ -1,0 +1,12 @@
+name: "nerdctl"
+category: "utils"
+version: "0.8.3"
+
+arch: amd64
+platform: linux
+labels:
+  github.repo: "nerdctl"
+  github.owner: "containerd"
+  autobump.revdeps: "true"
+  autobump.checksum_hook: "curl -L -s https://github.com/containerd/nerdctl/releases/download/v{{.Values.labels.package.version}}/SHA256SUMS | grep {{.Values.name}}-{{.Values.labels.package.version}}-{{.Values.platform}}-{{.Values.arch}} | awk '{ print $1 }'"
+  package.checksum: "b28df28b6f814d2b7c87f4be472c30605be93dd99e41670218387b7f7b94d592"


### PR DESCRIPTION
nerdctl and k9s are extremely useful, and could be also reused in the recovery image.

This change also renames the `iso/cOS.yaml` to `manifest.yaml`. It also adds a `build` field with an optional list of packages to build.

See also: https://github.com/ibuildthecloud/os2/blob/master/Dockerfile#L60
