### PR TITLE
Make ln command idempotent

### DIFF
--- a/packages/cos-setup/cos-setup-rootfs.service
+++ b/packages/cos-setup/cos-setup-rootfs.service
@@ -7,7 +7,7 @@ Conflicts=initrd-switch-root.target
 
 [Service]
 Type=oneshot
-ExecStartPre=/usr/bin/ln -s /sysroot/system /system
+ExecStartPre=/usr/bin/ln -sf -t / /sysroot/system
 ExecStart=/usr/bin/cos-setup rootfs
 
 [Install]


### PR DESCRIPTION
I'm not sure why but cos-setup-rootfs seems to be executing
twice on boot in my setup. That may be an issue in and of
itself, but regardless this unit can not be executed twice
because the second time the ln command will fail. On the
second execution it will try to create /system/system but
that will fail since system is pointing to /sysroot/system
which is read only.