### PR TITLE
ci: Drop create tag event

### DIFF
--- a/.github/config/master.yaml
+++ b/.github/config/master.yaml
@@ -14,6 +14,3 @@ skip_images_flavor: ["fedora","ubuntu"]
 on: 
   push: 
     branches: ["master"]
-  create:
-    tags:
-      - v*

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -2,9 +2,6 @@
 name: Build cOS master
 
 on: 
- create:
-   tags:
-     - v*
  push:
    branches:
      - master


### PR DESCRIPTION
It causes to fire events from the master pipeline also when we create
branches, as the create doesn't support filtering by tag. (and gets silently ignored from GH, as it's just additional YAML data! :facepalm:  )

See also: https://github.com/actions/runner/issues/1007 on how to filter
by tag.

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>