### PR TITLE
[ci] Use no-verify on crateing ami images

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -422,7 +422,7 @@ jobs:
             COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
             export COS_VERSION="${COS_VERSION/+/-}"
             export PKR_VAR_cos_version="${COS_VERSION}"
-            export PKR_VAR_aws_cos_install_args="cos-deploy --docker-image quay.io/costoolkit/{{{$config.repository}}}-{{{ $flavor }}}:cos-system-${COS_VERSION}"
+            export PKR_VAR_aws_cos_install_args="cos-deploy {{{ if (ne $flavor "opensuse") }}}--no-verify {{{ end }}}--docker-image quay.io/costoolkit/{{{$config.repository}}}-{{{ $flavor }}}:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor={{{ $flavor }}}
             make packer-aws
 

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -846,7 +846,7 @@ jobs:
             COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
             export COS_VERSION="${COS_VERSION/+/-}"
             export PKR_VAR_cos_version="${COS_VERSION}"
-            export PKR_VAR_aws_cos_install_args="cos-deploy --docker-image quay.io/costoolkit/releases-fedora:cos-system-${COS_VERSION}"
+            export PKR_VAR_aws_cos_install_args="cos-deploy --no-verify --docker-image quay.io/costoolkit/releases-fedora:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor=fedora
             make packer-aws
 
@@ -1084,7 +1084,7 @@ jobs:
             COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
             export COS_VERSION="${COS_VERSION/+/-}"
             export PKR_VAR_cos_version="${COS_VERSION}"
-            export PKR_VAR_aws_cos_install_args="cos-deploy --docker-image quay.io/costoolkit/releases-ubuntu:cos-system-${COS_VERSION}"
+            export PKR_VAR_aws_cos_install_args="cos-deploy --no-verify --docker-image quay.io/costoolkit/releases-ubuntu:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor=ubuntu
             make packer-aws
 


### PR DESCRIPTION
Currently there is some xattrs issues with the docker images on
ubuntu/fedora which prevent the installation to finish unless we use
--no-verify

Signed-off-by: Itxaka <igarcia@suse.com>