### PR TITLE
gce: Add script to create ready-to-upload disk to gce

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -480,6 +480,37 @@ jobs:
             *.vhd
           if-no-files-found: error
 
+  gce-img-{{{ $flavor }}}:
+    runs-on: ubuntu-latest
+    container: opensuse/leap:15.3
+    needs: raw-img-{{{ $flavor }}}
+
+    steps:
+      - name: Install OS deps
+        run: |
+          zypper in -y qemu-tools make tar gzip xz which curl
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-raw-img-{{{ $flavor }}}
+          path: .
+      - name: Install toolchain
+        run: |
+          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
+          rm -rf /var/lock
+          mkdir -p /var/lock
+          make deps
+      - name: Build Image
+        run: |
+          make gce_disk
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-gce-img-{{{ $flavor }}}
+          path: |
+            cOS-Vanilla-*.tar.gz
+          if-no-files-found: error
+
     {{{ if $config.publishing_pipeline }}}
 
   ami-publish-{{{ $flavor }}}:

--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -414,7 +414,7 @@ jobs:
 
   {{{ if not (has $config.skip_images_flavor $flavor) }}}
 
-  raw-img-{{{ $flavor }}}:
+  raw-images-{{{ $flavor }}}:
     runs-on: ubuntu-latest
     container: opensuse/leap:15.3
     needs: build-{{{ $flavor }}}
@@ -422,7 +422,7 @@ jobs:
     steps:
       - name: Install OS deps
         run: |
-          zypper in -y curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
+          zypper in -y bc qemu-tools curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
       - uses: actions/checkout@v2
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -435,80 +435,40 @@ jobs:
           rm -rf /var/lock
           mkdir -p /var/lock
           make deps
-      - name: Build Image
+      - name: Export cos version
+        run: |
+          echo "COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')" >> $GITHUB_ENV
+      - name: Build raw image
         run: |
           make raw_disk
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv disk.raw cOS-Vanilla-${COS_VERSION}.raw
-      - uses: actions/upload-artifact@v2
-        with:
-          name: cOS-raw-img-{{{ $flavor }}}
-          path: |
-            *.raw
-          if-no-files-found: error
-
-  azure-img-{{{ $flavor }}}:
-    runs-on: ubuntu-latest
-    container: opensuse/leap:15.3
-    needs: raw-img-{{{ $flavor }}}
-
-    steps:
-      - name: Install OS deps
-        run: |
-          zypper in -y qemu-tools make tar gzip xz which curl
-      - uses: actions/checkout@v2
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-raw-img-{{{ $flavor }}}
-          path: .
-      - name: Install toolchain
-        run: |
-          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
-          rm -rf /var/lock
-          mkdir -p /var/lock
-          make deps
-      - name: Build Image
+      - name: Build Azure image
         run: |
           make azure_disk
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv disk.vhd cOS_${COS_VERSION}.vhd
-      - uses: actions/upload-artifact@v2
-        with:
-          name: cOS-azure-img-{{{ $flavor }}}
-          path: |
-            *.vhd
-          if-no-files-found: error
-
-  gce-img-{{{ $flavor }}}:
-    runs-on: ubuntu-latest
-    container: opensuse/leap:15.3
-    needs: raw-img-{{{ $flavor }}}
-
-    steps:
-      - name: Install OS deps
-        run: |
-          zypper in -y qemu-tools make tar gzip xz which curl
-      - uses: actions/checkout@v2
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-raw-img-{{{ $flavor }}}
-          path: .
-      - name: Install toolchain
-        run: |
-          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
-          rm -rf /var/lock
-          mkdir -p /var/lock
-          make deps
-      - name: Build Image
+      - name: Build GCE image
         run: |
           make gce_disk
+      - name: Rename images
+        run: |
+          mv disk.raw cOS-Vanilla-RAW-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.raw
+          mv disk.vhd cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.vhd
+          mv disk.raw.tar.gz cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.tar.gz
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-gce-img-{{{ $flavor }}}
+          name: cOS-Vanilla-RAW-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}
           path: |
