### PR TITLE
Add SLE distribution

### DIFF
--- a/.github/config/master.yaml
+++ b/.github/config/master.yaml
@@ -7,7 +7,7 @@ pipeline: "master"
 publishing_pipeline: true
 repository: "releases"
 skip_tests: false
-flavors: ["opensuse", "fedora", "ubuntu"]
+flavors: ["sle", "opensuse", "fedora", "ubuntu"]
 skip_tests_flavor: ["fedora","ubuntu"]
 skip_images_flavor: ["fedora","ubuntu"]
 

--- a/.github/config/nightly.yaml
+++ b/.github/config/nightly.yaml
@@ -7,7 +7,7 @@ pipeline: "nightly"
 publishing_pipeline: false
 repository: "releases"
 skip_tests: false
-flavors: ["opensuse", "fedora", "ubuntu"]
+flavors: ["sle", "opensuse", "fedora", "ubuntu"]
 skip_tests_flavor: ["fedora","ubuntu"]
 skip_images_flavor: ["fedora","ubuntu"]
 

--- a/.github/config/pr.yaml
+++ b/.github/config/pr.yaml
@@ -9,7 +9,7 @@ skip_tests: false
 skip_tests_flavor: ["fedora","ubuntu"]
 skip_images_flavor: ["fedora","ubuntu"]
 
-flavors: ["opensuse", "fedora", "ubuntu"]
+flavors: ["sle", "opensuse", "fedora", "ubuntu"]
 on: 
   pull_request:
     paths:

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -25,6 +25,583 @@ jobs:
 
 
   
