### PR TITLE
azure: Use shared image gallery for cos base

### DIFF
--- a/packer/images.json.pkr.hcl
+++ b/packer/images.json.pkr.hcl
@@ -37,11 +37,18 @@ source "azure-arm" "cos" {
   tenant_id = var.azure_tenant_id
   client_secret = var.azure_client_secret
   subscription_id = var.azure_subscription_id
-  custom_managed_image_resource_group_name = var.azure_custom_managed_image_resource_group_name
-  custom_managed_image_name = var.azure_custom_managed_image_name
+  shared_image_gallery {
+    subscription = var.azure_shared_image_gallery_subscription
+    resource_group = var.azure_shared_image_gallery_resource_group
+    gallery_name = var.azure_shared_image_gallery_gallery_name
+    image_name = var.azure_shared_image_gallery_image_name
+    image_version = var.azure_shared_image_gallery_image_version
+  }
   managed_image_name = "${var.name}-${replace(var.cos_version, "+", "-")}-${formatdate("DDMMYYYY", timestamp())}-${var.flavor}"
   managed_image_resource_group_name = var.azure_managed_image_resource_group_name
-  user_data_file = var.azure_user_data_file
+  # User data not supported in the current released version of packer azure plugin
+  # also, no user-data -> no deployment
+  //user_data_file = var.azure_user_data_file
   location = var.azure_location
   os_type = "Linux"
   os_disk_size_gb = var.azure_os_disk_size_gb

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -100,19 +100,37 @@ variable "azure_subscription_id" {
   default = env("AZURE_SUBSCRIPTION_ID")
 }
 
-variable "azure_custom_managed_image_resource_group_name" {
-  type = string
-  default = "cos-testing"
-}
-
-variable "azure_custom_managed_image_name" {
-  type = string
-  default = "cos_0.5.7-recovery"
-}
-
 variable "azure_managed_image_resource_group_name" {
   type = string
   default = "cos-testing"
+}
+
+# shared_image_gallery options configure the shared image gallery where to pick
+# the base image from. The defaults point to cOS shared image gallery, if you plan on using a
+# vanilla image different that ours, change all the options to point to your shared image gallery
+variable "azure_shared_image_gallery_subscription" {
+  type = string
+  default = "c011786b-59d7-4817-880c-7cd8a6ca4b19"
+}
+
+variable "azure_shared_image_gallery_resource_group" {
+  type = string
+  default = "cos-testing"
+}
+
+variable "azure_shared_image_gallery_gallery_name" {
+  type = string
+  default = "cos"
+}
+
+variable "azure_shared_image_gallery_image_name" {
+  type = string
+  default = "cos-vanilla"
+}
+
+variable "azure_shared_image_gallery_image_version" {
+  type = string
+  default = "latest"
 }
 
 variable "azure_location" {


### PR DESCRIPTION
Instead of using our private images, use the ones in the shared
image gallery which are available to the world. Also make them
configurable so if someone wants to use their own shared image
becuase they modified the vanilla image, they can override the
values

Signed-off-by: Itxaka <igarcia@suse.com>