-            cOS-Vanilla-*.tar.gz
+            cOS-Vanilla-RAW-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.raw
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}
+          path: |
+            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.vhd
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-Vanilla-GCE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}
+          path: |
+            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.tar.gz
           if-no-files-found: error
 
     {{{ if $config.publishing_pipeline }}}

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -536,7 +536,7 @@ jobs:
 
   
 
-  raw-img-opensuse:
+  raw-images-opensuse:
     runs-on: ubuntu-latest
     container: opensuse/leap:15.3
     needs: build-opensuse
@@ -544,7 +544,7 @@ jobs:
     steps:
       - name: Install OS deps
         run: |
-          zypper in -y curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
+          zypper in -y bc qemu-tools curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
       - uses: actions/checkout@v2
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -557,80 +557,40 @@ jobs:
           rm -rf /var/lock
           mkdir -p /var/lock
           make deps
-      - name: Build Image
+      - name: Export cos version
+        run: |
+          echo "COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')" >> $GITHUB_ENV
+      - name: Build raw image
         run: |
           make raw_disk
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv disk.raw cOS-Vanilla-${COS_VERSION}.raw
-      - uses: actions/upload-artifact@v2
-        with:
-          name: cOS-raw-img-opensuse
-          path: |
-            *.raw
-          if-no-files-found: error
-
-  azure-img-opensuse:
-    runs-on: ubuntu-latest
-    container: opensuse/leap:15.3
-    needs: raw-img-opensuse
-
-    steps:
-      - name: Install OS deps
-        run: |
-          zypper in -y qemu-tools make tar gzip xz which curl
-      - uses: actions/checkout@v2
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-raw-img-opensuse
-          path: .
-      - name: Install toolchain
-        run: |
-          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
-          rm -rf /var/lock
-          mkdir -p /var/lock
-          make deps
-      - name: Build Image
+      - name: Build Azure image
         run: |
           make azure_disk
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv disk.vhd cOS_${COS_VERSION}.vhd
-      - uses: actions/upload-artifact@v2
-        with:
-          name: cOS-azure-img-opensuse
-          path: |
-            *.vhd
-          if-no-files-found: error
-
-  gce-img-opensuse:
-    runs-on: ubuntu-latest
-    container: opensuse/leap:15.3
-    needs: raw-img-opensuse
-
-    steps:
-      - name: Install OS deps
-        run: |
-          zypper in -y qemu-tools make tar gzip xz which curl
-      - uses: actions/checkout@v2
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-raw-img-opensuse
-          path: .
-      - name: Install toolchain
-        run: |
-          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
-          rm -rf /var/lock
-          mkdir -p /var/lock
-          make deps
-      - name: Build Image
+      - name: Build GCE image
         run: |
           make gce_disk
+      - name: Rename images
+        run: |
+          mv disk.raw cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
+          mv disk.vhd cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
+          mv disk.raw.tar.gz cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-gce-img-opensuse
+          name: cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
           path: |
-            cOS-Vanilla-*.tar.gz
+            cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          path: |
+            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-Vanilla-GCE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          path: |
+            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
           if-no-files-found: error
 
     

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -602,6 +602,37 @@ jobs:
             *.vhd
           if-no-files-found: error
 
+  gce-img-opensuse:
+    runs-on: ubuntu-latest
+    container: opensuse/leap:15.3
+    needs: raw-img-opensuse
+
+    steps:
+      - name: Install OS deps
+        run: |
+          zypper in -y qemu-tools make tar gzip xz which curl
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-raw-img-opensuse
+          path: .
+      - name: Install toolchain
+        run: |
+          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
+          rm -rf /var/lock
+          mkdir -p /var/lock
+          make deps
+      - name: Build Image
+        run: |
+          make gce_disk
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-gce-img-opensuse
+          path: |
+            cOS-Vanilla-*.tar.gz
+          if-no-files-found: error
+
     
 
   ami-publish-opensuse:

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -492,6 +492,37 @@ jobs:
             *.vhd
           if-no-files-found: error
 
