### PR TITLE
Improve cloud-config

### DIFF
--- a/packages/cloud-config/definition.yaml
+++ b/packages/cloud-config/definition.yaml
@@ -1,3 +1,3 @@
 name: cloud-config
 category: system
-version: "0.6.1"
+version: "0.6.2"

--- a/packages/cloud-config/oem/00_rootfs.yaml
+++ b/packages/cloud-config/oem/00_rootfs.yaml
@@ -8,19 +8,26 @@
 name: "Rootfs Layout Settings"
 stages:
   rootfs.before:
-    - name: "Layout configuration"
+    - name: "Pull data from provider"
+      datasource:
+        providers: ["aws", "gcp", "openstack", "cdrom"]
+        path: "/oem"
+  rootfs:
+    - if: '[ ! -f "/run/cos/recovery_mode" ]'
+      name: "Layout configuration"
       environment_file: /run/cos/cos-layout.env
       environment:
         VOLUMES: "LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local"
         OVERLAY: "tmpfs:25%"
-#       DEBUG_RW: "true"
-    - name: "Pull data from provider"
-      datasource:
-        providers: ["aws", "cdrom"]
-        path: "/oem"
-
+    - if: '[ -f "/run/cos/recovery_mode" ]'
+      # omit the persistent partition on recovery mode
+      name: "Layout configuration"
+      environment_file: /run/cos/cos-layout.env
+      environment:
+        VOLUMES: "LABEL=COS_OEM:/oem"
+        OVERLAY: "tmpfs:25%"
   initramfs:
-    - if: '[ -z "$(blkid -L COS_SYSTEM || true)" ]'
+    - if: '[ ! -f "/run/cos/recovery_mode" ]'
       name: "Persist /etc/machine-id"
       commands:
       - |

--- a/packages/cloud-config/oem/06_recovery.yaml
+++ b/packages/cloud-config/oem/06_recovery.yaml
@@ -7,10 +7,19 @@
 # copy the file with a prefix starting by 90, e.g. /oem/91_custom.yaml
 name: "Recovery partition boot setup"
 stages:
+   rootfs.before:
+     - if: |
+            [ -n "$(blkid -L COS_SYSTEM || true)" ] || cat /proc/cmdline | grep -q "COS_RECOVERY"
+       name: "Identify recovery mode"
+       files:
+       - path: /run/cos/recovery_mode
+         content: "1"
+         permissions: 0600
+         owner: 0
+         group: 0
    boot:
      - name: "Recovery"
-       if: |
-            [ -n "$(blkid -L COS_SYSTEM || true)" ] || cat /proc/cmdline | grep -q "COS_RECOVERY"
+       if: '[ -f "/run/cos/recovery_mode" ]'
        hostname: "cos-recovery"
        commands:
        - |
@@ -19,9 +28,3 @@ stages:
             echo "You are booting from recovery mode. Run 'cos-reset' to reset the system to $VERSION" >> /etc/issue
             echo " or CURRENT=active.img cos-upgrade to upgrade the active partition" >> /etc/issue
             echo >> /etc/issue
-       files:
-       - path: /run/cos/recovery_mode
-         content: "1"
-         permissions: 0600
-         owner: 0
-         group: 0

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,14 +1,14 @@
 packages:
   - name: "cos"
     category: "system"
-    version: "0.5.7+1"
+    version: "0.5.7+2"
     brand_name: "cOS"
     labels:
       autobump.revdeps: "true"
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos"
     category: "recovery"
-    version: "0.5.7+1"
+    version: "0.5.7+2"
     brand_name: "cOS recovery"
     labels:
       autobump.revdeps: "true"

--- a/packages/recovery-img/definition.yaml
+++ b/packages/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: "0.5.7+1"
+version: "0.5.7+2"
 brand_name: "cOS"

--- a/packages/recovery-img/squash/definition.yaml
+++ b/packages/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: "0.5.7+1"
+version: "0.5.7+2"


### PR DESCRIPTION
This commit moves the recovery_mode detection to the very very first
stage where 'yip' comes into play. This is specially helpful to make
use of it in later stages. In addition the default layout is changed for
recovery and system partitions, in recovery mode the COS_PERSISTENT
partition is ignored at boot time. This is is specially helpful for
vanilla images, with the change they can boo the recovery system as
they are, without requiring any partitioning at first boot.

Signed-off-by: David Cassany <dcassany@suse.com>