### PR TITLE
[ci] Fix local vs quay versioning

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -420,7 +420,7 @@ jobs:
       - name: Build AMI for {{{ $flavor }}}
         run: |
             COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-            export PKR_VAR_cos_version="${COS_VERSION}"
+            export PKR_VAR_cos_version="${COS_VERSION/+/-}"
             export PKR_VAR_aws_cos_install_args="cos-deploy --docker-image quay.io/costoolkit/{{{$config.repository}}}-{{{ $flavor }}}:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor={{{ $flavor }}}
             make packer-aws

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -539,7 +539,7 @@ jobs:
       - name: Build AMI for opensuse
         run: |
             COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-            export PKR_VAR_cos_version="${COS_VERSION}"
+            export PKR_VAR_cos_version="${COS_VERSION/+/-}"
             export PKR_VAR_aws_cos_install_args="cos-deploy --docker-image quay.io/costoolkit/releases-opensuse:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor=opensuse
             make packer-aws
@@ -843,7 +843,7 @@ jobs:
       - name: Build AMI for fedora
         run: |
             COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-            export PKR_VAR_cos_version="${COS_VERSION}"
+            export PKR_VAR_cos_version="${COS_VERSION/+/-}"
             export PKR_VAR_aws_cos_install_args="cos-deploy --docker-image quay.io/costoolkit/releases-fedora:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor=fedora
             make packer-aws
@@ -1080,7 +1080,7 @@ jobs:
       - name: Build AMI for ubuntu
         run: |
             COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-            export PKR_VAR_cos_version="${COS_VERSION}"
+            export PKR_VAR_cos_version="${COS_VERSION/+/-}"
             export PKR_VAR_aws_cos_install_args="cos-deploy --docker-image quay.io/costoolkit/releases-ubuntu:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor=ubuntu
             make packer-aws


### PR DESCRIPTION
Locally we use the major.minor.patch+build but when uploading to quay we
substitute the plus for a minus sign. We do the same when creating the
AMI images so we need to substitute the version we automatically gather
from local packages and replace the invalid chars

Signed-off-by: Itxaka <igarcia@suse.com>