### PR TITLE
ci: disable trigger on path

### DIFF
--- a/.github/config/master.yaml
+++ b/.github/config/master.yaml
@@ -14,13 +14,6 @@ skip_images_flavor: ["fedora","ubuntu"]
 on: 
   push: 
     branches: ["master"]
-    paths:
-      - 'conf/**'
-      - 'packages/**'
-      - '.github/**'
-      - 'tests/**'
-      - 'make/**'
-      - 'Makefile'
   create:
     tags:
       - v*

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -8,13 +8,6 @@ on:
  push:
    branches:
      - master
-   paths:
-     - conf/**
-     - packages/**
-     - .github/**
-     - tests/**
-     - make/**
-     - Makefile
 
 
 concurrency:


### PR DESCRIPTION
It is not supposed to filter, but it actually triggers an additional
build (on branches).

See also https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>