### PR TITLE
'build' target needs DESTINATION

### DIFF
--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -48,7 +48,7 @@ endif
 PUBLISH_ARGS?=
 
 .PHONY: build
-build: $(LUET)
+build: $(LUET) $(DESTINATION)
 ifneq ($(shell id -u), 0)
 	@echo "Please run 'make $@' as root"
 	@exit 1
@@ -105,4 +105,4 @@ validate: $(LUET)
 #
 
 clean_build:
-	rm -rf $(DESTINATION)
+	sudo rm -rf $(DESTINATION)

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -20,7 +20,7 @@ clean_iso:
 	sudo rm -rf isowork
 
 $(DESTINATION):
-	mkdir $(DESTINATION)
+	mkdir -m 755 $(DESTINATION)
 
 #
 # build ISO from repository


### PR DESCRIPTION
Otherwise builds of `utils/k9s` and `utils/nerdctl` will fail.

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>