### PR TITLE
ci: run docker-build test in sequence

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,6 +30,7 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         include:
           - flavor: "opensuse"


### PR DESCRIPTION
docker-build tests just make sure we don't break the `source .envrc && cos-build` workflow. As they start at the beginning of the build, it's acceptable to run those in sequence to leave room for parallel jobs.

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>