### PR TITLE
Add /etc/hosts file back

### DIFF
--- a/docs/creating_bootable_images.md
+++ b/docs/creating_bootable_images.md
@@ -95,7 +95,7 @@ ENV USER=root
 
 SHELL ["/usr/bin/luet", "install", "-y", "-d"]
 
-RUN system/cos
+RUN system/cos-container
 
 SHELL ["/bin/sh", "-c"]
 RUN rm -rf /var/cache/luet/packages/ /var/cache/luet/repos/

--- a/examples/scratch/Dockerfile
+++ b/examples/scratch/Dockerfile
@@ -16,7 +16,7 @@ ENV USER=root
 ENV LUET_NOLOCK=true
 SHELL ["/usr/bin/luet", "install", "-y", "-d"]
 
-RUN system/cos
+RUN system/cos-container
 
 SHELL ["/bin/sh", "-c"]
 RUN rm -rf /var/cache/luet/packages/ /var/cache/luet/repos/

--- a/packages/cos/build.yaml
+++ b/packages/cos/build.yaml
@@ -111,4 +111,21 @@ excludes:
 
 - ^/etc/hostname
 - ^/etc/machine-id
+
+{{ if eq .Values.name "cos-container" }}
+
 - ^/etc/hosts
+- ^/proc
+- ^/sys
+- ^/dev
+- ^/tmp
+- ^/run
+
+{{ else }}
+
+- ^/tmp/.*
+- ^/proc/.*
+- ^/sys/.*
+- ^/run/.*
+
+{{ end }}

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,7 +1,8 @@
 packages:
   - name: "cos"
     category: "system"
-    version: "0.5.7+2"
+    version: "0.5.7+5"
+    description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
       autobump.revdeps: "true"
@@ -10,6 +11,15 @@ packages:
     category: "recovery"
     version: 0.5.7+5
     brand_name: "cOS recovery"
+    description: "cOS recovery image, used to boot cOS for troubleshooting"
+    labels:
+      autobump.revdeps: "true"
+      autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
+  - name: "cos-container"
+    category: "system"
+    version: "0.5.7+5"
+    brand_name: "cOS"
+    description: "cOS container image, used to build cOS derivatives from scratch"
     labels:
       autobump.revdeps: "true"
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"

--- a/packages/recovery-img/definition.yaml
+++ b/packages/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: 0.5.7+5
+version: 0.5.7+7
 brand_name: "cOS"

--- a/packages/recovery-img/squash/definition.yaml
+++ b/packages/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: "0.5.7+2"
+version: "0.5.7+5"


### PR DESCRIPTION
While it fixes things for from scratch installs, it breaks many things:

- we should generate an /etc/hosts file during boot, ideally in
  cloud-init phase, but that looks cumbersome as we can just relay on
what's the default
- going to that route, and then excluding /proc, /sys, /run and /tmp
  requires further work on the bootstrap part, currently tests are not
passing (see #366)

It sounds easier instead to have a separate package for it just for
creating derivatives "from scratch" - in that way we don't interfere
with the standard system/cos which is supposed to run on ISO and other
medium too, where such folders are mandatory.

This addition adds a system/cos-container to just provide a separate package
with /proc, /run, /sys, /dev, /tmp stripped which is meant to be used for
from scratch scenarios.

Supersedes: #366

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>