+  docker-build-sle:
+  
+    runs-on: ubuntu-latest
+  
+    env:
+      FLAVOR: sle
+
+    steps:
+  
+      - uses: actions/checkout@v2
+
+      - run: |
+          git fetch --prune --unshallow
+  
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+  
+      - name: Build  🔧
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          source .envrc
+          cos-build $FLAVOR
+
+
+  build-sle:
+  
+    runs-on: ubuntu-latest
+  
+    env:
+      FLAVOR: sle
+      FINAL_REPO: quay.io/costoolkit/releases-sle
+      DOWNLOAD_METADATA: false
+      PUSH_CACHE: true
+    steps:
+  
+
+  
+      - name: Install Go
+        uses: actions/setup-go@v2
+  
+
+      - uses: actions/checkout@v2
+
+      - run: |
+          git fetch --prune --unshallow
+
+  
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+  
+
+  
+      - name: Login to Quay Registry
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+  
+
+      - name: Install deps
+        run: |
+          sudo -E make deps
+
+      - name: Validate 🌳
+        run: |
+          make validate
+
+      - name: Build packages 🔧
+        run: |
+          export PATH=$PATH:/usr/local/go/bin
+          mkdir build || true
+          pushd ./.github
+          go build -o build
+          popd
+          ./.github/build
+          ls -liah $PWD/build
+          sudo chmod -R 777 $PWD/build
+  
+      - name: Generate manifests
+        run: |
+          for f in build/*tar*; do
+            [ -e "$f" ] || continue
+            sudo -E luet mtree -- generate $f -o "$f.mtree"
+          done
+      - name: Append manifests to metadata
+        run: |
+          for f in build/*mtree; do
+            [ -e "$f" ] || continue
+            BASE_NAME=`basename -s .package.tar.zst.mtree $f`
+            sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
+          done
+  
+      - name: Create repo
+        run: |
+          sudo -E make create-repo
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-sle
+          path: build
+          if-no-files-found: error
+
+
+
+  
+  
+  
+
+  iso-squashfs-sle:
+  
+    runs-on: ubuntu-latest
+  
+    needs: build-sle
+    env:
+      FINAL_REPO: quay.io/costoolkit/releases-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-sle
+          path: build
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xorriso squashfs-tools
+          sudo -E make deps
+  
+      - name: Build ISO from local build 🔧
+        if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
+        run: |
+          MANIFEST=manifest.yaml
+          cp -rf $MANIFEST $MANIFEST.remote
+          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
+          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
+          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
+          sudo -E MANIFEST=$MANIFEST.remote make local-iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - name: Build ISO from remote repositories 🔧
+        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          sudo -E make iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle.iso.zip
+          path: |
+            *.iso
+            *.sha256
+          if-no-files-found: error
+  qemu-squashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-squashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-squashfs-sle.iso.zip
+      - name: Install deps
+        run: |
+          brew install qemu
+      - name: Build QEMU Image 🔧
+        run: |
+          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle.qcow
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle-QEMU.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  vbox-squashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-squashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-squashfs-sle.iso.zip
+
+      # - name: Install deps
+      #   run: |
+      #     brew tap hashicorp/tap
+      #     brew install hashicorp/tap/packer
+      - name: Build VBox Image 🔧
+        run: |
+          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle.ova
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle-vbox.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  
+  
+  tests-squashfs-sle:
+    env:
+      VAGRANT_CPU: 3
+      VAGRANT_MEMORY: 10240
+    runs-on: macos-10.15
+    needs: vbox-squashfs-sle
+    strategy:
+      matrix:
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: Download vagrant box
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-squashfs-sle-vbox.box
+          path: packer
+
+      - name: Run tests 🔧
+        run: |
+          export GOPATH="/Users/runner/go"
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
+          make test-clean
+          make vagrantfile
+          make prepare-test
+          make ${{ matrix.test }}
+      - uses: actions/upload-artifact@v2
+        if: failure() && contains(matrix.test, 'upgrade')
+        with:
+          name: cOS-squashfs-${{ matrix.test }}.logs.zip
+          path: tests/**/logs/*
+          if-no-files-found: warn
+
+  
+ 
+  
+  
+
+  iso-nonsquashfs-sle:
+  
+    runs-on: ubuntu-latest
+  
+    needs: build-sle
+    env:
+      FINAL_REPO: quay.io/costoolkit/releases-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-sle
+          path: build
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xorriso squashfs-tools
+          sudo -E make deps
+  
+      - name: Tweak manifest and drop squashfs recovery
+        run: |
+          yq d -i manifest.yaml 'packages.isoimage(.==recovery/cos-img)'
+  
+      - name: Build ISO from local build 🔧
+        if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
+        run: |
+          MANIFEST=manifest.yaml
+          cp -rf $MANIFEST $MANIFEST.remote
+          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
+          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
+          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
+          sudo -E MANIFEST=$MANIFEST.remote make local-iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - name: Build ISO from remote repositories 🔧
+        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          sudo -E make iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.iso.zip
+          path: |
+            *.iso
+            *.sha256
+          if-no-files-found: error
+  qemu-nonsquashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-nonsquashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.iso.zip
+      - name: Install deps
+        run: |
+          brew install qemu
+      - name: Build QEMU Image 🔧
+        run: |
+          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.qcow
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle-QEMU.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  vbox-nonsquashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-nonsquashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.iso.zip
+
+      # - name: Install deps
+      #   run: |
+      #     brew tap hashicorp/tap
+      #     brew install hashicorp/tap/packer
+      - name: Build VBox Image 🔧
+        run: |
+          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.ova
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle-vbox.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  
+  
+  tests-nonsquashfs-sle:
+    env:
+      VAGRANT_CPU: 3
+      VAGRANT_MEMORY: 10240
+    runs-on: macos-10.15
+    needs: vbox-nonsquashfs-sle
+    strategy:
+      matrix:
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: Download vagrant box
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle-vbox.box
+          path: packer
+
+      - name: Run tests 🔧
+        run: |
+          export GOPATH="/Users/runner/go"
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
+          make test-clean
+          make vagrantfile
+          make prepare-test
+          make ${{ matrix.test }}
+      - uses: actions/upload-artifact@v2
+        if: failure() && contains(matrix.test, 'upgrade')
+        with:
+          name: cOS-nonsquashfs-${{ matrix.test }}.logs.zip
+          path: tests/**/logs/*
+          if-no-files-found: warn
+
+  
+ 
+
+  
+  publish-sle:
+    runs-on: ubuntu-latest
+    
+    needs: tests-squashfs-sle
+    
+    env:
+      FLAVOR: sle
+      FINAL_REPO: quay.io/costoolkit/releases-sle
+      DOWNLOAD_METADATA: true
+      DOWNLOAD_ONLY: true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-sle
+          path: build
+      - run: |
+          git fetch --prune --unshallow
+
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+
+      # We patch docker to use all the HD available in GH action free runners
+      - name: Patch Docker Daemon data-root
+        run: |
+          DOCKER_DATA_ROOT='/mnt/var/lib/docker'
+          DOCKER_DAEMON_JSON='/etc/docker/daemon.json'
+          sudo mkdir -p "${DOCKER_DATA_ROOT}"
+          jq --arg dataroot "${DOCKER_DATA_ROOT}" '. + {"data-root": $dataroot}' "${DOCKER_DAEMON_JSON}" > "/tmp/docker.json.tmp"
+          sudo mv "/tmp/docker.json.tmp" "${DOCKER_DAEMON_JSON}"
+          sudo systemctl restart docker
+
+    
+      - name: Login to Quay Registry
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+    
+
+      - name: Install deps
+        run: |
+          sudo -E make deps
+    
+      - name: Install Go
+        uses: actions/setup-go@v2
+    
+      - name: Grab metadata from remotes
+        run: |
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o build
+          popd
+          sudo -E ./.github/build
+          ls -liah $PWD/build
+      - name: Publish to DockerHub 🚀
+        run: |
+          sudo -E make publish-repo
+
+  github-release-sle:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    
+    needs: tests-squashfs-sle
+    
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-sle.iso.zip
+          path: release
+      - name: Download vagrant box
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-sle-vbox.box
+          path: release
+      - name: Download OVA image
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-sle.ova
+          path: release
+      - name: Download QCOW image
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-sle.qcow
+          path: release
+      - name: Release
+        uses: fnkr/github-action-ghr@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GHR_PATH: release/
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+
+  
+
+  raw-img-sle:
+    runs-on: ubuntu-latest
+    container: opensuse/leap:15.3
+    needs: build-sle
+
+    steps:
+      - name: Install OS deps
+        run: |
+          zypper in -y curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-sle
+          path: build
+      - name: Install toolchain
+        run: |
+          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the continer
+          rm -rf /var/lock
+          mkdir -p /var/lock
+          make deps
+      - name: Build Image
+        run: |
+          make raw_disk
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
+          mv disk.raw cOS_${COS_VERSION}.raw
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-raw-img-sle
+          path: |
+            *.raw
+          if-no-files-found: error
+
+  azure-img-sle:
+    runs-on: ubuntu-latest
+    container: opensuse/leap:15.3
+    needs: raw-img-sle
+
+    steps:
+      - name: Install OS deps
+        run: |
+          zypper in -y qemu-tools make tar gzip xz which curl
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-raw-img-sle
+          path: .
+      - name: Install toolchain
+        run: |
+          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
+          rm -rf /var/lock
+          mkdir -p /var/lock
+          make deps
+      - name: Build Image
+        run: |
+          make azure_disk
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
+          mv disk.vhd cOS_${COS_VERSION}.vhd
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-azure-img-sle
+          path: |
+            *.vhd
+          if-no-files-found: error
+  
+
+  
   docker-build-opensuse:
   
     runs-on: ubuntu-latest

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -14,6 +14,474 @@ jobs:
 
 
   
+  docker-build-sle:
+  
+    runs-on: ubuntu-latest
+  
+    env:
+      FLAVOR: sle
+
+    steps:
+  
+      - uses: actions/checkout@v2
+
+      - run: |
+          git fetch --prune --unshallow
+  
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+  
+      - name: Build  🔧
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          source .envrc
+          cos-build $FLAVOR
+
+
+  build-sle:
+  
+    runs-on: ubuntu-latest
+  
+    env:
+      FLAVOR: sle
+      FINAL_REPO: quay.io/costoolkit/releases-sle
+      DOWNLOAD_METADATA: false
+      PUSH_CACHE: false
+    steps:
+  
+
+  
+      - name: Install Go
+        uses: actions/setup-go@v2
+  
+
+      - uses: actions/checkout@v2
+
+      - run: |
+          git fetch --prune --unshallow
+
+  
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+  
+
+  
+
+      - name: Install deps
+        run: |
+          sudo -E make deps
+
+      - name: Validate 🌳
+        run: |
+          make validate
+
+      - name: Build packages 🔧
+        run: |
+          export PATH=$PATH:/usr/local/go/bin
+          mkdir build || true
+          pushd ./.github
+          go build -o build
+          popd
+          ./.github/build
+          ls -liah $PWD/build
+          sudo chmod -R 777 $PWD/build
+  
+      - name: Create repo
+        run: |
+          sudo -E make create-repo
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-sle
+          path: build
+          if-no-files-found: error
+
+
+
+  
+  
+  
+
+  iso-squashfs-sle:
+  
+    runs-on: ubuntu-latest
+  
+    needs: build-sle
+    env:
+      FINAL_REPO: quay.io/costoolkit/releases-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-sle
+          path: build
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xorriso squashfs-tools
+          sudo -E make deps
+  
+      - name: Build ISO from local build 🔧
+        if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
+        run: |
+          MANIFEST=manifest.yaml
+          cp -rf $MANIFEST $MANIFEST.remote
+          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
+          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
+          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
+          sudo -E MANIFEST=$MANIFEST.remote make local-iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - name: Build ISO from remote repositories 🔧
+        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          sudo -E make iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle.iso.zip
+          path: |
+            *.iso
+            *.sha256
+          if-no-files-found: error
+  qemu-squashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-squashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-squashfs-sle.iso.zip
+      - name: Install deps
+        run: |
+          brew install qemu
+      - name: Build QEMU Image 🔧
+        run: |
+          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle.qcow
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle-QEMU.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  vbox-squashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-squashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-squashfs-sle.iso.zip
+
+      # - name: Install deps
+      #   run: |
+      #     brew tap hashicorp/tap
+      #     brew install hashicorp/tap/packer
+      - name: Build VBox Image 🔧
+        run: |
+          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle.ova
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle-vbox.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  
+  
+  tests-squashfs-sle:
+    env:
+      VAGRANT_CPU: 3
+      VAGRANT_MEMORY: 10240
+    runs-on: macos-10.15
+    needs: vbox-squashfs-sle
+    strategy:
+      matrix:
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: Download vagrant box
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-squashfs-sle-vbox.box
+          path: packer
+
+      - name: Run tests 🔧
+        run: |
+          export GOPATH="/Users/runner/go"
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
+          make test-clean
+          make vagrantfile
+          make prepare-test
+          make ${{ matrix.test }}
+      - uses: actions/upload-artifact@v2
+        if: failure() && contains(matrix.test, 'upgrade')
+        with:
+          name: cOS-squashfs-${{ matrix.test }}.logs.zip
+          path: tests/**/logs/*
+          if-no-files-found: warn
+
+  
+ 
+  
+  
+
+  iso-nonsquashfs-sle:
+  
+    runs-on: ubuntu-latest
+  
+    needs: build-sle
+    env:
+      FINAL_REPO: quay.io/costoolkit/releases-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-sle
+          path: build
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xorriso squashfs-tools
+          sudo -E make deps
+  
+      - name: Tweak manifest and drop squashfs recovery
+        run: |
+          yq d -i manifest.yaml 'packages.isoimage(.==recovery/cos-img)'
+  
+      - name: Build ISO from local build 🔧
+        if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
+        run: |
+          MANIFEST=manifest.yaml
+          cp -rf $MANIFEST $MANIFEST.remote
+          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
+          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
+          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
+          sudo -E MANIFEST=$MANIFEST.remote make local-iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - name: Build ISO from remote repositories 🔧
+        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          sudo -E make iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.iso.zip
+          path: |
+            *.iso
+            *.sha256
+          if-no-files-found: error
+  qemu-nonsquashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-nonsquashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.iso.zip
+      - name: Install deps
+        run: |
+          brew install qemu
+      - name: Build QEMU Image 🔧
+        run: |
+          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.qcow
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle-QEMU.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  vbox-nonsquashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-nonsquashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.iso.zip
+
+      # - name: Install deps
+      #   run: |
+      #     brew tap hashicorp/tap
+      #     brew install hashicorp/tap/packer
+      - name: Build VBox Image 🔧
+        run: |
+          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.ova
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle-vbox.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  
+  
+  tests-nonsquashfs-sle:
+    env:
+      VAGRANT_CPU: 3
+      VAGRANT_MEMORY: 10240
+    runs-on: macos-10.15
+    needs: vbox-nonsquashfs-sle
+    strategy:
+      matrix:
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: Download vagrant box
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle-vbox.box
+          path: packer
+
+      - name: Run tests 🔧
+        run: |
+          export GOPATH="/Users/runner/go"
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
+          make test-clean
+          make vagrantfile
+          make prepare-test
+          make ${{ matrix.test }}
+      - uses: actions/upload-artifact@v2
+        if: failure() && contains(matrix.test, 'upgrade')
+        with:
+          name: cOS-nonsquashfs-${{ matrix.test }}.logs.zip
+          path: tests/**/logs/*
+          if-no-files-found: warn
+
+  
+ 
+
+  
+
+  
+
+  raw-img-sle:
+    runs-on: ubuntu-latest
+    container: opensuse/leap:15.3
+    needs: build-sle
+
+    steps:
+      - name: Install OS deps
+        run: |
+          zypper in -y curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-sle
+          path: build
+      - name: Install toolchain
+        run: |
+          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the continer
+          rm -rf /var/lock
+          mkdir -p /var/lock
+          make deps
+      - name: Build Image
+        run: |
+          make raw_disk
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
+          mv disk.raw cOS_${COS_VERSION}.raw
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-raw-img-sle
+          path: |
+            *.raw
+          if-no-files-found: error
+
+  azure-img-sle:
+    runs-on: ubuntu-latest
+    container: opensuse/leap:15.3
+    needs: raw-img-sle
+
+    steps:
+      - name: Install OS deps
+        run: |
+          zypper in -y qemu-tools make tar gzip xz which curl
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-raw-img-sle
+          path: .
+      - name: Install toolchain
+        run: |
+          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
+          rm -rf /var/lock
+          mkdir -p /var/lock
+          make deps
+      - name: Build Image
+        run: |
+          make azure_disk
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
+          mv disk.vhd cOS_${COS_VERSION}.vhd
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-azure-img-sle
+          path: |
+            *.vhd
+          if-no-files-found: error
+  
+
+  
   docker-build-opensuse:
   
     runs-on: ubuntu-latest

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -20,6 +20,474 @@ jobs:
 
 
   
+  docker-build-sle:
+  
+    runs-on: ubuntu-latest
+  
+    env:
+      FLAVOR: sle
+
+    steps:
+  
+      - uses: actions/checkout@v2
+
+      - run: |
+          git fetch --prune --unshallow
+  
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+  
+      - name: Build  🔧
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          source .envrc
+          cos-build $FLAVOR
+
+
+  build-sle:
+  
+    runs-on: ubuntu-latest
+  
+    env:
+      FLAVOR: sle
+      FINAL_REPO: quay.io/costoolkit/releases-sle
+      DOWNLOAD_METADATA: false
+      PUSH_CACHE: false
+    steps:
+  
+
+  
+      - name: Install Go
+        uses: actions/setup-go@v2
+  
+
+      - uses: actions/checkout@v2
+
+      - run: |
+          git fetch --prune --unshallow
+
+  
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+  
+
+  
+
+      - name: Install deps
+        run: |
+          sudo -E make deps
+
+      - name: Validate 🌳
+        run: |
+          make validate
+
+      - name: Build packages 🔧
+        run: |
+          export PATH=$PATH:/usr/local/go/bin
+          mkdir build || true
+          pushd ./.github
+          go build -o build
+          popd
+          ./.github/build
+          ls -liah $PWD/build
+          sudo chmod -R 777 $PWD/build
+  
+      - name: Create repo
+        run: |
+          sudo -E make create-repo
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-sle
+          path: build
+          if-no-files-found: error
+
+
+
+  
+  
+  
+
+  iso-squashfs-sle:
+  
+    runs-on: ubuntu-latest
+  
+    needs: build-sle
+    env:
+      FINAL_REPO: quay.io/costoolkit/releases-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-sle
+          path: build
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xorriso squashfs-tools
+          sudo -E make deps
+  
+      - name: Build ISO from local build 🔧
+        if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
+        run: |
+          MANIFEST=manifest.yaml
+          cp -rf $MANIFEST $MANIFEST.remote
+          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
+          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
+          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
+          sudo -E MANIFEST=$MANIFEST.remote make local-iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - name: Build ISO from remote repositories 🔧
+        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          sudo -E make iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle.iso.zip
+          path: |
+            *.iso
+            *.sha256
+          if-no-files-found: error
+  qemu-squashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-squashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-squashfs-sle.iso.zip
+      - name: Install deps
+        run: |
+          brew install qemu
+      - name: Build QEMU Image 🔧
+        run: |
+          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle.qcow
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle-QEMU.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  vbox-squashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-squashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-squashfs-sle.iso.zip
+
+      # - name: Install deps
+      #   run: |
+      #     brew tap hashicorp/tap
+      #     brew install hashicorp/tap/packer
+      - name: Build VBox Image 🔧
+        run: |
+          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle.ova
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-squashfs-sle-vbox.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  
+  
+  tests-squashfs-sle:
+    env:
+      VAGRANT_CPU: 3
+      VAGRANT_MEMORY: 10240
+    runs-on: macos-10.15
+    needs: vbox-squashfs-sle
+    strategy:
+      matrix:
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: Download vagrant box
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-squashfs-sle-vbox.box
+          path: packer
+
+      - name: Run tests 🔧
+        run: |
+          export GOPATH="/Users/runner/go"
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
+          make test-clean
+          make vagrantfile
+          make prepare-test
+          make ${{ matrix.test }}
+      - uses: actions/upload-artifact@v2
+        if: failure() && contains(matrix.test, 'upgrade')
+        with:
+          name: cOS-squashfs-${{ matrix.test }}.logs.zip
+          path: tests/**/logs/*
+          if-no-files-found: warn
+
+  
+ 
+  
+  
+
+  iso-nonsquashfs-sle:
+  
+    runs-on: ubuntu-latest
+  
+    needs: build-sle
+    env:
+      FINAL_REPO: quay.io/costoolkit/releases-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-sle
+          path: build
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xorriso squashfs-tools
+          sudo -E make deps
+  
+      - name: Tweak manifest and drop squashfs recovery
+        run: |
+          yq d -i manifest.yaml 'packages.isoimage(.==recovery/cos-img)'
+  
+      - name: Build ISO from local build 🔧
+        if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
+        run: |
+          MANIFEST=manifest.yaml
+          cp -rf $MANIFEST $MANIFEST.remote
+          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
+          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
+          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
+          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
+          sudo -E MANIFEST=$MANIFEST.remote make local-iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - name: Build ISO from remote repositories 🔧
+        if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
+        run: |
+          sudo -E make iso
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
+          mv *.iso cOS-$COS_VERSION.iso
+          mv *.sha256 cOS-$COS_VERSION.iso.sha256
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.iso.zip
+          path: |
+            *.iso
+            *.sha256
+          if-no-files-found: error
+  qemu-nonsquashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-nonsquashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.iso.zip
+      - name: Install deps
+        run: |
+          brew install qemu
+      - name: Build QEMU Image 🔧
+        run: |
+          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.qcow
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle-QEMU.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  vbox-nonsquashfs-sle:
+    runs-on: macos-10.15
+    needs: iso-nonsquashfs-sle
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download ISO
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.iso.zip
+
+      # - name: Install deps
+      #   run: |
+      #     brew tap hashicorp/tap
+      #     brew install hashicorp/tap/packer
+      - name: Build VBox Image 🔧
+        run: |
+          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso" make packer
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle.ova
+          path: |
+            packer/*.tar.gz
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle-vbox.box
+          path: |
+            packer/*.box
+          if-no-files-found: error
+  
+  
+  tests-nonsquashfs-sle:
+    env:
+      VAGRANT_CPU: 3
+      VAGRANT_MEMORY: 10240
+    runs-on: macos-10.15
+    needs: vbox-nonsquashfs-sle
+    strategy:
+      matrix:
+        test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - name: Download vagrant box
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-nonsquashfs-sle-vbox.box
+          path: packer
+
+      - name: Run tests 🔧
+        run: |
+          export GOPATH="/Users/runner/go"
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
+          make test-clean
+          make vagrantfile
+          make prepare-test
+          make ${{ matrix.test }}
+      - uses: actions/upload-artifact@v2
+        if: failure() && contains(matrix.test, 'upgrade')
+        with:
+          name: cOS-nonsquashfs-${{ matrix.test }}.logs.zip
+          path: tests/**/logs/*
+          if-no-files-found: warn
+
+  
+ 
+
+  
+
+  
+
+  raw-img-sle:
+    runs-on: ubuntu-latest
+    container: opensuse/leap:15.3
+    needs: build-sle
+
+    steps:
+      - name: Install OS deps
+        run: |
+          zypper in -y curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-sle
+          path: build
+      - name: Install toolchain
+        run: |
+          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the continer
+          rm -rf /var/lock
+          mkdir -p /var/lock
+          make deps
+      - name: Build Image
+        run: |
+          make raw_disk
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
+          mv disk.raw cOS_${COS_VERSION}.raw
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-raw-img-sle
+          path: |
+            *.raw
+          if-no-files-found: error
+
+  azure-img-sle:
+    runs-on: ubuntu-latest
+    container: opensuse/leap:15.3
+    needs: raw-img-sle
+
+    steps:
+      - name: Install OS deps
+        run: |
+          zypper in -y qemu-tools make tar gzip xz which curl
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-raw-img-sle
+          path: .
+      - name: Install toolchain
+        run: |
+          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
+          rm -rf /var/lock
+          mkdir -p /var/lock
+          make deps
+      - name: Build Image
+        run: |
+          make azure_disk
+          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
+          mv disk.vhd cOS_${COS_VERSION}.vhd
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-azure-img-sle
+          path: |
+            *.vhd
+          if-no-files-found: error
+  
+
+  
   docker-build-opensuse:
   
     runs-on: ubuntu-latest

--- a/packages/base/build.yaml
+++ b/packages/base/build.yaml
@@ -11,6 +11,14 @@ steps:
 {{if eq .Values.distribution "opensuse" }}
 - zypper in -y --no-recommends {{.Values.packages}} {{.Values.kernel_package}}
 - zypper cc
+{{else if eq .Values.distribution "sle" }}
+- zypper rm -y container-suseconnect
+- zypper ar --priority=200 http://download.opensuse.org/distribution/leap/15.3/repo/oss repo-oss
+# We don't want to import the opensuse gpg key for the repo. We don't need to trust the repo
+# itself because all rpms will later be validated
+- zypper --no-gpg-checks ref
+- zypper in -y --no-recommends {{.Values.packages}} {{.Values.kernel_package}}
+- zypper cc
 {{else if eq .Values.distribution "fedora" }}
 - echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
 - dnf install -y {{.Values.packages}} {{.Values.kernel_package}}

--- a/packages/cloud-config/build.yaml
+++ b/packages/cloud-config/build.yaml
@@ -9,6 +9,8 @@ steps:
 {{ if .Values.distribution }}
 {{if eq .Values.distribution "opensuse" }}
 - sed -i 's/:FLAVOR:/opensuse/g' /system/oem/02_upgrades.yaml
+{{else if eq .Values.distribution "sle" }}
+- sed -i 's/:FLAVOR:/sle/g' /system/oem/02_upgrades.yaml
 {{else if eq .Values.distribution "fedora" }}
 - sed -i 's/:FLAVOR:/fedora/g' /system/oem/02_upgrades.yaml
 {{else if eq .Values.distribution "ubuntu" }}

--- a/packages/golang/build.yaml
+++ b/packages/golang/build.yaml
@@ -5,7 +5,7 @@ requires:
 
 prelude:
 {{ if .Values.distribution }}
-{{if eq .Values.distribution "opensuse" }}
+{{if eq .Values.distribution_like "opensuse" }}
 - zypper in -y wget && zypper install -y -t pattern devel_basis
 {{else if eq .Values.distribution "fedora" }}
 - dnf install -y wget "@Development Tools"

--- a/packages/immutable-rootfs/build.yaml
+++ b/packages/immutable-rootfs/build.yaml
@@ -19,7 +19,7 @@ copy:
 
 steps:
 {{ if .Values.distribution }}
-{{if eq .Values.distribution "opensuse" }}
+{{if eq .Values.distribution_like "opensuse" }}
 # Mount /tmp as tmpfs by default as set by systemd itself
 - cp /usr/share/systemd/tmp.mount /etc/systemd/system
 {{end}}

--- a/packages/selinux/build.yaml
+++ b/packages/selinux/build.yaml
@@ -7,7 +7,7 @@ env:
 - GITHUB_REPO={{ ( index .Values.labels "github.repo" ) }}
 
 {{ if .Values.distribution }}
-{{if eq .Values.distribution "opensuse" }}
+{{if eq .Values.distribution_like "opensuse" }}
 prelude:
 - zypper ar https://download.opensuse.org/repositories/security:/SELinux/openSUSE_Leap_15.3/security:SELinux.repo
 - zypper --gpg-auto-import-keys in -y --allow-vendor-change --allow-downgrade container-selinux -libsemanage1

--- a/packages/toolchain/luet-mtree/build.yaml
+++ b/packages/toolchain/luet-mtree/build.yaml
@@ -10,7 +10,7 @@ env:
   - LDFLAGS="-s -w"
 prelude:
   {{ if .Values.distribution }}
-  {{if eq .Values.distribution "opensuse" }}
+  {{if eq .Values.distribution_like "opensuse" }}
 - zypper in -y git
   {{else if eq .Values.distribution "fedora" }}
 - dnf install -y git

--- a/packages/toolchain/luet/build.yaml
+++ b/packages/toolchain/luet/build.yaml
@@ -8,7 +8,7 @@ env:
 - GO111MODULE=off
 prelude:
 {{ if .Values.distribution }}
-{{if eq .Values.distribution "opensuse" }}
+{{if eq .Values.distribution_like "opensuse" }}
 - zypper in -y git upx
 {{else if eq .Values.distribution "fedora" }}
 - dnf install -y git upx

--- a/packages/toolchain/yip/build.yaml
+++ b/packages/toolchain/yip/build.yaml
@@ -10,7 +10,7 @@ env:
 - LDFLAGS="-s -w"
 prelude:
 {{ if .Values.distribution }}
-{{if eq .Values.distribution "opensuse" }}
+{{if eq .Values.distribution_like "opensuse" }}
 - zypper in -y git upx
 {{else if eq .Values.distribution "fedora" }}
 - dnf install -y git upx

--- a/packages/toolchain/yq/build.yaml
+++ b/packages/toolchain/yq/build.yaml
@@ -10,7 +10,7 @@ env:
   - LDFLAGS="-s -w"
 prelude:
   {{ if .Values.distribution }}
-  {{if eq .Values.distribution "opensuse" }}
+  {{if eq .Values.distribution_like "opensuse" }}
 - zypper in -y git
   {{else if eq .Values.distribution "fedora" }}
 - dnf install -y git

--- a/packages/utils/k9s/build.yaml
+++ b/packages/utils/k9s/build.yaml
@@ -6,7 +6,7 @@ env:
 - PATH=$PATH:/usr/local/go/bin
 prelude:
 {{ if .Values.distribution }}
-{{if eq .Values.distribution "opensuse" }}
+{{if eq .Values.distribution_like "opensuse" }}
 - zypper in -y git
 {{else if eq .Values.distribution "fedora" }}
 - dnf install -y git

--- a/packages/utils/nerdctl/build.yaml
+++ b/packages/utils/nerdctl/build.yaml
@@ -6,7 +6,7 @@ env:
 - PATH=$PATH:/usr/local/go/bin
 prelude:
 {{ if .Values.distribution }}
-{{if eq .Values.distribution "opensuse" }}
+{{if eq .Values.distribution_like "opensuse" }}
 - zypper in -y git
 {{else if eq .Values.distribution "fedora" }}
 - dnf install -y git

--- a/values/fedora.yaml
+++ b/values/fedora.yaml
@@ -1,5 +1,6 @@
 image: "fedora:33"
 distribution: "fedora"
+distribution_like: "fedora"
 
 packages: >-
     grub2-pc

--- a/values/sle.yaml
+++ b/values/sle.yaml
@@ -1,5 +1,5 @@
-image: opensuse/leap:15.3
-distribution: "opensuse"
+image: registry.suse.com/suse/sle15:15.3
+distribution: "sle"
 distribution_like: "opensuse"
 
 packages: >-

--- a/values/ubuntu.yaml
+++ b/values/ubuntu.yaml
@@ -1,5 +1,6 @@
 image: ubuntu:20.10
 distribution: "ubuntu"
+distribution_like: "ubuntu"
 
 packages: >-
     systemd


### PR DESCRIPTION
This distribution is functionally equivalent to opensuse with the key
difference being that the only gpg keys trusted are from SUSE build
service.  This ensures no community built binaries are in the final
build.

Since this distribution is basically the same as opensuse I added
the field "distribution_like" to the values to mimic the behavior of
ID_LIKE in os-release.