### PR TITLE
ci: split vbox/qemu into separate groups

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -177,7 +177,7 @@ jobs:
           if-no-files-found: error
   qemu:
     concurrency: 
-      group: ci-dismissable-${{ github.head_ref || github.ref }}-${{ github.repository }}-${{ matrix.flavor }}
+      group: ci-dismissable-qemu-${{ github.head_ref || github.ref }}-${{ github.repository }}-${{ matrix.flavor }}
       cancel-in-progress: true
     runs-on: macos-10.15
     needs: iso
@@ -339,7 +339,7 @@ jobs:
 
   github-release:
     concurrency: 
-      group: ci-publish-${{ github.head_ref || github.ref }}-${{ github.repository }}-${{ matrix.flavor }}
+      group: ci-publish-release-${{ github.head_ref || github.ref }}-${{ github.repository }}-${{ matrix.flavor }}
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: tests


### PR DESCRIPTION
This avoids that vbox/qemu jobs skips each others (as they are running in parallel)

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>