### PR TITLE
Update tests

### DIFF
--- a/tests/deploys-images/deploy_test.go
+++ b/tests/deploys-images/deploy_test.go
@@ -49,11 +49,11 @@ var _ = Describe("cOS Deploy tests", func() {
 		When("deploying again", func() {
 			It("deploys only if --force flag is provided", func() {
 				By("deploying without --force")
-				out, err := s.Command("cos-deploy --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.5")
+				out, err := s.Command("cos-deploy --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.7")
 				Expect(out).Should(ContainSubstring("There is already an active deployment"))
 				Expect(err).To(HaveOccurred())
 				By("deploying with --force")
-				out, err = s.Command("cos-deploy --force --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.5")
+				out, err = s.Command("cos-deploy --force --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.7")
 				Expect(out).Should(ContainSubstring("Forcing overwrite"))
 				Expect(out).Should(ContainSubstring("now you might want to reboot"))
 				Expect(err).NotTo(HaveOccurred())
@@ -64,7 +64,7 @@ var _ = Describe("cOS Deploy tests", func() {
 				s.Reboot()
 				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Recovery))
 				By("deploying with --force")
-				out, err := s.Command("cos-deploy --force --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.5")
+				out, err := s.Command("cos-deploy --force --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.7")
 				Expect(out).Should(ContainSubstring("now you might want to reboot"))
 				Expect(err).NotTo(HaveOccurred())
 			})

--- a/tests/recovery/recovery_test.go
+++ b/tests/recovery/recovery_test.go
@@ -52,7 +52,7 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Recovery))
 
 			recoveryName := s.GetOSRelease("NAME")
-			
+
 			// In these tests, if we are booting into squashfs we are booting into recovery. And the recovery image
 			// is shipping a different os-release name (cOS recovery) instead of the standard one (cOS)
 			if s.SquashFSRecovery() {
@@ -88,9 +88,8 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 			s.Reboot()
 			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Recovery))
 
-			out, err := s.Command("CURRENT=active.img cos-upgrade --no-verify --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.1")
+			out, err := s.Command("CURRENT=active.img cos-upgrade --no-verify --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.7")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
 			Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
 
 			err = s.ChangeBoot(sut.Active)
@@ -101,7 +100,7 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 
 			upgradedVersion := s.GetOSRelease("VERSION")
 			Expect(upgradedVersion).ToNot(Equal(currentVersion))
-			Expect(upgradedVersion).To(Equal("0.5.1\n"))
+			Expect(upgradedVersion).To(Equal("0.5.7\n"))
 		})
 	})
 

--- a/tests/upgrades-images-signed/upgrade_test.go
+++ b/tests/upgrades-images-signed/upgrade_test.go
@@ -47,12 +47,6 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 	})
 	Context("After install", func() {
 		When("upgrading", func() {
-			It("fails if verify is enabled on an unsigned/malformed version", func() {
-				out, err := s.Command("cos-upgrade --docker-image raccos/releases-opensuse:cos-system-0.5.0")
-				Expect(out).Should(ContainSubstring("luet-mtree"))
-				Expect(out).Should(ContainSubstring("error while executing plugin"))
-				Expect(err).To(HaveOccurred())
-			})
 			It("upgrades to latest available (master) and reset", func() {
 				out, err := s.Command("cos-upgrade")
 				Expect(err).ToNot(HaveOccurred())
@@ -69,7 +63,7 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 
 				version := out
 				By("upgrading to an old image")
-				out, err = s.Command("cos-upgrade --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.1")
+				out, err = s.Command("cos-upgrade --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.7")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
 				Expect(out).Should(ContainSubstring("to /usr/local/tmp/rootfs"))
@@ -82,7 +76,7 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
 				Expect(out).ToNot(Equal(version))
-				Expect(out).To(Equal("0.5.1\n"))
+				Expect(out).To(Equal("0.5.7\n"))
 			})
 		})
 	})

--- a/tests/upgrades-images-unsigned/upgrade_test.go
+++ b/tests/upgrades-images-unsigned/upgrade_test.go
@@ -42,13 +42,13 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 	})
 	Context("After install", func() {
 		When("images are not signed", func() {
-			It("upgrades to latest available (master) with --no-verify", func() {
+			It("upgrades to v0.5.7 with --no-verify", func() {
 				out, err := s.Command("source /etc/os-release && echo $VERSION")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
 
 				version := out
-				out, err = s.Command("cos-upgrade --no-verify --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.1")
+				out, err = s.Command("cos-upgrade --no-verify --docker-image quay.io/costoolkit/releases-opensuse:cos-system-0.5.7")
 				if err != nil {
 					fmt.Fprintf(GinkgoWriter, "Error from cos-upgrade: %v\n", err)
 				}
@@ -63,7 +63,7 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
 				Expect(out).ToNot(Equal(version))
-				Expect(out).To(Equal("0.5.1\n"))
+				Expect(out).To(Equal("0.5.7\n"))
 
 				By("rollbacking state")
 				s.Reset()
@@ -71,7 +71,7 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 				out, err = s.Command("source /etc/os-release && echo $VERSION")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
-				Expect(out).ToNot(Equal("0.5.1\n"))
+				Expect(out).ToNot(Equal("0.5.7\n"))
 				Expect(out).To(Equal(version))
 			})
 		})

--- a/tests/upgrades-local/upgrade_test.go
+++ b/tests/upgrades-local/upgrade_test.go
@@ -24,15 +24,15 @@ var _ = Describe("cOS Upgrade tests - local upgrades", func() {
 
 				version := out
 
-				out, err = s.Command("mkdir /run/update && luet util unpack quay.io/costoolkit/releases-opensuse:cos-system-0.5.1 /run/update")
-				if err != nil{
+				out, err = s.Command("mkdir /run/update && luet util unpack quay.io/costoolkit/releases-opensuse:cos-system-0.5.7 /run/update")
+				if err != nil {
 					fmt.Fprintf(GinkgoWriter, "Error from luet util unpack: %v\n", err)
 				}
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
 
 				out, err = s.Command("cos-upgrade --no-verify --directory /run/update")
-				if err != nil{
+				if err != nil {
 					fmt.Fprintf(GinkgoWriter, "Error from cos-upgrade: %v\n", err)
 				}
 				Expect(err).ToNot(HaveOccurred())
@@ -46,7 +46,7 @@ var _ = Describe("cOS Upgrade tests - local upgrades", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
 				Expect(out).ToNot(Equal(version))
-				Expect(out).To(Equal("0.5.1\n"))
+				Expect(out).To(Equal("0.5.7\n"))
 
 				By("rollbacking state")
 				s.Reset()
@@ -54,7 +54,7 @@ var _ = Describe("cOS Upgrade tests - local upgrades", func() {
 				out, err = s.Command("source /etc/os-release && echo $VERSION")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
-				Expect(out).ToNot(Equal("0.5.1\n"))
+				Expect(out).ToNot(Equal("0.5.7\n"))
 				Expect(out).To(Equal(version))
 			})
 		})


### PR DESCRIPTION
This commit is two fold:

* Removes the test upgrading against docker-hub because we are hitting
  the rate limit and the test usefullness is, at least, arguable.

* It upgrades the images used in upgrade and similar tests to a more
  recent image. This is because in 5.6 there were some boot related
  changes and in #277 issue is hard to tell if failures are in pre 0.5.6
  systems or not. With this change all tests (except the image for
  test-recovery) will upgrade to 0.5.7.

Signed-off-by: David Cassany <dcassany@suse.com>