### PR TITLE
Add bootargs.cfg docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you are looking after only generating a container image that can be used for 
 
 ### Usage hints
 
-- [Grub2 default boot entry setup](/docs/configure_grub.md)
+- [Grub2 configuration](/docs/configure_grub.md)
 
 ## License
 

--- a/docs/configure_grub.md
+++ b/docs/configure_grub.md
@@ -1,4 +1,43 @@
-# Grub2 default boot entry setup
+# Grub configuration
+
+cOS set to deploy a persistent `grub.cfg` into the `COS_RECOVERY` partition during
+the system installation or image creation. COS grub configuration
+includes three menu entries: first for the main OS system, second for the
+fallback OS system and a third for the recovery OS.
+
+For example the main OS system menu entry could be something like:
+
+```
+menuentry "cOS" --id cos {
+  search.fs_label COS_STATE root
+  set img=/cOS/active.img
+  set label=COS_ACTIVE
+  loopback loop0 /$img
+  set root=($root)
+  source (loop0)/etc/cos/bootargs.cfg
+  linux (loop0)$kernel $kernelcmd
+  initrd (loop0)$initramfs
+}
+```
+
+Someting relevant to note is that the kernel parameters are not part of the 
+persistent `grub.cfg` file stored in `COS_RECOVERY` partition. Kernel parameters
+are sourced from the loop device of the OS image to boot. This is mainly to
+keep kernel parameters consistent across different potential OS images or
+system upgrades. 
+
+In fact, cOS images and its derivatives, are expected to include a
+`/etc/cos/bootargs.cfg` file which provides the definition of the following
+variables:
+
+* `$kernel`: Path of the kernel binary 
+* `$kernelcmd`: Kernel parameters
+* `$initramfs`: Path of the initrd binary
+
+This is the mechanism any cOS image or cOS derivative has to communicate
+its boot parameters (kernel, kernel params and initrd file) to grub2.
+
+## Grub2 default boot entry setup
 
 cOS (since v0.5.8) makes use of the grub2 environment block which can used to define
 persistent grub2 variables across reboots.


### PR DESCRIPTION
This commit adds some documentation about the purpose and use cases
of the `/etc/cos/bootargs.cfg` file regarding grub2 configuration and
boot parameters.

Related to #237

Signed-off-by: David Cassany <dcassany@suse.com>