### PR TITLE
Use a different cache per OS flavor

### DIFF
--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -27,7 +27,7 @@ PUSH_CACHE?=false
 
 BUILD_ARGS?=--pull --no-spinner --only-target-package --live-output
 
-REPO_CACHE?=quay.io/costoolkit/build-cache
+REPO_CACHE?=quay.io/costoolkit/build-$(FLAVOR)-cache
 
 export REPO_CACHE
 ifneq ($(strip $(REPO_CACHE)),)


### PR DESCRIPTION
This PR is to ensure caches between flavor are not mixed. In https://github.com/rancher-sandbox/cOS-toolkit/suites/3187960702/artifacts/73622493 the built ISO is using a Fedora based image for recovery while it should be an openSUSE based one. This PR is to enforce caches are separate for each flavor.

Signed-off-by: David Cassany <dcassany@suse.com>