### PR TITLE
ci: allocate capacity fitting the runner specs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -249,6 +249,9 @@ jobs:
             packer/*.box
           if-no-files-found: error
   tests:
+    env:
+      VAGRANT_CPU: 3
+      VAGRANT_MEMORY: 10240
     concurrency: 
       group: ci-dismissable-${{ github.head_ref || github.ref }}-${{ github.repository }}-${{ matrix.flavor }}
       cancel-in-progress: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -445,6 +445,7 @@ jobs:
     runs-on: macos-10.15
     needs: vbox-nosquashfs
     strategy:
+      max-parallel: 1
       matrix:
         flavor: ["opensuse"]
         test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned"]

--- a/packer/images.json
+++ b/packer/images.json
@@ -9,6 +9,8 @@
         "iso_url": "{{user `iso`}}",
         "iso_checksum": "none",
         "shutdown_command": "shutdown -hP now",
+        "cpus": "{{ user `cpus` }}",
+        "memory": "{{ user `memory` }}",
         "ssh_password": "{{user `root_password`}}",
         "ssh_username": "{{user `root_username`}}",
         "format": "ova",
@@ -25,11 +27,12 @@
         "accelerator": "{{user `accelerator`}}",
         "headless": true,
         "iso_url": "{{user `iso`}}",
+        "cpus": "{{ user `cpus` }}",
         "iso_checksum": "none",
         "qemuargs": [
           [
             "-m",
-            "8192M"
+            "{{ user `memory` }}M"
           ]
         ],
         "shutdown_command": "shutdown -hP now",
@@ -84,6 +87,8 @@
       "arch": "amd64",
       "build": "dev",
       "disk_size": "50000",
+      "cpus": "3",
+      "memory": "8192",
       "flavor": "leap",
       "root_password": "cos",
       "root_username": "root",


### PR DESCRIPTION
hopefully should make tests go faster by allocating (almost) all the available space of the runner