### PR TITLE
amazon: Enhance AMI name and tags

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -501,6 +501,7 @@ jobs:
             export PKR_VAR_cos_version="${COS_VERSION}"
             export PKR_VAR_aws_cos_install_args="cos-deploy {{{ if (ne $flavor "opensuse") }}}--no-verify {{{ end }}}--docker-image quay.io/costoolkit/{{{$config.repository}}}-{{{ $flavor }}}:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor={{{ $flavor }}}
+            export PKR_VAR_git_sha="${GITHUB_SHA}"
             make packer-aws
     {{{ end }}}
   {{{ end }}}
@@ -528,6 +529,6 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Upload and publish vanilla image
         run: |
-          export github_sha="${GITHUB_SHA}"
+          export git_sha="${GITHUB_SHA}"
           make aws_vanilla_ami
 {{{ end }}}

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -623,6 +623,7 @@ jobs:
             export PKR_VAR_cos_version="${COS_VERSION}"
             export PKR_VAR_aws_cos_install_args="cos-deploy --docker-image quay.io/costoolkit/releases-opensuse:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor=opensuse
+            export PKR_VAR_git_sha="${GITHUB_SHA}"
             make packer-aws
     
   
@@ -1082,6 +1083,6 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Upload and publish vanilla image
         run: |
-          export github_sha="${GITHUB_SHA}"
+          export git_sha="${GITHUB_SHA}"
           make aws_vanilla_ami
 

--- a/images/aws_upload.sh
+++ b/images/aws_upload.sh
@@ -40,7 +40,7 @@ snap_id=$(aws ec2 describe-import-snapshot-tasks \
 
 echo "Tagging Snapshot"
 aws ec2 create-tags --resources "${snap_id}" \
-    --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=Git_SHA,Value=$git_sha Key=Flavor,Value=vanilla
+    --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=Git_SHA,Value=$git_sha Key=Flavor,Value=cos-vanilla
 
 echo "Register AMI from snapshot"
 ami_id=$(aws ec2 register-image \
@@ -56,6 +56,6 @@ ami_id=$(aws ec2 register-image \
 
 echo "Tagging AMI"
 aws ec2 create-tags --resources "${ami_id}" --tags \
-   --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=Git_SHA,Value=$git_sha Key=Flavor,Value=vanilla
+   --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=Git_SHA,Value=$git_sha Key=Flavor,Value=cos-vanilla
 
 echo "AMI Created: ${ami_id}"

--- a/images/aws_upload.sh
+++ b/images/aws_upload.sh
@@ -6,7 +6,7 @@ disk="$1"
 s3_bucket="cos-images"
 disk_name="cOS-Vanilla"
 disk_desc="cOS Vanilla Image"
-: "${github_sha:=none}"
+: "${git_sha:=none}"
 
 [ -f "${disk}" ] || exit 1
 
@@ -40,7 +40,7 @@ snap_id=$(aws ec2 describe-import-snapshot-tasks \
 
 echo "Tagging Snapshot"
 aws ec2 create-tags --resources "${snap_id}" \
-    --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=GITHUB_SHA,Value=$github_sha
+    --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=Git_SHA,Value=$git_sha Key=Flavor,Value=recovery
 
 echo "Register AMI from snapshot"
 ami_id=$(aws ec2 register-image \
@@ -56,6 +56,6 @@ ami_id=$(aws ec2 register-image \
 
 echo "Tagging AMI"
 aws ec2 create-tags --resources "${ami_id}" --tags \
-   --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=GITHUB_SHA,Value=$github_sha
+   --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=Git_SHA,Value=$git_sha Key=Flavor,Value=recovery
 
 echo "AMI Created: ${ami_id}"

--- a/images/aws_upload.sh
+++ b/images/aws_upload.sh
@@ -40,7 +40,7 @@ snap_id=$(aws ec2 describe-import-snapshot-tasks \
 
 echo "Tagging Snapshot"
 aws ec2 create-tags --resources "${snap_id}" \
-    --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=Git_SHA,Value=$git_sha Key=Flavor,Value=recovery
+    --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=Git_SHA,Value=$git_sha Key=Flavor,Value=vanilla
 
 echo "Register AMI from snapshot"
 ami_id=$(aws ec2 register-image \
@@ -56,6 +56,6 @@ ami_id=$(aws ec2 register-image \
 
 echo "Tagging AMI"
 aws ec2 create-tags --resources "${ami_id}" --tags \
-   --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=Git_SHA,Value=$git_sha Key=Flavor,Value=recovery
+   --tags Key=Name,Value=${disk_name} Key=Project,Value=cOS Key=Git_SHA,Value=$git_sha Key=Flavor,Value=vanilla
 
 echo "AMI Created: ${ami_id}"

--- a/packer/images.json.pkr.hcl
+++ b/packer/images.json.pkr.hcl
@@ -1,7 +1,7 @@
 source "amazon-ebs" "cos" {
   access_key      = var.aws_access_key
-  ami_name        = "${var.name}-${replace(var.cos_version, "+", "-")}-${formatdate("DDMMYYYY", timestamp())}-${var.flavor}"
-  ami_description = "${var.name}-${replace(var.cos_version, "+", "-")}-${formatdate("DDMMYYYY", timestamp())}-${var.flavor}"
+  ami_name        = "${var.name}-${replace(var.cos_version, "+", "-")}-${formatdate("DDMMYYYY", timestamp())}-${substr(var.git_sha, 0, 7)}-${var.flavor}"
+  ami_description = "${var.name}-${replace(var.cos_version, "+", "-")}-${formatdate("DDMMYYYY", timestamp())}-${substr(var.git_sha, 0, 7)}-${var.flavor}"
   ami_groups      = var.aws_ami_groups
   instance_type   = var.aws_instance_type
   region          = var.aws_region
@@ -25,6 +25,8 @@ source "amazon-ebs" "cos" {
   tags = {
     Name          = var.name
     Version       = var.cos_version
+    Flavor        = var.flavor
+    Git_SHA       = var.git_sha  # use full sha here
     Base_AMI_ID   = "{{ .SourceAMI }}"  # This info comes from the build process directly
     Base_AMI_Name = "{{ .SourceAMIName }}"  # This info comes from the build process directly
   }

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -147,3 +147,9 @@ variable "name" {
   default = "cOS"
   description = "Name of the product being built. Only used for naming artifacts."
 }
+
+variable "git_sha" {
+  type = string
+  default ="none"
+  description = "Git sha of the current build, defaults to none."
+}


### PR DESCRIPTION
This patch adds the github.sha to the build name of the AMI so we can
easily identify where the image came from if pushed from CI and to be
able to upload more than one image per day on CI as well.

Also adds it to the tags, and add a new Flavor tag, so we can use data
lifecycle policies to auto remove images and search for an X flavor by
using those tags.

The default value for no git_sha is none.

Signed-off-by: Itxaka <igarcia@suse.com>