### PR TITLE
golang: add apt-get update before installing deps

### DIFF
--- a/packages/golang/build.yaml
+++ b/packages/golang/build.yaml
@@ -10,6 +10,7 @@ prelude:
 {{else if eq .Values.distribution "fedora" }}
 - dnf install -y wget "@Development Tools"
 {{else if eq .Values.distribution "ubuntu" }}
+- apt-get update
 - apt-get install -y build-essential wget
 {{end}}
 {{end}}


### PR DESCRIPTION
This avoids errors if repos are out-of-sync