### PR TITLE
Speed up the rootfs copying in the installer

### DIFF
--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -216,7 +216,7 @@ do_copy()
 {
     echo "Copying cOS.."
 
-    rsync -aqzAX --exclude='mnt' --exclude='proc' --exclude='sys' --exclude='dev' --exclude='tmp' ${DISTRO}/ ${TARGET}
+    rsync -aqAX --exclude='mnt' --exclude='proc' --exclude='sys' --exclude='dev' --exclude='tmp' ${DISTRO}/ ${TARGET}
      if [ -n "$COS_INSTALL_CONFIG_URL" ]; then
         OEM=${TARGET}/oem/99_custom.yaml
         get_url "$COS_INSTALL_CONFIG_URL" $OEM


### PR DESCRIPTION
Remove the rsync compress option to decrease the copying time.
- Copying files with compression in the same host might not be worth it.
- Copying small-size files with compression could add more overhead.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>

Not sure if the change is needed, but I got a noticeable speed boost by removing the compress option in rsync.
Here are some experiments (installing a ~634M `/run/rootfsbase/` to a virtual disk on nvme device) by putting a time command before the `rsync` command. For each case I test two times, each time the VM is destroyed and re-created.

With `-z`:
```
real	0m30.863s
user	0m24.990s
sys	0m9.315s

real	0m31.783s
user	0m24.878s
sys	0m9.524s
```

Without `-z`:
```
real	0m11.228s
user	0m2.216s
sys	0m9.343s

real	0m11.127s
user	0m2.238s
sys	0m9.304s
```
