### PR TITLE
Re-enable recovery upgrade test

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,14 +1,14 @@
 packages:
   - name: "cos"
     category: "system"
-    version: "0.5.4"
+    version: "0.5.5"
     brand_name: "cOS"
     labels:
       autobump.revdeps: "true"
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos"
     category: "recovery"
-    version: "0.5.4"
+    version: "0.5.5"
     brand_name: "cOS recovery"
     labels:
       autobump.revdeps: "true"

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.7.5"
+version: "0.7.6"

--- a/packages/installer/upgrade.sh
+++ b/packages/installer/upgrade.sh
@@ -160,19 +160,24 @@ upgrade() {
     export LUET_PRIVILEGED_EXTRACT=true
 
     args=""
-    if [ -z "$VERIFY" ]; then
-        args="--enable-logfile --logfile /tmp/luet.log --plugin image-mtree-check"
+    if [ -z "$VERIFY" ] || [ "$VERIFY" == true ]; then
+        args="--enable-logfile --logfile /tmp/luet.log --plugin luet-mtree"
     fi
+
     if [ -n "$CHANNEL_UPGRADES" ] && [ "$CHANNEL_UPGRADES" == true ]; then
         echo "Upgrading from release channel"
+        set -x
         luet install $args --system-target $TARGET --system-engine memory -y $UPGRADE_IMAGE
         luet cleanup
+        set +x
     elif [ "$DIRECTORY" == true ]; then
         echo "Upgrading from local folder: $UPGRADE_IMAGE"
         rsync -axq --exclude='host' --exclude='mnt' --exclude='proc' --exclude='sys' --exclude='dev' --exclude='tmp' ${UPGRADE_IMAGE}/ $TARGET
     else
         echo "Upgrading from container image: $UPGRADE_IMAGE"
+        set -x
         luet util unpack $args $UPGRADE_IMAGE /usr/local/tmp/rootfs
+        set +x
         rsync -aqzAX --exclude='mnt' --exclude='proc' --exclude='sys' --exclude='dev' --exclude='tmp' /usr/local/tmp/rootfs/ $TARGET
         rm -rf /usr/local/tmp/rootfs
     fi

--- a/packages/recovery-img/definition.yaml
+++ b/packages/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: "0.5.4"
+version: "0.5.5"
 brand_name: "cOS"

--- a/packages/recovery-img/squash/definition.yaml
+++ b/packages/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: "0.5.4"
+version: "0.5.5"

--- a/tests/recovery/recovery_test.go
+++ b/tests/recovery/recovery_test.go
@@ -142,7 +142,7 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 
 		When("using upgrade channel", func() {
 			// TODO: This test cannot be enabled until we have in master a published version of cOS >=0.5.3
-			PIt("upgrades to latest image", func() {
+			It("upgrades to latest image", func() {
 				By("upgrading recovery and reboot")
 				out, err := s.Command("cos-upgrade --no-verify --recovery")
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/upgrades-images-signed/upgrade_test.go
+++ b/tests/upgrades-images-signed/upgrade_test.go
@@ -47,6 +47,12 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 	})
 	Context("After install", func() {
 		When("upgrading", func() {
+			It("fails if verify is enabled on an unsigned/malformed version", func() {
+				out, err := s.Command("cos-upgrade --docker-image raccos/releases-opensuse:cos-system-0.5.0")
+				Expect(out).Should(ContainSubstring("luet-mtree"))
+				Expect(out).Should(ContainSubstring("error while executing plugin"))
+				Expect(err).To(HaveOccurred())
+			})
 			It("upgrades to latest available (master) and reset", func() {
 				out, err := s.Command("cos-upgrade")
 				Expect(err).ToNot(HaveOccurred())
@@ -77,12 +83,6 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 				Expect(out).ToNot(Equal(""))
 				Expect(out).ToNot(Equal(version))
 				Expect(out).To(Equal("0.5.1\n"))
-			})
-			It("fails if verify is enabled on an unsigned/malformed version", func() {
-				out, err := s.Command("cos-upgrade --docker-image raccos/releases-opensuse:cos-system-0.5.0")
-				Expect(err).To(HaveOccurred())
-				Expect(out).Should(ContainSubstring("luet-mtree"))
-				Expect(out).Should(ContainSubstring("error while executing plugin"))
 			})
 		})
 	})


### PR DESCRIPTION
We had to disable this because we didn't had published changes
supporting the scenario. 
It also fixes a leftover from a rebase that I believe slipped from the merges due to the automatic PR merge features (seems it is flaky and catches success early if there are no results back from the CI yet.. :shrug: )

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>