### PR TITLE
More make cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,12 @@ export MANIFEST?=$(ROOT_DIR)/manifest.yaml
 #
 PACKER_ARGS?=
 
+#
+# Used by .iso, .test, and .run
+#
+ISO?=$(shell ls $(ROOT_DIR)/*.iso 2> /dev/null)
+
+
 #----------------------- end global variables -----------------------
 
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -145,6 +145,26 @@ $> QEMU=qemu-system-x86_64 make run-qemu
 
 ```
 
+This will create a disk image at `.qemu/drive.img` and boot from the ISO.
+
+> If the image already exists, it will NOT be overwritten.
+> You need to run an explicit `make clean_run` to wipe the image and
+> start over.
+
+#### Installing
+
+With a fresh `drive.img`, `make run-qemu` will boot from ISO. You can then log in as `root` with password `cos` and install cOS on
+the disk image with:
+
+```bash
+# cos-installer /dev/sda
+```
+
+A subsequent reboot (resp. running `make run-qemu` with an installed
+`drive.img`) will boot the installed cOS operating system.
+
+
+
 ### Run tests
 
 Requires: Virtualbox or libvirt, vagrant, packer

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -147,9 +147,12 @@ $> QEMU=qemu-system-x86_64 make run-qemu
 
 This will create a disk image at `.qemu/drive.img` and boot from the ISO.
 
+>
 > If the image already exists, it will NOT be overwritten.
+>
 > You need to run an explicit `make clean_run` to wipe the image and
 > start over.
+>
 
 #### Installing
 

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -3,18 +3,34 @@
 #
 #
 
-ISO?=$(shell ls $(ROOT_DIR)/*.iso 2> /dev/null)
-
 MKSQUASHFS?=$(shell which mksquashfs 2> /dev/null)
 ifeq ("$(MKSQUASHFS)","")
 MKSQUASHFS="/usr/bin/mksquashfs"
 endif
 
 #
+# Find correct (hashicorp/packer) binary
+#
+
+# if PACKER is pre-set, leave it alone
+PACKER?=$(shell which packer 2> /dev/null)
+ifeq ("$(PACKER)","")
+PACKER="/usr/bin/packer"
+endif
+
+$(PACKER):
+ifneq ($(shell id -u), 0)
+	@echo "'$@' is missing and you must be root to install it."
+	@exit 1
+else
+	$(LUET) install -y utils/packer
+endif
+
+#
 # remove iso artifacts
 #
 
-clean_iso:
+clean_iso: packer-clean
 	rm -rf $(ROOT_DIR)/*.iso $(ROOT_DIR)/*.iso.sha256
 	rm -rf $(DESTINATION)/tree.tar.zst
 	rm -rf $(MANIFEST).remote
@@ -79,3 +95,34 @@ else
 	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].urls[0]' $(FINAL_REPO)
 	$(LUET) makeiso $(MANIFEST).remote
 endif
+
+
+BOXFILE=$(shell ls $(ROOT_DIR)/packer/*.box 2> /dev/null)
+ifeq ("$(BOXFILE)","")
+BOXFILE="$(ROOT_DIR)/packer/cOS.box"
+endif
+
+#
+#
+#
+
+.PHONY: packer
+#
+# target 'packer' creates a compressed tarball with an 'ova' file
+#
+packer: $(BOXFILE)
+
+packer-clean:
+	rm -rf $(BOXFILE)
+
+$(BOXFILE): $(PACKER)
+ifeq ("$(PACKER)","/usr/sbin/packer")
+	@echo "The 'packer' binary at $(PACKER) might be from cracklib"
+	@echo "Please set PACKER to the correct binary before calling make"
+	@exit 1
+endif
+ifeq ("$(ISO)","")
+	@echo "Please run 'make iso' or 'make local-iso' first"
+	@exit 1
+endif
+	cd $(ROOT_DIR)/packer && $(PACKER) build -var "iso=$(ISO)" $(PACKER_ARGS) images.json

--- a/make/Makefile.run
+++ b/make/Makefile.run
@@ -17,7 +17,11 @@ $(ROOT_DIR)/.qemu:
 	mkdir -p $(ROOT_DIR)/.qemu
 
 $(ROOT_DIR)/.qemu/drive.img: $(ROOT_DIR)/.qemu
+ifeq (,$(wildcard $(ROOT_DIR)/.qemu/drive.img))
 	qemu-img create -f qcow2 $(ROOT_DIR)/.qemu/drive.img 24g
+else
+	@echo "Using $@"
+endif
 
 run-qemu: $(ROOT_DIR)/.qemu/drive.img
 	$(QEMU) \

--- a/make/Makefile.run
+++ b/make/Makefile.run
@@ -23,6 +23,7 @@ else
 	@echo "Using $@"
 endif
 
+.PHONY: run-qemu
 run-qemu: $(ROOT_DIR)/.qemu/drive.img
 	$(QEMU) \
 	-m $(QEMU_MEMORY) \

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -16,26 +16,6 @@ VAGRANT="/usr/bin/vagrant"
 endif
 
 #
-# Find correct (hashicorp/packer) binary
-#
-
-# if PACKER is pre-set, leave it alone
-ifeq ("$(PACKER)","")
-PACKER=$(shell which packer 2> /dev/null)
-ifeq ("$(PACKER)","")
-PACKER="/usr/bin/packer"
-endif
-endif
-
-$(PACKER):
-ifneq ($(shell id -u), 0)
-	@echo "'$@' is missing and you must be root to install it."
-	@exit 1
-else
-	$(LUET) install -y utils/packer
-endif
-
-#
 # VirtualBox
 #
 
@@ -56,32 +36,6 @@ else
 	@exit 1
 endif
 
-BOXFILE=$(shell ls $(ROOT_DIR)/packer/*.box 2> /dev/null)
-ifeq ("$(BOXFILE)","")
-BOXFILE="$(ROOT_DIR)/packer/cOS.box"
-endif
-
-.PHONY: packer
-#
-# target 'packer' creates a compressed tarball with an 'ova' file
-#
-packer: $(BOXFILE)
-
-packer-clean:
-	rm -rf $(BOXFILE)
-
-$(BOXFILE): $(PACKER)
-ifeq ("$(PACKER)","/usr/sbin/packer")
-	@echo "The 'packer' binary at $(PACKER) might be from cracklib"
-	@echo "Please set PACKER to the correct binary before calling make"
-	@exit 1
-endif
-ifeq ("$(ISO)","")
-	@echo "Please run 'make iso' or 'make local-iso' first"
-	@exit 1
-endif
-	cd $(ROOT_DIR)/packer && $(PACKER) build -var "iso=$(ISO)" $(PACKER_ARGS) images.json
-
 #
 # ------------ actual test targets ------------
 #
@@ -92,7 +46,7 @@ test: test-clean vagrantfile prepare-test test-smoke test-upgrades-signed test-u
 # remove test artifacts
 #
 
-clean_test: test-clean packer-clean
+clean_test: test-clean
 
 
 prepare-test: $(VAGRANT) $(BOXFILE)


### PR DESCRIPTION
- move shared make variables to toplevel Makefile
- 'packer' target does not belong to Makefile.test
- improve 'run-qemu' target
- adapt documentation