+  gce-img-opensuse:
+    runs-on: ubuntu-latest
+    container: opensuse/leap:15.3
+    needs: raw-img-opensuse
+
+    steps:
+      - name: Install OS deps
+        run: |
+          zypper in -y qemu-tools make tar gzip xz which curl
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-raw-img-opensuse
+          path: .
+      - name: Install toolchain
+        run: |
+          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
+          rm -rf /var/lock
+          mkdir -p /var/lock
+          make deps
+      - name: Build Image
+        run: |
+          make gce_disk
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-gce-img-opensuse
+          path: |
+            cOS-Vanilla-*.tar.gz
+          if-no-files-found: error
+
     
   
 

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -426,7 +426,7 @@ jobs:
 
   
 
-  raw-img-opensuse:
+  raw-images-opensuse:
     runs-on: ubuntu-latest
     container: opensuse/leap:15.3
     needs: build-opensuse
@@ -434,7 +434,7 @@ jobs:
     steps:
       - name: Install OS deps
         run: |
-          zypper in -y curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
+          zypper in -y bc qemu-tools curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
       - uses: actions/checkout@v2
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -447,80 +447,40 @@ jobs:
           rm -rf /var/lock
           mkdir -p /var/lock
           make deps
-      - name: Build Image
+      - name: Export cos version
+        run: |
+          echo "COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')" >> $GITHUB_ENV
+      - name: Build raw image
         run: |
           make raw_disk
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv disk.raw cOS-Vanilla-${COS_VERSION}.raw
-      - uses: actions/upload-artifact@v2
-        with:
-          name: cOS-raw-img-opensuse
-          path: |
-            *.raw
-          if-no-files-found: error
-
-  azure-img-opensuse:
-    runs-on: ubuntu-latest
-    container: opensuse/leap:15.3
-    needs: raw-img-opensuse
-
-    steps:
-      - name: Install OS deps
-        run: |
-          zypper in -y qemu-tools make tar gzip xz which curl
-      - uses: actions/checkout@v2
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-raw-img-opensuse
-          path: .
-      - name: Install toolchain
-        run: |
-          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
-          rm -rf /var/lock
-          mkdir -p /var/lock
-          make deps
-      - name: Build Image
+      - name: Build Azure image
         run: |
           make azure_disk
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv disk.vhd cOS_${COS_VERSION}.vhd
-      - uses: actions/upload-artifact@v2
-        with:
-          name: cOS-azure-img-opensuse
-          path: |
-            *.vhd
-          if-no-files-found: error
-
-  gce-img-opensuse:
-    runs-on: ubuntu-latest
-    container: opensuse/leap:15.3
-    needs: raw-img-opensuse
-
-    steps:
-      - name: Install OS deps
-        run: |
-          zypper in -y qemu-tools make tar gzip xz which curl
-      - uses: actions/checkout@v2
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-raw-img-opensuse
-          path: .
-      - name: Install toolchain
-        run: |
-          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
-          rm -rf /var/lock
-          mkdir -p /var/lock
-          make deps
-      - name: Build Image
+      - name: Build GCE image
         run: |
           make gce_disk
+      - name: Rename images
+        run: |
+          mv disk.raw cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
+          mv disk.vhd cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
+          mv disk.raw.tar.gz cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-gce-img-opensuse
+          name: cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
           path: |
-            cOS-Vanilla-*.tar.gz
+            cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          path: |
+            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-Vanilla-GCE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          path: |
+            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
           if-no-files-found: error
 
     

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -432,7 +432,7 @@ jobs:
 
   
 
-  raw-img-opensuse:
+  raw-images-opensuse:
     runs-on: ubuntu-latest
     container: opensuse/leap:15.3
     needs: build-opensuse
