### PR TITLE
Prevent multiple job runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,8 +21,14 @@ on:
   create:
     tags:
       - v*
+
+
 jobs:
   docker-build:
+    concurrency: 
+      group: ci-docker-build-dismissable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+      cancel-in-progress: true
+
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -53,6 +59,9 @@ jobs:
           cos-build $FLAVOR
 
   build:
+    concurrency: 
+      group: ci-dismissable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -127,6 +136,9 @@ jobs:
           if-no-files-found: error
 
   iso:
+    concurrency: 
+      group: ci-dismissable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     needs: build
     strategy:
@@ -165,6 +177,9 @@ jobs:
             *.sha256
           if-no-files-found: error
   qemu:
+    concurrency: 
+      group: ci-dismissable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+      cancel-in-progress: true
     runs-on: macos-10.15
     needs: iso
 
@@ -198,6 +213,9 @@ jobs:
             packer/*.box
           if-no-files-found: error
   vbox:
+    concurrency: 
+      group: ci-dismissable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+      cancel-in-progress: true
     runs-on: macos-10.15
     needs: iso
     strategy:
@@ -232,6 +250,9 @@ jobs:
             packer/*.box
           if-no-files-found: error
   tests:
+    concurrency: 
+      group: ci-dismissable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+      cancel-in-progress: true
     runs-on: macos-10.15
     needs: vbox
     strategy:
@@ -266,6 +287,8 @@ jobs:
           if-no-files-found: warn
 
   publish:
+    concurrency: 
+      group: ci-publish-${{ github.head_ref || github.ref }}-${{ github.repository }}
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
     needs: tests
@@ -316,6 +339,8 @@ jobs:
           sudo -E make publish-repo
 
   github-release:
+    concurrency: 
+      group: ci-publish-${{ github.head_ref || github.ref }}-${{ github.repository }}
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: tests
@@ -357,6 +382,9 @@ jobs:
 # Non-squashfs tests
 
   iso-nosquashfs:
+    concurrency: 
+      group: ci-dismissable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     needs: build
     strategy:
@@ -400,6 +428,9 @@ jobs:
           if-no-files-found: error
   
   vbox-nosquashfs:
+    concurrency: 
+      group: ci-dismissable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+      cancel-in-progress: true
     runs-on: macos-10.15
     needs: iso-nosquashfs
     strategy:
@@ -434,6 +465,9 @@ jobs:
             packer/*.box
           if-no-files-found: error
   tests-nosquashfs:
+    concurrency: 
+      group: ci-dismissable-${{ github.head_ref || github.ref }}-${{ github.repository }}
+      cancel-in-progress: true
     runs-on: macos-10.15
     needs: vbox-nosquashfs
     strategy:


### PR DESCRIPTION
Make use of concurrency (https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency) to prevent multiple job runs for the same github reference.

We don't apply it to the whole workflow to prevent publish/release jobs to be canceled while being executed. Otherwise it could invalidate repository states.

Fixes #265
Fixes #136

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>