### PR TITLE
Enable env vars for vagrant cpu/memory

### DIFF
--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -5,15 +5,16 @@ Vagrant.configure("2") do |config|
   config.vm.box = "cos"
 
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "4098", "--cpus", "2"]
+    vb.memory = ENV['VAGRANT_MEMORY'] || "4096"
+    vb.cpus = ENV['VAGRANT_CPU'] || "2"
   end
 
   config.vm.provider :libvirt do |libvirt|
     config.vm.guest = :linux
     config.vm.synced_folder ".", "/vagrant", disabled: true
     libvirt.driver = "kvm"
-    libvirt.memory = 4096
-    libvirt.cpus = 2
+    libvirt.memory = ENV['VAGRANT_MEMORY'] || "4096"
+    libvirt.cpus = ENV['VAGRANT_CPU'] || "2"
     config.vm.network "forwarded_port", guest: 22, host: 2222
   end
     


### PR DESCRIPTION
Some of us are lucky to have lots of cpu/ram so we can take advantage
of that when running the tests by defining VAGRANT_MEMORY and
VAGRANT_CPU to our desired values.

This doesnt affect the current defaults

Signed-off-by: Itxaka <igarcia@suse.com>