### PR TITLE
ci: Add workflow to publish toolchain image

### DIFF
--- a/.github/workflows/toolchain_image.yaml
+++ b/.github/workflows/toolchain_image.yaml
@@ -1,0 +1,29 @@
+name: Build toolchain image
+
+on: 
+ schedule:
+   - cron: 0 20 * * *
+ push:
+   branches:
+     - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+      - name: Login to Quay Registry
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+  
+      - name: Build  🔧
+        run: |
+          docker build -t quay.io/costoolkit/toolchain:latest .
+          docker push quay.io/costoolkit/toolchain:latest


### PR DESCRIPTION
This allows us to reuse the image inside docs and also to provide easier steps without having to build the main image.
I've already tested the workflow, and an image was already pushed here: https://quay.io/repository/costoolkit/toolchain?tab=info