### PR TITLE
Add nerdctl and k9s

### DIFF
--- a/packages/toolchain/k9s/build.yaml
+++ b/packages/toolchain/k9s/build.yaml
@@ -1,0 +1,26 @@
+requires:
+- name: "golang"
+  category: "build"
+  version: ">=0"
+env:
+- PATH=$PATH:/usr/local/go/bin
+prelude:
+{{ if .Values.distribution }}
+{{if eq .Values.distribution "opensuse" }}
+- zypper in -y git
+{{else if eq .Values.distribution "fedora" }}
+- dnf install -y git
+{{else if eq .Values.distribution "ubuntu" }}
+- apt-get install -y git
+{{end}}
+{{end}}
+- |
+   PACKAGE_VERSION=v${PACKAGE_VERSION%\+*} && \
+   git clone --depth=1 --branch ${PACKAGE_VERSION} https://github.com/derailed/k9s
+steps:
+- |
+   cd k9s && \
+   make build && \
+   cp execs/k9s /usr/bin
+includes:
+- /usr/bin/k9s

--- a/packages/toolchain/k9s/definition.yaml
+++ b/packages/toolchain/k9s/definition.yaml
@@ -1,0 +1,6 @@
+category: "toolchain"
+name: "k9s"
+version: 0.24.10+1
+labels:
+  github.repo: "k9s"
+  github.owner: "derailed"

--- a/packages/toolchain/nerdctl/build.yaml
+++ b/packages/toolchain/nerdctl/build.yaml
@@ -1,0 +1,26 @@
+requires:
+- name: "golang"
+  category: "build"
+  version: ">=0"
+env:
+- PATH=$PATH:/usr/local/go/bin
+prelude:
+{{ if .Values.distribution }}
+{{if eq .Values.distribution "opensuse" }}
+- zypper in -y git
+{{else if eq .Values.distribution "fedora" }}
+- dnf install -y git
+{{else if eq .Values.distribution "ubuntu" }}
+- apt-get install -y git
+{{end}}
+{{end}}
+- |
+   PACKAGE_VERSION=v${PACKAGE_VERSION%\+*} && \
+   git clone --depth=1 --branch ${PACKAGE_VERSION} https://github.com/containerd/nerdctl
+steps:
+- |
+   cd nerdctl && \
+   make binaries && \
+   make BINDIR=/usr/bin install
+includes:
+- /usr/bin/nerdctl

--- a/packages/toolchain/nerdctl/definition.yaml
+++ b/packages/toolchain/nerdctl/definition.yaml
@@ -1,0 +1,6 @@
+category: "toolchain"
+name: "nerdctl"
+version: 0.8.3+1
+labels:
+  github.repo: "nerdctl"
+  github.owner: "containerd"


### PR DESCRIPTION
What I'd like to do is for RancherOS that I pull content from only
three sources

1. Leap
2. cOS Toolkit
3. Rancher built projects

So for example rancherd I can download that binary directly because
I can trust the build process, but for something third party like k9s
I'd prefer that be maintained in the toolkit.

Eventually the cOS toolkit is going to need to use FIPS compliant
go toolchain (essentially https://github.com/golang/go/tree/dev.boringcrypto/misc/boring),
so everything will have to be rebuilt by us.