### PR TITLE
Exclude /proc and /sys

### DIFF
--- a/packages/cos/build.yaml
+++ b/packages/cos/build.yaml
@@ -109,6 +109,9 @@ excludes:
 - ^/usr/local/src
 - ^/usr/local/games
 
+# excluding the followings makes the package installable in a container from scratch
 - ^/etc/hostname
 - ^/etc/machine-id
 - ^/etc/hosts
+- ^/sys
+- ^/proc

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "cos"
     category: "system"
-    version: "0.5.7+2"
+    version: "0.5.7+3"
     brand_name: "cOS"
     labels:
       autobump.revdeps: "true"

--- a/packages/recovery-img/squash/definition.yaml
+++ b/packages/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: "0.5.7+2"
+version: "0.5.7+3"


### PR DESCRIPTION
This fixes the following error while trying to install system/cos from a
container from scratch:
```
 DEBUG (docker.go:#66:github.com/mudler/luet/pkg/installer/client.(*DockerClient).DownloadArtifact) Cache file /var/cache/luet/packages/cos-system-0.5.7+2.package.tar.zst
 DEBUG (docker.go:#81:github.com/mudler/luet/pkg/installer/client.(*DockerClient).DownloadArtifact) Cache hit for artifact cos-system-0.5.7+2.package.tar.zst
 Failed installing package cos Error met while unpacking rootfs: lchown /sys: read-only file system
The command '/usr/bin/luet install -y -d system/cos' returned a non-zero code: 1
```

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>