### PR TITLE
Unattended deployment on a vanilla image

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -272,7 +272,7 @@ jobs:
     needs: vbox-{{{$subset}}}-{{{ $flavor }}}
     strategy:
       matrix:
-        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -247,7 +247,7 @@ jobs:
     needs: vbox-squashfs-opensuse
     strategy:
       matrix:
-        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
@@ -400,7 +400,7 @@ jobs:
     needs: vbox-nonsquashfs-opensuse
     strategy:
       matrix:
-        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -226,7 +226,7 @@ jobs:
     needs: vbox-squashfs-opensuse
     strategy:
       matrix:
-        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
@@ -379,7 +379,7 @@ jobs:
     needs: vbox-nonsquashfs-opensuse
     strategy:
       matrix:
-        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -232,7 +232,7 @@ jobs:
     needs: vbox-squashfs-opensuse
     strategy:
       matrix:
-        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
@@ -385,7 +385,7 @@ jobs:
     needs: vbox-nonsquashfs-opensuse
     strategy:
       matrix:
-        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/images/img-builder.sh
+++ b/images/img-builder.sh
@@ -32,7 +32,6 @@ mkdir -p root/grub2/x86_64-efi
 mkdir -p root/cOS
 cp recovery/usr/share/grub2/x86_64-efi/*.mod root/grub2/x86_64-efi
 cp recovery/etc/cos/grub.cfg root/grub2
-sed -i 's/${saved_entry}/recovery/g' root/grub2/grub.cfg
 luet install --system-target root/cOS -y recovery/cos-img
 
 # Create a 2GB filesystem for COS_RECOVERY including the contents for root (grub config and squasfs container)

--- a/images/user-data.yaml
+++ b/images/user-data.yaml
@@ -1,0 +1,28 @@
+name: "Default deployment"
+stages:
+   rootfs.after:
+     - name: "Repart image"
+       layout:
+         # It will partition a device including the given filesystem label or part label (filesystem label matches first)
+         device:
+           label: COS_RECOVERY
+         # Only last partition can be expanded
+         # expand_partition:
+         #   size: 4096
+         add_partitions:
+           - fsLabel: COS_STATE
+             size: 8192
+             pLabel: state
+           - fsLabel: COS_PERSISTENT
+             # unset size or 0 size means all available space
+             # size: 0 
+             # default filesystem is ext2 when omitted
+             # filesystem: ext4
+             pLabel: persistent
+   network:
+     - if: '[ -z "$(blkid -L COS_SYSTEM || true)" ]'
+       name: "Deploy cos-system"
+       commands:                                                                 
+         - |
+             cos-deploy --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.3-3 && \
+             shutdown -r +1

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -40,7 +40,7 @@ endif
 # ------------ actual test targets ------------
 #
 
-test: test-clean vagrantfile prepare-test test-smoke test-upgrades-signed test-upgrades-unsigned test-features test-fallback test-recovery
+test: test-clean vagrantfile prepare-test test-smoke test-upgrades-images-signed test-upgrades-images-unsigned test-features test-fallback test-recovery test-deploys-images
 
 #
 # remove test artifacts
@@ -86,6 +86,9 @@ test-smoke: $(GINKGO)
 
 test-recovery: $(GINKGO)
 	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) ./recovery
+
+test-deploys-images: $(GINKGO)
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) ./deploys-images
 
 $(GINKGO):
 	@echo "'ginkgo' not found."

--- a/packages/cloud-config/definition.yaml
+++ b/packages/cloud-config/definition.yaml
@@ -1,3 +1,3 @@
 name: cloud-config
 category: system
-version: 0.5+4
+version: "0.6"

--- a/packages/cloud-config/oem/00_rootfs.yaml
+++ b/packages/cloud-config/oem/00_rootfs.yaml
@@ -7,12 +7,18 @@
 # copy the file with a prefix starting by 90, e.g. /oem/91_custom.yaml
 name: "Rootfs Layout Settings"
 stages:
-  rootfs:
-    - environment_file: /run/cos/cos-layout.env
+  rootfs.before:
+    - name: "Layout configuration"
+      environment_file: /run/cos/cos-layout.env
       environment:
         VOLUMES: "LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local"
         OVERLAY: "tmpfs:25%"
 #       DEBUG_RW: "true"
+    - name: "Pull data from provider"
+      datasource:
+        providers: ["aws", "cdrom"]
+        path: "/oem"
+
   initramfs:
     - if: '[ -z "$(blkid -L COS_SYSTEM || true)" ]'
       name: "Persist /etc/machine-id"

--- a/packages/cos-setup/02-cos-setup-initramfs.conf
+++ b/packages/cos-setup/02-cos-setup-initramfs.conf
@@ -1,3 +1,4 @@
 install_items+=" /lib/systemd/system/cos-setup-initramfs.service /etc/systemd/system/initrd.target.requires/cos-setup-initramfs.service "
 install_items+=" /lib/systemd/system/cos-setup-rootfs.service /etc/systemd/system/initrd-fs.target.requires/cos-setup-rootfs.service "
+install_items+=" /etc/hosts "
 add_dracutmodules+=" network "

--- a/packages/cos-setup/cos-setup-initramfs.service
+++ b/packages/cos-setup/cos-setup-initramfs.service
@@ -7,7 +7,7 @@ Before=initrd.target
 
 [Service]
 RootDirectory=/sysroot
-MountAPIVFS=true
+BindPaths=/proc /sys /dev /run
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/cos-setup initramfs

--- a/packages/cos-setup/cos-setup-rootfs.service
+++ b/packages/cos-setup/cos-setup-rootfs.service
@@ -7,6 +7,7 @@ Conflicts=initrd-switch-root.target
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStartPre=/usr/bin/ln -sf -t / /sysroot/system
 ExecStart=/usr/bin/cos-setup rootfs
 

--- a/packages/cos-setup/definition.yaml
+++ b/packages/cos-setup/definition.yaml
@@ -1,6 +1,6 @@
 name: cos-setup
 category: system
-version: 0.2.16+2
+version: "0.3.0"
 requires:
   - name: "yip"
     category: "toolchain"

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,14 +1,14 @@
 packages:
   - name: "cos"
     category: "system"
-    version: "0.5.5"
+    version: "0.5.6+1"
     brand_name: "cOS"
     labels:
       autobump.revdeps: "true"
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos"
     category: "recovery"
-    version: 0.5.5+2
+    version: "0.5.6+1"
     brand_name: "cOS recovery"
     labels:
       autobump.revdeps: "true"

--- a/packages/grub-config/config/bootargs.cfg
+++ b/packages/grub-config/config/bootargs.cfg
@@ -1,8 +1,8 @@
 set kernel=/boot/vmlinuz
 if [ -n "$recoverylabel" ]; then
-    set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5"
+    set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5 rd.neednet=1"
 else
-    set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label cos-img/filename=$img panic=5 security=selinux selinux=1"
+    set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label cos-img/filename=$img panic=5 security=selinux selinux=1 rd.neednet=1"
 fi
 
 set initramfs=/boot/initrd

--- a/packages/grub-config/definition.yaml
+++ b/packages/grub-config/definition.yaml
@@ -1,3 +1,3 @@
 name: "grub-config"
 category: "system"
-version: 0.0.7+2
+version: "0.0.8"

--- a/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
+++ b/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
@@ -7,7 +7,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo rootfs-block dm 
+    echo rootfs-block dm
     return 0
 }
 
@@ -24,7 +24,12 @@ install() {
     declare initdir="${initdir}"
 
     inst_multiple \
-        mount mountpoint yip cos-setup sort findmnt rmdir
+        mount mountpoint yip cos-setup sort findmnt rmdir findmnt
+
+    # Include utilities required for cos-setup services,
+    # probably a devoted cos-setup dracut module makes sense
+    inst_multiple -o \
+        partprobe lsblk sgdisk mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat mkfs.xfs
     inst_hook cmdline 30 "${moddir}/parse-cos-cmdline.sh"
     inst_script "${moddir}/cos-generator.sh" \
         "${systemdutildir}/system-generators/dracut-cos-generator"

--- a/packages/immutable-rootfs/30cos-immutable-rootfs/parse-cos-cmdline.sh
+++ b/packages/immutable-rootfs/30cos-immutable-rootfs/parse-cos-cmdline.sh
@@ -7,14 +7,17 @@
 # rd.cos.overlay=UUID=<vol_uuid>
 # rd.cos.oemtimeout=<seconds>
 # rd.cos.debugrw
+# rd.cos.disable
 # cos-img/filename=/cOS/active.img
 
 type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
+if getargbool 0 rd.cos.disable; then
+    return 0
+fi
+
 cos_img=$(getarg cos-img/filename=)
 [ -z "${cos_img}" ] && return 0
-cos_overlay=$(getarg rd.cos.overlay=)
-[ -z "${cos_overlay}" ] && cos_overlay="tmpfs:20%"
 [ -z "${root}" ] && root=$(getarg root=)
 
 cos_root_perm="ro"

--- a/packages/immutable-rootfs/definition.yaml
+++ b/packages/immutable-rootfs/definition.yaml
@@ -1,3 +1,3 @@
 name: "immutable-rootfs"
 category: "system"
-version: 0.0.31+2
+version: "0.1.1"

--- a/packages/installer/build.yaml
+++ b/packages/installer/build.yaml
@@ -7,3 +7,4 @@ steps:
 - cp -rfv installer.sh /usr/sbin/cos-installer && chmod +x /usr/sbin/cos-installer
 - cp -rfv upgrade.sh /usr/sbin/cos-upgrade && chmod +x /usr/sbin/cos-upgrade
 - cp -rfv reset.sh /usr/sbin/cos-reset && chmod +x /usr/sbin/cos-reset
+- cp -rfv deploy.sh /usr/sbin/cos-deploy && chmod +x /usr/sbin/cos-deploy

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: 0.7.6+2
+version: "0.7.9"

--- a/packages/installer/deploy.sh
+++ b/packages/installer/deploy.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+set -e
+
+CHANNEL_UPGRADES="${CHANNEL_UPGRADES:-true}"
+FORCE=""${FORCE:-false}
+
+# 1. Identify active/passive partitions
+# 2. Deploy active and passive to the same image
+
+find_partitions() {
+    STATE=$(blkid -L COS_STATE || true)
+    if [ -z "$STATE" ]; then
+        echo "State partition cannot be found"
+        exit 1
+    fi
+
+    PERSISTENT=$(blkid -L COS_PERSISTENT || true)
+    if [ -z "$PERSISTENT" ]; then
+        echo "Persistent partition cannot be found"
+        exit 1
+    fi
+
+    COS_ACTIVE=$(blkid -L COS_ACTIVE || true)
+    COS_PASSIVE=$(blkid -L COS_PASSIVE || true)
+    if [ -n "$COS_ACTIVE" ] || [ -n "$COS_PASSIVE" ]; then
+        if [ "$FORCE" == "true" ]; then
+            echo "Forcing overwrite current COS_ACTIVE and COS_PASSIVE partitions"
+            return 0
+        else
+            echo "There is already an active deployment in the system, use '--force' flag to overwrite it"
+            exit 1
+        fi
+   
+    fi
+}
+
+# cos-upgrade-image: system/cos
+find_upgrade_channel() {
+    if [ -e "/etc/cos-upgrade-image" ]; then
+        source /etc/cos-upgrade-image
+    fi
+
+    if [ -n "$IMAGE" ]; then
+        UPGRADE_IMAGE=$IMAGE
+        echo "Upgrading to image $UPGRADE_IMAGE"
+    fi
+
+    if [ -z "$UPGRADE_IMAGE" ]; then
+        UPGRADE_IMAGE="system/cos"
+    fi
+}
+
+prepare_target() {
+    if [ -f  ${STATEDIR}/cOS/active.img ] && [ "$FORCE" != "true" ]; then
+        echo "There is already an active deployment in the system, use '--force' flag to overwrite it"
+        exit 1
+    fi
+
+    mkdir -p ${STATEDIR}/cOS || true
+    rm -rf ${STATEDIR}/cOS/active.img || true
+    dd if=/dev/zero of=${STATEDIR}/cOS/active.img bs=1M count=3240
+    mkfs.ext2 ${STATEDIR}/cOS/active.img
+    mount -t ext2 -o loop ${STATEDIR}/cOS/active.img $TARGET
+}
+
+mount_state() {
+    STATEDIR=/run/initramfs/state
+    mkdir -p $STATEDIR
+    mount ${STATE} ${STATEDIR}
+}
+
+mount_image() {
+    STATEDIR=/run/initramfs/cos-state
+    TARGET=/tmp/upgrade
+
+    mkdir -p $TARGET || true
+
+    if [ -d "$STATEDIR" ]; then
+        if [ -f /run/cos/recovery_mode ]; then
+            mount_state
+        else
+            mount -o remount,rw ${STATE} ${STATEDIR}
+        fi
+    else
+        mount_state
+    fi
+
+    prepare_target
+}
+
+upgrade() {
+    ensure_dir_structure
+
+    temp_upgrade=$STATEDIR/tmp/upgrade
+    rm -rf $temp_upgrade || true
+    mkdir -p $temp_upgrade
+
+    # FIXME: XDG_RUNTIME_DIR is for containerd, by default that points to /run/user/<uid>
+    # which might not be sufficient to unpack images. Use /usr/local/tmp until we get a separate partition
+    # for the state
+    # FIXME: Define default /var/tmp as tmpdir_base in default luet config file
+    export XDG_RUNTIME_DIR=$temp_upgrade
+    export TMPDIR=$temp_upgrade
+    export LUET_PRIVILEGED_EXTRACT=true
+
+    if [ -n "$CHANNEL_UPGRADES" ] && [ "$CHANNEL_UPGRADES" == true ]; then
+        if [ -z "$VERIFY" ]; then
+          args="--enable-logfile --logfile /tmp/luet.log --plugin luet-mtree"
+        fi
+        luet install $args --system-target $TARGET --system-engine memory -y $UPGRADE_IMAGE
+        luet cleanup
+    else
+        args=""
+        if [ -z "$VERIFY" ]; then
+          args="--enable-logfile --logfile /tmp/luet.log --plugin luet-mtree"
+        fi
+        luet util unpack $args $UPGRADE_IMAGE /usr/local/tmp/rootfs
+        rsync -aqzAX --exclude='mnt' --exclude='proc' --exclude='sys' --exclude='dev' --exclude='tmp' /usr/local/tmp/rootfs/ $TARGET
+        rm -rf /usr/local/tmp/rootfs
+    fi
+
+    SELinux_relabel
+
+    rm -rf $temp_upgrade
+    umount $TARGET || true
+}
+
+SELinux_relabel()
+{
+    if which setfiles > /dev/null && [ -e ${TARGET}/etc/selinux/targeted/contexts/files/file_contexts ]; then
+        setfiles -r ${TARGET} ${TARGET}/etc/selinux/targeted/contexts/files/file_contexts ${TARGET}
+    fi
+}
+
+set_active_passive() {
+    tune2fs -L COS_ACTIVE ${STATEDIR}/cOS/active.img
+
+    cp -f ${STATEDIR}/cOS/active.img ${STATEDIR}/cOS/passive.img
+    tune2fs -L COS_PASSIVE ${STATEDIR}/cOS/passive.img
+}
+
+ensure_dir_structure() {
+    mkdir ${TARGET}/proc || true
+    mkdir ${TARGET}/boot || true
+    mkdir ${TARGET}/dev || true
+    mkdir ${TARGET}/sys || true
+    mkdir ${TARGET}/tmp || true
+    mkdir ${TARGET}/usr/local || true
+    mkdir ${TARGET}/oem || true
+}
+
+cleanup2()
+{
+    rm -rf /usr/local/tmp/upgrade || true
+    mount -o remount,ro ${STATE} ${STATEDIR} || true
+    if [ -n "${TARGET}" ]; then
+        umount ${TARGET}/boot/efi || true
+        umount ${TARGET}/ || true
+        rm -rf ${TARGET}
+    fi
+
+    if [ "$STATEDIR" == "/run/initramfs/state" ]; then
+        umount ${STATEDIR}
+        rm -rf $STATEDIR
+    fi
+}
+
+cleanup()
+{
+    EXIT=$?
+    cleanup2 2>/dev/null || true
+    return $EXIT
+}
+
+usage()
+{
+    echo "Usage: cos-deploy [--no-verify] [--docker-image] [--force] IMAGE"
+    echo ""
+    echo "Example: cos-deploy"
+    echo ""
+    echo "IMAGE is optional, and deployes the system to the given specified docker image."
+    echo ""
+    echo ""
+    exit 1
+}
+
+find_upgrade_channel
+
+while [ "$#" -gt 0 ]; do
+    case $1 in
+        --docker-image)
+            CHANNEL_UPGRADES=false
+            ;;
+        --no-verify)
+            VERIFY=false
+            ;;
+        --force)
+            FORCE=true
+            ;;
+        -h)
+            usage
+            ;;
+        --help)
+            usage
+            ;;
+        *)
+            if [ "$#" -gt 2 ]; then
+                usage
+            fi
+            UPGRADE_IMAGE=$1
+            break
+            ;;
+    esac
+    shift 1
+done
+
+trap cleanup exit
+
+
+echo "Deploying system.."
+
+find_partitions
+
+mount_image
+
+upgrade
+
+set_active_passive
+
+echo "Flush changes to disk"
+sync
+
+echo "Deployment done, now you might want to reboot"

--- a/packages/livecd/live-boot/definition.yaml
+++ b/packages/livecd/live-boot/definition.yaml
@@ -1,5 +1,5 @@
 name: "boot"
 category: "live"
-version: "0.2.1"
+version: "0.2.2"
 
 hidden: true # No need to make it installable for now

--- a/packages/livecd/live-boot/package/EFI/BOOT/startup.nsh
+++ b/packages/livecd/live-boot/package/EFI/BOOT/startup.nsh
@@ -1,3 +1,3 @@
 echo -off
 echo cOS Linux Live is starting.
-\boot\kernel.xz initrd=\boot\rootfs.xz root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs
+\boot\kernel.xz initrd=\boot\rootfs.xz root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs rd.cos.disable

--- a/packages/livecd/live-boot/package/boot/bios/EFI/BOOT/startup.nsh
+++ b/packages/livecd/live-boot/package/boot/bios/EFI/BOOT/startup.nsh
@@ -1,3 +1,3 @@
 echo -off
 echo cOS Linux Live is starting.
-\boot\kernel.xz initrd=\boot\rootfs.xz root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs
+\boot\kernel.xz initrd=\boot\rootfs.xz root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs rd.cos.disable

--- a/packages/livecd/live-boot/package/boot/bios/boot/syslinux/syslinux.cfg
+++ b/packages/livecd/live-boot/package/boot/bios/boot/syslinux/syslinux.cfg
@@ -16,15 +16,15 @@ SAY
 
 LABEL vga
   LINUX  /boot/kernel.xz
-  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0
+  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
   INITRD /boot/rootfs.xz
 
 LABEL vga_nomodeset
   LINUX  /boot/kernel.xz
-  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0
+  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
   INITRD /boot/rootfs.xz
 
 LABEL console
   LINUX  /boot/kernel.xz
-  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0
+  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
   INITRD /boot/rootfs.xz

--- a/packages/livecd/live-boot/package/boot/syslinux/syslinux.cfg
+++ b/packages/livecd/live-boot/package/boot/syslinux/syslinux.cfg
@@ -16,15 +16,15 @@ SAY
 
 LABEL vga
   LINUX  /boot/kernel.xz
-  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0
+  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
   INITRD /boot/rootfs.xz
 
 LABEL vga_nomodeset
   LINUX  /boot/kernel.xz
-  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0
+  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
   INITRD /boot/rootfs.xz
 
 LABEL console
   LINUX  /boot/kernel.xz
-  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0
+  APPEND cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable
   INITRD /boot/rootfs.xz

--- a/packages/livecd/live-boot/package/boot/uefi/loader/entries/cos-x86_64.conf
+++ b/packages/livecd/live-boot/package/boot/uefi/loader/entries/cos-x86_64.conf
@@ -1,4 +1,4 @@
 title cOS Linux Live
 version x86_64
 efi /minimal/x86_64/kernel.xz
-options initrd=/minimal/x86_64/rootfs.xz root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0
+options initrd=/minimal/x86_64/rootfs.xz root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable

--- a/packages/livecd/live-boot/package/loader/entries/cos-x86_64.conf
+++ b/packages/livecd/live-boot/package/loader/entries/cos-x86_64.conf
@@ -1,4 +1,4 @@
 title cOS Linux Live
 version x86_64
 efi /minimal/x86_64/kernel.xz
-options initrd=/minimal/x86_64/rootfs.xz root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0
+options initrd=/minimal/x86_64/rootfs.xz root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable

--- a/packages/recovery-img/definition.yaml
+++ b/packages/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: 0.5.5+2
+version: "0.5.6+1"
 brand_name: "cOS"

--- a/packages/recovery-img/squash/definition.yaml
+++ b/packages/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: "0.5.5"
+version: "0.5.6+1"

--- a/tests/deploys-images/deploy_test.go
+++ b/tests/deploys-images/deploy_test.go
@@ -1,0 +1,73 @@
+package cos_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/cOS/tests/sut"
+)
+
+var _ = Describe("cOS Deploy tests", func() {
+	var s *sut.SUT
+	var isVagrant bool
+
+	BeforeSuite(func() {
+		isVagrant = sut.IsVagrantTest()
+		if isVagrant {
+			sut.SnapshotVagrant()
+		}
+	})
+
+	AfterSuite(func() {
+		if isVagrant {
+			sut.SnapshotVagrantDelete()
+		}
+	})
+
+	BeforeEach(func() {
+		s = sut.NewSUT()
+		s.EventuallyConnects(360)
+	})
+
+	AfterEach(func() {
+		// Try to gather mtree logs on failure
+		if CurrentGinkgoTestDescription().Failed {
+			s.GatherLog("/tmp/image-mtree-check.log")
+			s.GatherLog("/tmp/luet_mtree_failures.log")
+			s.GatherLog("/tmp/luet_mtree.log")
+			s.GatherLog("/tmp/luet.log")
+		}
+		if CurrentGinkgoTestDescription().Failed == false {
+			if isVagrant {
+				sut.ResetWithVagrant()
+			} else {
+				s.Reset()
+			}
+
+		}
+	})
+	Context("After install", func() {
+		When("deploying again", func() {
+			It("deploys only if --force flag is provided", func() {
+				By("deploying without --force")
+				out, err := s.Command("cos-deploy --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.5")
+				Expect(out).Should(ContainSubstring("There is already an active deployment"))
+				Expect(err).To(HaveOccurred())
+				By("deploying with --force")
+				out, err = s.Command("cos-deploy --force --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.5")
+				Expect(out).Should(ContainSubstring("Forcing overwrite"))
+				Expect(out).Should(ContainSubstring("now you might want to reboot"))
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("force deploys from recovery", func() {
+				err := s.ChangeBoot(sut.Recovery)
+				Expect(err).ToNot(HaveOccurred())
+				s.Reboot()
+				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Recovery))
+				By("deploying with --force")
+				out, err := s.Command("cos-deploy --force --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.5")
+				Expect(out).Should(ContainSubstring("now you might want to reboot"))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})

--- a/tests/deploys-images/tests_suite_test.go
+++ b/tests/deploys-images/tests_suite_test.go
@@ -1,0 +1,13 @@
+package cos_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "cOS Deploy test Suite")
+}


### PR DESCRIPTION
This PR allows unattended deployments on top of vanilla images by
using simple cloud init configuration files that can be injected to the
system as part of the user data of public providers.
    
This PR includes an `images/user-data.yaml` file as an example.
    
Fixes #220