@@ -440,7 +440,7 @@ jobs:
     steps:
       - name: Install OS deps
         run: |
-          zypper in -y curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
+          zypper in -y bc qemu-tools curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
       - uses: actions/checkout@v2
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -453,80 +453,40 @@ jobs:
           rm -rf /var/lock
           mkdir -p /var/lock
           make deps
-      - name: Build Image
+      - name: Export cos version
+        run: |
+          echo "COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')" >> $GITHUB_ENV
+      - name: Build raw image
         run: |
           make raw_disk
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv disk.raw cOS-Vanilla-${COS_VERSION}.raw
-      - uses: actions/upload-artifact@v2
-        with:
-          name: cOS-raw-img-opensuse
-          path: |
-            *.raw
-          if-no-files-found: error
-
-  azure-img-opensuse:
-    runs-on: ubuntu-latest
-    container: opensuse/leap:15.3
-    needs: raw-img-opensuse
-
-    steps:
-      - name: Install OS deps
-        run: |
-          zypper in -y qemu-tools make tar gzip xz which curl
-      - uses: actions/checkout@v2
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-raw-img-opensuse
-          path: .
-      - name: Install toolchain
-        run: |
-          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
-          rm -rf /var/lock
-          mkdir -p /var/lock
-          make deps
-      - name: Build Image
+      - name: Build Azure image
         run: |
           make azure_disk
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv disk.vhd cOS_${COS_VERSION}.vhd
-      - uses: actions/upload-artifact@v2
-        with:
-          name: cOS-azure-img-opensuse
-          path: |
-            *.vhd
-          if-no-files-found: error
-
-  gce-img-opensuse:
-    runs-on: ubuntu-latest
-    container: opensuse/leap:15.3
-    needs: raw-img-opensuse
-
-    steps:
-      - name: Install OS deps
-        run: |
-          zypper in -y qemu-tools make tar gzip xz which curl
-      - uses: actions/checkout@v2
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-raw-img-opensuse
-          path: .
-      - name: Install toolchain
-        run: |
-          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
-          rm -rf /var/lock
-          mkdir -p /var/lock
-          make deps
-      - name: Build Image
+      - name: Build GCE image
         run: |
           make gce_disk
+      - name: Rename images
+        run: |
+          mv disk.raw cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
+          mv disk.vhd cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
+          mv disk.raw.tar.gz cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-gce-img-opensuse
+          name: cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
           path: |
-            cOS-Vanilla-*.tar.gz
+            cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          path: |
+            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-Vanilla-GCE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          path: |
+            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
           if-no-files-found: error
 
     

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -498,6 +498,37 @@ jobs:
             *.vhd
           if-no-files-found: error
 
+  gce-img-opensuse:
+    runs-on: ubuntu-latest
+    container: opensuse/leap:15.3
+    needs: raw-img-opensuse
+
+    steps:
+      - name: Install OS deps
+        run: |
+          zypper in -y qemu-tools make tar gzip xz which curl
+      - uses: actions/checkout@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-raw-img-opensuse
+          path: .
+      - name: Install toolchain
+        run: |
+          # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the container
+          rm -rf /var/lock
+          mkdir -p /var/lock
+          make deps
+      - name: Build Image
+        run: |
+          make gce_disk
+      - uses: actions/upload-artifact@v2
+        with:
+          name: cOS-gce-img-opensuse
+          path: |
+            cOS-Vanilla-*.tar.gz
+          if-no-files-found: error
+
     
   
 

