### PR TITLE
Always enable cdrom datasource

### DIFF
--- a/packages/cloud-config/oem/07_cloud-metadata.yaml
+++ b/packages/cloud-config/oem/07_cloud-metadata.yaml
@@ -10,5 +10,5 @@ stages:
    network:
      - name: "Cloud providers datasources"
        datasource:
-         providers: ["aws", "gcp"]
+         providers: ["aws", "gcp", "cdrom"]
          path: "/system/oem"


### PR DESCRIPTION
I'm in the middle of refactoring quite a bit of things so haven't fully tested this change.  One thing that confused me is that the path is set to /system/oem.  Isn't that path read-only?  I'm confused on how this works.