--- a/images/gce-image.sh
+++ b/images/gce-image.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Transform a raw image disk to gce compatible
+RAWIMAGE="$1"
+RAW_DISK="disk.raw"
+COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
+
+
+GB=$((1024*1024*1024))
+size=$(qemu-img info -f raw --output json "$RAWIMAGE" | gawk 'match($0, /"virtual-size": ([0-9]+),/, val) {print val[1]}')
+# shellcheck disable=SC2004
+ROUNDED_SIZE=$(echo "$size/$GB+1"|bc)
+if [[ "$RAWIMAGE" != "$RAW_DISK" ]]; then
+  echo "Renaming raw image to $RAW_DISK"
+  mv "$RAWIMAGE" "$RAW_DISK"
+fi
+echo "Resizing raw image from $size to $ROUNDED_SIZE"
+qemu-img resize -f raw "$RAW_DISK" "$ROUNDED_SIZE"G
+echo "Compressing raw image"
+tar -c -z --format=oldgnu -f cOS-Vanilla-"$COS_VERSION".tar.gz $RAW_DISK
+echo "Done"

--- a/images/gce-image.sh
+++ b/images/gce-image.sh
@@ -2,20 +2,15 @@
 
 # Transform a raw image disk to gce compatible
 RAWIMAGE="$1"
-RAW_DISK="disk.raw"
-COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-
 
 GB=$((1024*1024*1024))
 size=$(qemu-img info -f raw --output json "$RAWIMAGE" | gawk 'match($0, /"virtual-size": ([0-9]+),/, val) {print val[1]}')
 # shellcheck disable=SC2004
 ROUNDED_SIZE=$(echo "$size/$GB+1"|bc)
-if [[ "$RAWIMAGE" != "$RAW_DISK" ]]; then
-  echo "Renaming raw image to $RAW_DISK"
-  mv "$RAWIMAGE" "$RAW_DISK"
-fi
-echo "Resizing raw image from $size to $ROUNDED_SIZE"
-qemu-img resize -f raw "$RAW_DISK" "$ROUNDED_SIZE"G
-echo "Compressing raw image"
-tar -c -z --format=oldgnu -f cOS-Vanilla-"$COS_VERSION".tar.gz $RAW_DISK
+echo "Resizing raw image from \"$size\"MB to \"$ROUNDED_SIZE\"GB"
+qemu-img resize -f raw "$RAWIMAGE" "$ROUNDED_SIZE"G
+echo "Compressing raw image $RAWIMAGE to $RAWIMAGE.tar.gz"
+tar -c -z --format=oldgnu -f "$RAWIMAGE".tar.gz $RAWIMAGE
+echo "Restoring size to original raw image"
+qemu-img resize -f raw "$RAWIMAGE" --shrink "$size"
 echo "Done"

--- a/make/Makefile.images
+++ b/make/Makefile.images
@@ -66,7 +66,7 @@ endif
 .PHONY: aws_vanilla_ami
 aws_vanilla_ami: $(AWSCLI) $(JQ)
 ifeq ("$(RAW)","")
-	@echo "Raw image does not exists, please run make_raw first"
+	@echo "Raw image does not exists, please run make raw_disk first"
 	@exit 1
 endif
 	$(ROOT_DIR)/images/aws_upload.sh $(RAW)
@@ -74,7 +74,15 @@ endif
 .PHONY: azure_disk
 azure_disk: as_root $(QEMUIMG)
 ifeq ("$(RAW)","")
-	@echo "Raw image does not exists, please run make_raw first"
+	@echo "Raw image does not exists, please run make raw_disk first"
 	@exit 1
 endif
 	@$(ROOT_DIR)/images/azure-image.sh $(RAW)
+
+.PHONY: gce_disk
+gce_disk: as_root $(QEMUIMG)
+ifeq ("$(RAW)","")
+	@echo "Raw image does not exists, please run make raw_disk first"
+	@exit 1
+endif
+	@$(ROOT_DIR)/images/gce-image.sh $(RAW)


### PR DESCRIPTION
Same as the other images, this adds a script to prepare the raw disk in
a format that can be uploaded to gce and then imported directly as image

GCE as has some caveats:
 - Image needs to be rounded up to the next Gb
 - Image needs to be tar.gzipped with oldgnu format
 - Image inside the tar needs to be called disk.raw

Those are the main changes from the normal raw disk

Signed-off-by: Itxaka <igarcia@suse.com>