### PR TITLE
Add templates to workflow and rework release job

### DIFF
--- a/.github/PIPELINES.md
+++ b/.github/PIPELINES.md
@@ -6,3 +6,11 @@ Requirements:
 Pipelines are generated from `build.yaml.gomplate`, which is a gomplate template. To generate the pipelines, run `./pipelines.sh`.
 
 Each configuration in `config` is turned to its own pipeline, named `build-$NAME`.
+
+## Github Secrets
+
+The pipeline needs `QUAY_USERNAME` and `QUAY_PASSWORD` as Github Secret for logging in for pushing container images.
+
+## Notes
+
+The templating syntax delimiter for gomplate is `{{{` and `}}}`. This is to differentiate from the Github delimiters `${{` and `}}`.

--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -1,113 +1,115 @@
 {{{ $config := (datasource "config") }}}
-name: Build cOS {{{$config.pipeline}}}
 
-on: 
-{{{$config.on | toYAML | indent 1 }}}
+{{{define "cos_version" }}}
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+{{{ end }}}
 
-concurrency:
-  group: ci-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
 
-jobs:
-
-{{{ range $config.flavors }}}
-  {{{$flavor:=.}}}
-  docker-build-{{{ $flavor }}}:
-  {{{ if $config.local_runner }}}
-    runs-on: self-hosted
-    if: contains(["mudler", "davidcassany", "itxaka", kkaempf", "cOS-cibot"], "${{ github.actor }}") || contains(github.event.pull_request.labels.*.name, 'safe to test')
-  {{{ else }}}
-    runs-on: ubuntu-latest
-  {{{ end }}}
-    env:
-      FLAVOR: {{{ $flavor }}}
-
-    steps:
-  {{{ if $config.local_runner }}}
-      - run: |
-          sudo rm -rf build || true
-          sudo rm -rf bin || true
-  {{{ end }}}
+{{{define "prepare_worker" }}}
+  {{{ $config := (datasource "config") }}}
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-  {{{ if not $config.local_runner }}}
+  {{{- if not $config.local_runner }}}
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  {{{end}}}
+  {{{- end }}}
+{{{ end }}}
+
+{{{define "prepare_build" }}}
+  {{{ $config := (datasource "config") }}}
+  {{{- if $config.local_runner }}}
+      - run: |
+          sudo rm -rf build || true
+          sudo rm -rf bin || true
+  {{{- end }}}
+
+  {{{- if $config.local_runner }}}
+      - name: Install Go
+        run: |
+          curl -L https://golang.org/dl/go1.16.5.linux-amd64.tar.gz -o go1.16.5.linux-amd64.tar.gz
+          sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
+  {{{- else }}}
+      - name: Install Go
+        uses: actions/setup-go@v2
+  {{{- end }}}
+  {{{- if $config.local_runner }}}
+      - name: Install make
+        run: |
+            sudo apt-get update
+            sudo apt-get install -y make
+  {{{- end }}}
+{{{ end }}}
+
+{{{define "make"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $target := . }}}
+      - name: Run make {{{ $target }}}
+        run: |
+          sudo -E make {{{ $target }}}
+  {{{- if eq $target "deps" }}}
+          sudo luet install -y toolchain/yq
+  {{{- end }}}
+{{{end}}}
+
+{{{define "runner"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{- if $config.local_runner }}}
+    runs-on: self-hosted
+    if: contains(["mudler", "davidcassany", "itxaka", kkaempf", "cOS-cibot"], "${{ github.actor }}") || contains(github.event.pull_request.labels.*.name, 'safe to test')
+  {{{- else }}}
+    runs-on: ubuntu-latest
+  {{{ end }}}
+{{{end}}}
+
+{{{define "docker_build_packages"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := . }}}
+  docker-build-{{{ $flavor }}}:
+    {{{ tmpl.Exec "runner" }}}
+    env:
+      FLAVOR: {{{ $flavor }}}
+    steps:
+  {{{- if $config.local_runner }}}
+      - run: |
+          sudo rm -rf build || true
+          sudo rm -rf bin || true
+  {{{- end }}}
+      {{{ tmpl.Exec "prepare_worker" }}}
       - name: Build  🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source .envrc
           cos-build $FLAVOR
+{{{end}}}
 
-
+{{{define "build_packages"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := . }}}
   build-{{{ $flavor }}}:
-  {{{ if $config.local_runner }}}
-    runs-on: self-hosted
-    if: contains(["mudler", "davidcassany", "itxaka", kkaempf", "cOS-cibot"], "${{ github.actor }}")
-  {{{ else }}}
-    runs-on: ubuntu-latest
-  {{{ end }}}
+    {{{ tmpl.Exec "runner" }}}
     env:
       FLAVOR: {{{ $flavor }}}
-      FINAL_REPO: quay.io/costoolkit/{{{$config.repository}}}-{{{ $flavor }}}
+      FINAL_REPO: {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}
       DOWNLOAD_METADATA: false
       PUSH_CACHE: {{{$config.push_cache}}}
+      REPO_CACHE: {{{$config.organization}}}/{{{$config.cache_repository}}}-{{{ $flavor }}}-cache
     steps:
-  {{{ if $config.local_runner }}}
-      - run: |
-          sudo rm -rf build || true
-          sudo rm -rf bin || true
-  {{{ end }}}
-
-  {{{ if $config.local_runner }}}
-      - name: Install Go
-        run: |
-          curl -L https://golang.org/dl/go1.16.5.linux-amd64.tar.gz -o go1.16.5.linux-amd64.tar.gz
-          sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
-  {{{ else }}}
-      - name: Install Go
-        uses: actions/setup-go@v2
-  {{{ end }}}
-
-      - uses: actions/checkout@v2
-
-      - run: |
-          git fetch --prune --unshallow
-
-  {{{ if $config.local_runner }}}
-      - name: Install make
-        run: |
-            sudo apt-get update
-            sudo apt-get install -y make
-  {{{ else }}}
-      - name: setup-docker
-        uses: docker-practice/actions-setup-docker@master
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  {{{ end }}}
-
-  {{{ if or $config.publishing_pipeline $config.push_cache }}}
+      {{{ tmpl.Exec "prepare_build" }}}
+      {{{ tmpl.Exec "prepare_worker" }}}
+  {{{- if or $config.publishing_pipeline $config.push_cache }}}
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
-  {{{ end }}}
-
-      - name: Install deps
-        run: |
-          sudo -E make deps
-
-      - name: Validate 🌳
-        run: |
-          make validate
-
+  {{{- end }}}
+      {{{ tmpl.Exec "make" "deps" }}}
+      {{{ tmpl.Exec "make" "validate" }}}
       - name: Build packages 🔧
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -118,7 +120,7 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
-  {{{ if $config.publishing_pipeline }}}
+  {{{- if $config.publishing_pipeline }}}
       - name: Generate manifests
         run: |
           for f in build/*tar*; do
@@ -132,35 +134,29 @@ jobs:
             BASE_NAME=`basename -s .package.tar.zst.mtree $f`
             sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
           done
-  {{{ end }}}
-      - name: Create repo
-        run: |
-          sudo -E make create-repo
+  {{{- end }}}
+      {{{ tmpl.Exec "make" "create-repo" }}}
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
           name: build-{{{ $flavor }}}
           path: build
           if-no-files-found: error
+{{{end}}}
 
-
-
-  {{{ range slice "squashfs" "nonsquashfs" }}}
-  {{{$subset:=.}}}
-  {{{ if not (has $config.skip_images_flavor $flavor) }}}
-
+{{{define "build_iso"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := index . "flavor" }}}
+  {{{ $subset := index . "subset" }}}
   iso-{{{$subset}}}-{{{ $flavor }}}:
-  {{{ if $config.local_runner }}}
-    runs-on: self-hosted
-    if: contains(["mudler", "davidcassany", "itxaka", kkaempf", "cOS-cibot"], "${{ github.actor }}") || contains(github.event.pull_request.labels.*.name, 'safe to test')
-  {{{ else }}}
-    runs-on: ubuntu-latest
-  {{{ end }}}
+    {{{ tmpl.Exec "runner" }}}
+    {{{- if not $config.skip_build }}}
     needs: build-{{{ $flavor }}}
+    {{{- end }}}
     env:
-      FINAL_REPO: quay.io/costoolkit/{{{$config.repository}}}-{{{ $flavor }}}
+      FINAL_REPO: {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}
     steps:
-      - uses: actions/checkout@v2
+      {{{ tmpl.Exec "prepare_worker" }}}
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -170,35 +166,24 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y xorriso squashfs-tools
-          sudo -E make deps
-  {{{ if eq $subset "nonsquashfs" }}}
+      {{{ tmpl.Exec "make" "deps" }}}
+  {{{- if eq $subset "nonsquashfs" }}}
       - name: Tweak manifest and drop squashfs recovery
         run: |
-          yq d -i manifest.yaml 'packages.isoimage(.==recovery/cos-img)'
-  {{{ end }}}
+          source .github/helpers.sh
+          drop_recovery manifest.yaml
+  {{{- end }}}
+      {{{ tmpl.Exec "cos_version" }}}
       - name: Build ISO from local build 🔧
         if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
         run: |
-          MANIFEST=manifest.yaml
-          cp -rf $MANIFEST $MANIFEST.remote
-          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
-          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
-          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
-          sudo -E MANIFEST=$MANIFEST.remote make local-iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          source .github/helpers.sh
+          create_remote_manifest manifest.yaml
+          sudo -E MAKEISO_ARGS="--output cOS-{{{ $flavor }}}-${{ env.COS_VERSION }}" MANIFEST=manifest.yaml.remote make local-iso
       - name: Build ISO from remote repositories 🔧
         if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
         run: |
-          sudo -E make iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          sudo -E YQ=/usr/bin/yq MAKEISO_ARGS="--output cOS-{{{ $flavor }}}-${{ env.COS_VERSION }}" make iso
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-{{{$subset}}}-{{{ $flavor }}}.iso.zip
@@ -206,6 +191,13 @@ jobs:
             *.iso
             *.sha256
           if-no-files-found: error
+{{{ end }}}
+
+
+{{{define "build_qemu"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := index . "flavor" }}}
+  {{{ $subset := index . "subset" }}}
   qemu-{{{$subset}}}-{{{ $flavor }}}:
     runs-on: macos-10.15
     needs: iso-{{{$subset}}}-{{{ $flavor }}}
@@ -218,9 +210,13 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
+          brew install yq@3
       - name: Build QEMU Image 🔧
         run: |
-          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor={{{ $flavor }}}' -var='feature=vagrant' -only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-{{{$subset}}}-{{{ $flavor }}}.qcow
@@ -233,6 +229,12 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+{{{ end }}}
+
+{{{define "build_vbox"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := index . "flavor" }}}
+  {{{ $subset := index . "subset" }}}
   vbox-{{{$subset}}}-{{{ $flavor }}}:
     runs-on: macos-10.15
     needs: iso-{{{$subset}}}-{{{ $flavor }}}
@@ -247,9 +249,15 @@ jobs:
       #   run: |
       #     brew tap hashicorp/tap
       #     brew install hashicorp/tap/packer
+      - name: Install deps
+        run: |
+            brew install yq@3
       - name: Build VBox Image 🔧
         run: |
-          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor={{{ $flavor }}}' -only virtualbox-iso.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-{{{$subset}}}-{{{ $flavor }}}.ova
@@ -262,8 +270,12 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
-  {{{ end }}}
-  {{{ if not (or $config.skip_tests (has $config.skip_tests_flavor $flavor)) }}}
+{{{ end }}}
+
+{{{define "test"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := index . "flavor" }}}
+  {{{ $subset := index . "subset" }}}
   tests-{{{$subset}}}-{{{ $flavor }}}:
     env:
       VAGRANT_CPU: 3
@@ -305,63 +317,50 @@ jobs:
           name: cOS-{{{$subset}}}-${{ matrix.test }}.serial.zip
           path: tests/serial_port1
           if-no-files-found: warn
+{{{ end }}}
 
-  {{{end}}}
- {{{end}}}
-
-  {{{ if $config.publishing_pipeline }}}
+{{{define "publish_packages"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := . }}}
   publish-{{{ $flavor }}}:
     runs-on: ubuntu-latest
-    {{{ if or $config.skip_tests (has $config.skip_tests_flavor $flavor) }}}
-    needs: build-{{{ $flavor }}}
-    {{{ else }}}
+    {{{- if or $config.skip_tests (has $config.skip_tests_flavor $flavor) }}}
+    needs: 
+    {{{- if not $config.skip_build }}}
+    - build-{{{ $flavor }}}
+    {{{- end }}}
+    {{{- if not ( has $config.skip_images_flavor $flavor ) }}}
+    - iso-squashfs-{{{ $flavor }}}
+    {{{- end }}}
+    {{{- else }}}
     needs: tests-squashfs-{{{ $flavor }}}
-    {{{ end }}}
+    {{{- end }}}
     env:
       FLAVOR: {{{ $flavor }}}
-      FINAL_REPO: quay.io/costoolkit/{{{$config.repository}}}-{{{ $flavor }}}
+      FINAL_REPO: {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
     steps:
-      - uses: actions/checkout@v2
+      {{{ tmpl.Exec "prepare_worker" }}}
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
           name: build-{{{ $flavor }}}
           path: build
-      - run: |
-          git fetch --prune --unshallow
-
-      - name: setup-docker
-        uses: docker-practice/actions-setup-docker@master
-
-      # We patch docker to use all the HD available in GH action free runners
-      - name: Patch Docker Daemon data-root
-        run: |
-          DOCKER_DATA_ROOT='/mnt/var/lib/docker'
-          DOCKER_DAEMON_JSON='/etc/docker/daemon.json'
-          sudo mkdir -p "${DOCKER_DATA_ROOT}"
-          jq --arg dataroot "${DOCKER_DATA_ROOT}" '. + {"data-root": $dataroot}' "${DOCKER_DAEMON_JSON}" > "/tmp/docker.json.tmp"
-          sudo mv "/tmp/docker.json.tmp" "${DOCKER_DAEMON_JSON}"
-          sudo systemctl restart docker
-
-    {{{ if or $config.publishing_pipeline $config.push_cache }}}
+    {{{- if or $config.publishing_pipeline $config.push_cache }}}
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
-    {{{ end }}}
-
-      - name: Install deps
-        run: |
-          sudo -E make deps
-    {{{ if $config.local_runner }}}
+    {{{- end }}}
+      {{{ tmpl.Exec "make" "deps" }}}
+    {{{- if $config.local_runner }}}
       - name: Install Go
         run: |
           curl -L https://golang.org/dl/go1.16.5.linux-amd64.tar.gz -o go1.16.5.linux-amd64.tar.gz
           sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
-    {{{ else }}}
+    {{{- else }}}
       - name: Install Go
         uses: actions/setup-go@v2
-    {{{ end }}}
+    {{{- end }}}
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -373,56 +372,100 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
+{{{ end }}}
+
+
+
+{{{define "github_release"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := . }}}
 
   github-release-{{{ $flavor }}}:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    {{{ if or $config.skip_tests (has $config.skip_tests_flavor $flavor) }}}
-    needs: build-{{{ $flavor }}}
-    {{{ else }}}
-    needs: tests-squashfs-{{{ $flavor }}}
-    {{{ end }}}
+    needs: 
+    {{{- if not $config.skip_build }}}
+    - build-{{{ $flavor }}}
+    {{{- end }}}
+    - raw-images-{{{ $flavor }}}
+    - vbox-nonsquashfs-{{{ $flavor }}}
+    - qemu-nonsquashfs-{{{ $flavor }}}
+    - iso-nonsquashfs-{{{ $flavor }}}
+    - image-link-{{{ $flavor }}}
+    {{{- if or $config.skip_tests (has $config.skip_tests_flavor $flavor) }}}
+    {{{- else }}}
+    - tests-nonsquashfs-{{{ $flavor }}}
+    - tests-squashfs-{{{ $flavor }}}
+    {{{- end }}}
     steps:
       - uses: actions/checkout@v2
+      {{{ tmpl.Exec "make" "deps" }}}
+      {{{ tmpl.Exec "cos_version" }}}
       - name: Download ISO
         uses: actions/download-artifact@v2
         with:
-          name: cOS-{{{ $flavor }}}.iso.zip
+          name: cOS-nonsquashfs-{{{ $flavor }}}.iso.zip
           path: release
       - name: Download vagrant box
         uses: actions/download-artifact@v2
         with:
-          name: cOS-{{{ $flavor }}}-vbox.box
+          name: cOS-nonsquashfs-{{{ $flavor }}}-vbox.box
           path: release
       - name: Download OVA image
         uses: actions/download-artifact@v2
         with:
-          name: cOS-{{{ $flavor }}}.ova
+          name: cOS-nonsquashfs-{{{ $flavor }}}.ova
           path: release
       - name: Download QCOW image
         uses: actions/download-artifact@v2
         with:
-          name: cOS-{{{ $flavor }}}.qcow
+          name: cOS-nonsquashfs-{{{ $flavor }}}.qcow
+          path: release
+      - name: Download GCE RAW image
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-Vanilla-GCE-{{{ $flavor }}}-${{ env.COS_VERSION }}
+          path: release
+      - name: Download AZURE RAW image
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-Vanilla-AZURE-{{{ $flavor }}}-${{ env.COS_VERSION }}
+          path: release
+      - name: Download RAW image
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-Vanilla-RAW-{{{ $flavor }}}-${{ env.COS_VERSION }}
+          path: release
+      - name: Download Image links
+        uses: actions/download-artifact@v2
+        with:
+          name: images-{{{ $flavor }}}.txt
           path: release
       - name: Release
         uses: fnkr/github-action-ghr@v1
         if: startsWith(github.ref, 'refs/tags/')
         env:
+          GHR_COMPRESS: xz
           GHR_PATH: release/
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  {{{ end }}}
+{{{ end }}}
 
-  {{{ if not (has $config.skip_images_flavor $flavor) }}}
-
+{{{define "raw_image"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := . }}}
   raw-images-{{{ $flavor }}}:
     runs-on: ubuntu-latest
     container: opensuse/leap:15.3
-    needs: build-{{{ $flavor }}}
+
+    {{{- if not $config.skip_build }}}
+    needs:
+    - build-{{{ $flavor }}}
+    {{{- end }}}
 
     steps:
       - name: Install OS deps
         run: |
-          zypper in -y bc qemu-tools curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
+          zypper in -y bc qemu-tools sudo curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
       - uses: actions/checkout@v2
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -434,45 +477,39 @@ jobs:
           # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the continer
           rm -rf /var/lock
           mkdir -p /var/lock
-          make deps
-      - name: Export cos version
-        run: |
-          echo "COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')" >> $GITHUB_ENV
-      - name: Build raw image
-        run: |
-          make raw_disk
-      - name: Build Azure image
-        run: |
-          make azure_disk
-      - name: Build GCE image
-        run: |
-          make gce_disk
+      {{{ tmpl.Exec "make" "deps" }}}
+      {{{ tmpl.Exec "cos_version" }}}
+      {{{ tmpl.Exec "make" "raw_disk" }}}
+      {{{ tmpl.Exec "make" "azure_disk" }}}
+      {{{ tmpl.Exec "make" "gce_disk" }}}
       - name: Rename images
         run: |
-          mv disk.raw cOS-Vanilla-RAW-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.raw
-          mv disk.vhd cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.vhd
-          mv disk.raw.tar.gz cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.tar.gz
+          mv disk.raw cOS-Vanilla-RAW-{{{ $flavor }}}-${{ env.COS_VERSION }}.raw
+          mv disk.vhd cOS-Vanilla-AZURE-{{{ $flavor }}}-${{ env.COS_VERSION }}.vhd
+          mv disk.raw.tar.gz cOS-Vanilla-AZURE-{{{ $flavor }}}-${{ env.COS_VERSION }}.tar.gz
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-RAW-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}
+          name: cOS-Vanilla-RAW-{{{ $flavor }}}-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-RAW-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.raw
+            cOS-Vanilla-RAW-{{{ $flavor }}}-${{ env.COS_VERSION }}.raw
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}
+          name: cOS-Vanilla-AZURE-{{{ $flavor }}}-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.vhd
+            cOS-Vanilla-AZURE-{{{ $flavor }}}-${{ env.COS_VERSION }}.vhd
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-GCE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}
+          name: cOS-Vanilla-GCE-{{{ $flavor }}}-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-{{{ $flavor }}}-${{ github.sha }}.tar.gz
+            cOS-Vanilla-AZURE-{{{ $flavor }}}-${{ env.COS_VERSION }}.tar.gz
           if-no-files-found: error
+{{{ end }}}
 
-    {{{ if $config.publishing_pipeline }}}
-
+{{{define "ami_publish"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := . }}}
   ami-publish-{{{ $flavor }}}:
     runs-on: ubuntu-latest
     needs: publish-vanilla-ami
@@ -482,37 +519,58 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install deps
-        run: |
-          sudo -E make deps
+      {{{ tmpl.Exec "make" "deps" }}}
       - name: Build AMI for {{{ $flavor }}}
         run: |
-            COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-            export COS_VERSION="${COS_VERSION/+/-}"
+            source .github/helpers.sh
+            PACKAGE_VERSION=$(cos_package_version)
+            export COS_VERSION="${PACKAGE_VERSION/+/-}"
             export PKR_VAR_cos_version="${COS_VERSION}"
-            export PKR_VAR_cos_deploy_args="cos-deploy {{{ if (ne $flavor "opensuse") }}}--no-verify {{{ end }}}--docker-image quay.io/costoolkit/{{{$config.repository}}}-{{{ $flavor }}}:cos-system-${COS_VERSION}"
+            export PKR_VAR_cos_deploy_args="cos-deploy {{{ if (ne $flavor "opensuse") }}}--no-verify {{{ end }}}--docker-image {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor={{{ $flavor }}}
             export PKR_VAR_git_sha="${GITHUB_SHA}"
             make packer-aws
-    {{{ end }}}
-  {{{ end }}}
 {{{ end }}}
 
-{{{ if eq $config.pipeline "master" }}}
+{{{define "image_link"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := . }}}
+  image-link-{{{ $flavor }}}:
+    runs-on: ubuntu-latest
+    needs: publish-{{{$flavor}}}
+    steps:
+      - uses: actions/checkout@v2
+      {{{ tmpl.Exec "make" "deps" }}}
+      - name: Generate link for {{{ $flavor }}}
+        run: |
+            source .github/helpers.sh
+            PACKAGE_VERSION=$(cos_package_version)
+            export COS_VERSION="${PACKAGE_VERSION/+/-}"
+            echo "{{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}:cos-system-${COS_VERSION}" > images-{{{ $flavor }}}.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: images-{{{ $flavor }}}.txt
+          path: |
+            images-{{{ $flavor }}}.txt
+{{{ end }}}
+
+{{{define "publish_vanilla"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := "opensuse" }}}
   # We need only a single vanilla image for any OS
   # Vanilla image is always based on openSUSE
   publish-vanilla-ami:
     runs-on: ubuntu-latest
-    needs: [raw-images-opensuse, tests-squashfs-opensuse]
+    {{{- if or $config.skip_tests (has $config.skip_tests_flavor $flavor) }}}
+    needs: raw-images-{{{ $flavor }}}
+    {{{- else }}}
+    needs: [raw-images-{{{ $flavor }}}, tests-squashfs-{{{ $flavor }}}]
+    {{{- end }}}
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install deps
-        run: |
-          sudo -E make deps
-      - name: Export cOS version
-        run: |
-          echo "COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')" >> $GITHUB_ENV
+      {{{ tmpl.Exec "make" "deps" }}}
+      {{{ tmpl.Exec "cos_version" }}}
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -530,3 +588,60 @@ jobs:
           export COPY_AMI_ALL_REGIONS="true"
           make aws_vanilla_ami
 {{{ end }}}
+
+name: Build cOS {{{$config.pipeline}}}
+
+on: 
+{{{$config.on | toYAML | indent 1 }}}
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+
+jobs:
+
+{{{- range $config.flavors }}}
+  {{{$flavor:=.}}}
+
+  {{{- if not $config.skip_build }}}
+  {{{tmpl.Exec "docker_build_packages" $flavor}}}
+  {{{tmpl.Exec "build_packages" $flavor}}}
+  {{{- end }}}
+
+  {{{- range slice "squashfs" "nonsquashfs" }}}
+
+    {{{- $subset:=. }}}
+    {{{ $context := coll.Dict "flavor" $flavor "subset" $subset }}}
+
+    {{{- if not (has $config.skip_images_flavor $flavor) }}}
+  {{{ tmpl.Exec "build_iso" $context }}}
+  {{{ tmpl.Exec "build_qemu" $context }}}
+  {{{ tmpl.Exec "build_vbox" $context }}}
+    {{{- end }}}
+
+    {{{- if not (or $config.skip_tests (has $config.skip_tests_flavor $flavor)) }}}
+  {{{ tmpl.Exec "test" $context }}}
+    {{{- end}}}
+
+  {{{- end}}}
+
+  {{{- if $config.publishing_pipeline }}}
+  {{{tmpl.Exec "image_link" $flavor}}}
+  {{{tmpl.Exec "publish_packages" $flavor}}}
+  {{{- if has $config.release_flavor $flavor }}}
+  {{{tmpl.Exec "github_release" $flavor}}}
+  {{{- end }}}
+  {{{- end }}}
+
+    {{{- if not (has $config.skip_images_flavor $flavor) }}}
+  {{{tmpl.Exec "raw_image" $flavor}}}
+
+      {{{- if $config.publish_cloud }}}
+  {{{tmpl.Exec "ami_publish" $flavor}}}
+      {{{- end }}}
+    {{{- end }}}
+{{{- end }}}
+
+{{{- if $config.publish_cloud }}}
+{{{tmpl.Exec "publish_vanilla"}}}
+{{{- end }}}

--- a/.github/config/master.yaml
+++ b/.github/config/master.yaml
@@ -3,14 +3,23 @@
 
 local_runner: false
 push_cache: true
+skip_build: false
+
 pipeline: "master"
 publishing_pipeline: true
+publish_cloud: true
+
 repository: "releases"
+cache_repository: "build"
+organization: "quay.io/costoolkit"
 skip_tests: false
 flavors: ["opensuse", "fedora", "ubuntu"]
 skip_tests_flavor: ["fedora","ubuntu"]
 skip_images_flavor: ["fedora","ubuntu"]
+release_flavor: ["opensuse"]
 
 on: 
   push: 
     branches: ["master"]
+    tags:
+      - "v*"

--- a/.github/config/nightly.yaml
+++ b/.github/config/nightly.yaml
@@ -3,14 +3,19 @@
 
 local_runner: false
 push_cache: false
+skip_build: false
+
 pipeline: "nightly"
 publishing_pipeline: false
+publish_cloud: false
 repository: "releases"
+cache_repository: "build"
+organization: "quay.io/costoolkit"
 skip_tests: false
 flavors: ["opensuse", "fedora", "ubuntu"]
 skip_tests_flavor: ["fedora","ubuntu"]
 skip_images_flavor: ["fedora","ubuntu"]
-
+release_flavor: ["opensuse"]
 on: 
   schedule:
     - cron:  '0 20 * * *'

--- a/.github/config/pr.yaml
+++ b/.github/config/pr.yaml
@@ -4,10 +4,15 @@ local_runner: false
 pipeline: "Pull requests"
 push_cache: false
 publishing_pipeline: false
+publish_cloud: false
+skip_build: false
 repository: "releases" # releases for prod
+cache_repository: "build"
+organization: "quay.io/costoolkit"
 skip_tests: false
 skip_tests_flavor: ["fedora","ubuntu"]
 skip_images_flavor: ["fedora","ubuntu"]
+release_flavor: ["opensuse"]
 
 flavors: ["opensuse", "fedora", "ubuntu"]
 on: 

--- a/.github/helpers.sh
+++ b/.github/helpers.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+YQ="${YQ:-/usr/bin/yq}"
+
+cos_package_version() {
+    echo $($YQ r packages/cos/collection.yaml 'packages.[0].version')
+}
+
+cos_version() {
+    SHA=$(echo $GITHUB_SHA | cut -c1-8 )
+    echo $(cos_package_version)-g$SHA
+}
+
+create_remote_manifest() {
+    MANIFEST=$1
+    cp -rf $MANIFEST $MANIFEST.remote
+    $YQ w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
+    $YQ w -i $MANIFEST.remote 'luet.repositories[0].enable' true
+    $YQ w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
+    $YQ w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
+    $YQ w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
+}
+
+drop_recovery() {
+    MANIFEST=$1
+    $YQ d -i $MANIFEST 'packages.isoimage(.==recovery/cos-img)'
+}

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -1,10 +1,51 @@
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 name: Build cOS master
 
 on: 
  push:
    branches:
      - master
+   tags:
+     - v*
 
 
 concurrency:
@@ -12,80 +53,86 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
-
+  
+  
+  
   
   docker-build-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: opensuse
-
     steps:
+      
   
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
+
       - name: Build  🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source .envrc
           cos-build $FLAVOR
 
-
+  
+  
+  
   build-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: opensuse
       FINAL_REPO: quay.io/costoolkit/releases-opensuse
       DOWNLOAD_METADATA: false
       PUSH_CACHE: true
+      REPO_CACHE: quay.io/costoolkit/build-opensuse-cache
     steps:
-  
-
+      
   
       - name: Install Go
         uses: actions/setup-go@v2
+
+      
   
-
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
 
-  
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      
   
-
-      - name: Install deps
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
+          sudo luet install -y toolchain/yq
 
-      - name: Validate 🌳
+      
+  
+  
+      - name: Run make validate
         run: |
-          make validate
+          sudo -E make validate
 
       - name: Build packages 🔧
         run: |
@@ -97,7 +144,6 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
-  
       - name: Generate manifests
         run: |
           for f in build/*tar*; do
@@ -111,10 +157,13 @@ jobs:
             BASE_NAME=`basename -s .package.tar.zst.mtree $f`
             sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
           done
+      
   
-      - name: Create repo
+  
+      - name: Run make create-repo
         run: |
           sudo -E make create-repo
+
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
@@ -122,21 +171,33 @@ jobs:
           path: build
           if-no-files-found: error
 
-
-
+    
   
   
   
-
+  
   iso-squashfs-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     needs: build-opensuse
     env:
       FINAL_REPO: quay.io/costoolkit/releases-opensuse
     steps:
+      
+  
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -146,31 +207,30 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y xorriso squashfs-tools
-          sudo -E make deps
+      
   
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
+
+      
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+
       - name: Build ISO from local build 🔧
         if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
         run: |
-          MANIFEST=manifest.yaml
-          cp -rf $MANIFEST $MANIFEST.remote
-          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
-          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
-          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
-          sudo -E MANIFEST=$MANIFEST.remote make local-iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          source .github/helpers.sh
+          create_remote_manifest manifest.yaml
+          sudo -E MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" MANIFEST=manifest.yaml.remote make local-iso
       - name: Build ISO from remote repositories 🔧
         if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
         run: |
-          sudo -E make iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          sudo -E YQ=/usr/bin/yq MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" make iso
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-squashfs-opensuse.iso.zip
@@ -178,6 +238,11 @@ jobs:
             *.iso
             *.sha256
           if-no-files-found: error
+
+  
+  
+  
+  
   qemu-squashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-squashfs-opensuse
@@ -190,9 +255,13 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
+          brew install yq@3
       - name: Build QEMU Image 🔧
         run: |
-          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -var='feature=vagrant' -only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-squashfs-opensuse.qcow
@@ -205,6 +274,11 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
+  
+  
   vbox-squashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-squashfs-opensuse
@@ -219,9 +293,15 @@ jobs:
       #   run: |
       #     brew tap hashicorp/tap
       #     brew install hashicorp/tap/packer
+      - name: Install deps
+        run: |
+            brew install yq@3
       - name: Build VBox Image 🔧
         run: |
-          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -only virtualbox-iso.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-squashfs-opensuse.ova
@@ -234,6 +314,9 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
   
   
   tests-squashfs-opensuse:
@@ -278,20 +361,33 @@ jobs:
           path: tests/serial_port1
           if-no-files-found: warn
 
+    
   
- 
   
   
-
+  
   iso-nonsquashfs-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     needs: build-opensuse
     env:
       FINAL_REPO: quay.io/costoolkit/releases-opensuse
     steps:
+      
+  
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -301,35 +397,34 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y xorriso squashfs-tools
-          sudo -E make deps
+      
   
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
+
       - name: Tweak manifest and drop squashfs recovery
         run: |
-          yq d -i manifest.yaml 'packages.isoimage(.==recovery/cos-img)'
-  
+          source .github/helpers.sh
+          drop_recovery manifest.yaml
+      
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+
       - name: Build ISO from local build 🔧
         if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
         run: |
-          MANIFEST=manifest.yaml
-          cp -rf $MANIFEST $MANIFEST.remote
-          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
-          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
-          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
-          sudo -E MANIFEST=$MANIFEST.remote make local-iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          source .github/helpers.sh
+          create_remote_manifest manifest.yaml
+          sudo -E MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" MANIFEST=manifest.yaml.remote make local-iso
       - name: Build ISO from remote repositories 🔧
         if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
         run: |
-          sudo -E make iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          sudo -E YQ=/usr/bin/yq MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" make iso
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-nonsquashfs-opensuse.iso.zip
@@ -337,6 +432,11 @@ jobs:
             *.iso
             *.sha256
           if-no-files-found: error
+
+  
+  
+  
+  
   qemu-nonsquashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-nonsquashfs-opensuse
@@ -349,9 +449,13 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
+          brew install yq@3
       - name: Build QEMU Image 🔧
         run: |
-          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -var='feature=vagrant' -only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-nonsquashfs-opensuse.qcow
@@ -364,6 +468,11 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
+  
+  
   vbox-nonsquashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-nonsquashfs-opensuse
@@ -378,9 +487,15 @@ jobs:
       #   run: |
       #     brew tap hashicorp/tap
       #     brew install hashicorp/tap/packer
+      - name: Install deps
+        run: |
+            brew install yq@3
       - name: Build VBox Image 🔧
         run: |
-          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -only virtualbox-iso.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-nonsquashfs-opensuse.ova
@@ -393,6 +508,9 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
   
   
   tests-nonsquashfs-opensuse:
@@ -438,54 +556,74 @@ jobs:
           if-no-files-found: warn
 
   
- 
+  
+  
+  image-link-opensuse:
+    runs-on: ubuntu-latest
+    needs: publish-opensuse
+    steps:
+      - uses: actions/checkout@v2
+      
+  
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
 
+      - name: Generate link for opensuse
+        run: |
+            source .github/helpers.sh
+            PACKAGE_VERSION=$(cos_package_version)
+            export COS_VERSION="${PACKAGE_VERSION/+/-}"
+            echo "quay.io/costoolkit/releases-opensuse:cos-system-${COS_VERSION}" > images-opensuse.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: images-opensuse.txt
+          path: |
+            images-opensuse.txt
+
+  
+  
   
   publish-opensuse:
     runs-on: ubuntu-latest
-    
     needs: tests-squashfs-opensuse
-    
     env:
       FLAVOR: opensuse
       FINAL_REPO: quay.io/costoolkit/releases-opensuse
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
     steps:
+      
+  
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
           name: build-opensuse
           path: build
-      - run: |
-          git fetch --prune --unshallow
-
-      - name: setup-docker
-        uses: docker-practice/actions-setup-docker@master
-
-      # We patch docker to use all the HD available in GH action free runners
-      - name: Patch Docker Daemon data-root
-        run: |
-          DOCKER_DATA_ROOT='/mnt/var/lib/docker'
-          DOCKER_DAEMON_JSON='/etc/docker/daemon.json'
-          sudo mkdir -p "${DOCKER_DATA_ROOT}"
-          jq --arg dataroot "${DOCKER_DATA_ROOT}" '. + {"data-root": $dataroot}' "${DOCKER_DAEMON_JSON}" > "/tmp/docker.json.tmp"
-          sudo mv "/tmp/docker.json.tmp" "${DOCKER_DAEMON_JSON}"
-          sudo systemctl restart docker
-
-    
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
-    
-
-      - name: Install deps
+      
+  
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
-    
+          sudo luet install -y toolchain/yq
+
       - name: Install Go
         uses: actions/setup-go@v2
-    
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -498,53 +636,99 @@ jobs:
         run: |
           sudo -E make publish-repo
 
+  
+  
+  
+
   github-release-opensuse:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-    
-    needs: tests-squashfs-opensuse
-    
+    needs:
+    - build-opensuse
+    - raw-images-opensuse
+    - vbox-nonsquashfs-opensuse
+    - qemu-nonsquashfs-opensuse
+    - iso-nonsquashfs-opensuse
+    - image-link-opensuse
+    - tests-nonsquashfs-opensuse
+    - tests-squashfs-opensuse
     steps:
       - uses: actions/checkout@v2
+      
+  
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
+
+      
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+
       - name: Download ISO
         uses: actions/download-artifact@v2
         with:
-          name: cOS-opensuse.iso.zip
+          name: cOS-nonsquashfs-opensuse.iso.zip
           path: release
       - name: Download vagrant box
         uses: actions/download-artifact@v2
         with:
-          name: cOS-opensuse-vbox.box
+          name: cOS-nonsquashfs-opensuse-vbox.box
           path: release
       - name: Download OVA image
         uses: actions/download-artifact@v2
         with:
-          name: cOS-opensuse.ova
+          name: cOS-nonsquashfs-opensuse.ova
           path: release
       - name: Download QCOW image
         uses: actions/download-artifact@v2
         with:
-          name: cOS-opensuse.qcow
+          name: cOS-nonsquashfs-opensuse.qcow
+          path: release
+      - name: Download GCE RAW image
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-Vanilla-GCE-opensuse-${{ env.COS_VERSION }}
+          path: release
+      - name: Download AZURE RAW image
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}
+          path: release
+      - name: Download RAW image
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-Vanilla-RAW-opensuse-${{ env.COS_VERSION }}
+          path: release
+      - name: Download Image links
+        uses: actions/download-artifact@v2
+        with:
+          name: images-opensuse.txt
           path: release
       - name: Release
         uses: fnkr/github-action-ghr@v1
         if: startsWith(github.ref, 'refs/tags/')
         env:
+          GHR_COMPRESS: xz
           GHR_PATH: release/
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
 
   
-
+  
+  
   raw-images-opensuse:
     runs-on: ubuntu-latest
     container: opensuse/leap:15.3
-    needs: build-opensuse
+    needs:
+    - build-opensuse
 
     steps:
       - name: Install OS deps
         run: |
-          zypper in -y bc qemu-tools curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
+          zypper in -y bc qemu-tools sudo curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
       - uses: actions/checkout@v2
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -556,45 +740,68 @@ jobs:
           # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the continer
           rm -rf /var/lock
           mkdir -p /var/lock
-          make deps
+      
+  
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
+
+      
       - name: Export cos version
         run: |
-          echo "COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')" >> $GITHUB_ENV
-      - name: Build raw image
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+
+      
+  
+  
+      - name: Run make raw_disk
         run: |
-          make raw_disk
-      - name: Build Azure image
+          sudo -E make raw_disk
+
+      
+  
+  
+      - name: Run make azure_disk
         run: |
-          make azure_disk
-      - name: Build GCE image
+          sudo -E make azure_disk
+
+      
+  
+  
+      - name: Run make gce_disk
         run: |
-          make gce_disk
+          sudo -E make gce_disk
+
       - name: Rename images
         run: |
-          mv disk.raw cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
-          mv disk.vhd cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
-          mv disk.raw.tar.gz cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
+          mv disk.raw cOS-Vanilla-RAW-opensuse-${{ env.COS_VERSION }}.raw
+          mv disk.vhd cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.vhd
+          mv disk.raw.tar.gz cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.tar.gz
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          name: cOS-Vanilla-RAW-opensuse-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
+            cOS-Vanilla-RAW-opensuse-${{ env.COS_VERSION }}.raw
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          name: cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
+            cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.vhd
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-GCE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          name: cOS-Vanilla-GCE-opensuse-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
+            cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.tar.gz
           if-no-files-found: error
 
-    
-
+  
+  
+  
   ami-publish-opensuse:
     runs-on: ubuntu-latest
     needs: publish-vanilla-ami
@@ -604,93 +811,105 @@ jobs:
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install deps
+      
+  
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
+          sudo luet install -y toolchain/yq
+
       - name: Build AMI for opensuse
         run: |
-            COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-            export COS_VERSION="${COS_VERSION/+/-}"
+            source .github/helpers.sh
+            PACKAGE_VERSION=$(cos_package_version)
+            export COS_VERSION="${PACKAGE_VERSION/+/-}"
             export PKR_VAR_cos_version="${COS_VERSION}"
             export PKR_VAR_cos_deploy_args="cos-deploy --docker-image quay.io/costoolkit/releases-opensuse:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor=opensuse
             export PKR_VAR_git_sha="${GITHUB_SHA}"
             make packer-aws
-    
-  
 
   
+  
+  
+  
   docker-build-fedora:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: fedora
-
     steps:
+      
   
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
+
       - name: Build  🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source .envrc
           cos-build $FLAVOR
 
-
+  
+  
+  
   build-fedora:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: fedora
       FINAL_REPO: quay.io/costoolkit/releases-fedora
       DOWNLOAD_METADATA: false
       PUSH_CACHE: true
+      REPO_CACHE: quay.io/costoolkit/build-fedora-cache
     steps:
-  
-
+      
   
       - name: Install Go
         uses: actions/setup-go@v2
+
+      
   
-
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
 
-  
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      
   
-
-      - name: Install deps
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
+          sudo luet install -y toolchain/yq
 
-      - name: Validate 🌳
+      
+  
+  
+      - name: Run make validate
         run: |
-          make validate
+          sudo -E make validate
 
       - name: Build packages 🔧
         run: |
@@ -702,7 +921,6 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
-  
       - name: Generate manifests
         run: |
           for f in build/*tar*; do
@@ -716,10 +934,13 @@ jobs:
             BASE_NAME=`basename -s .package.tar.zst.mtree $f`
             sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
           done
+      
   
-      - name: Create repo
+  
+      - name: Run make create-repo
         run: |
           sudo -E make create-repo
+
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
@@ -727,64 +948,78 @@ jobs:
           path: build
           if-no-files-found: error
 
+    
+    
+  
+  
+  
+  image-link-fedora:
+    runs-on: ubuntu-latest
+    needs: publish-fedora
+    steps:
+      - uses: actions/checkout@v2
+      
+  
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
 
+      - name: Generate link for fedora
+        run: |
+            source .github/helpers.sh
+            PACKAGE_VERSION=$(cos_package_version)
+            export COS_VERSION="${PACKAGE_VERSION/+/-}"
+            echo "quay.io/costoolkit/releases-fedora:cos-system-${COS_VERSION}" > images-fedora.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: images-fedora.txt
+          path: |
+            images-fedora.txt
 
   
   
-  
-  
- 
-  
-  
-  
- 
-
   
   publish-fedora:
     runs-on: ubuntu-latest
-    
-    needs: build-fedora
-    
+    needs:
+    - build-fedora
     env:
       FLAVOR: fedora
       FINAL_REPO: quay.io/costoolkit/releases-fedora
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
     steps:
+      
+  
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
           name: build-fedora
           path: build
-      - run: |
-          git fetch --prune --unshallow
-
-      - name: setup-docker
-        uses: docker-practice/actions-setup-docker@master
-
-      # We patch docker to use all the HD available in GH action free runners
-      - name: Patch Docker Daemon data-root
-        run: |
-          DOCKER_DATA_ROOT='/mnt/var/lib/docker'
-          DOCKER_DAEMON_JSON='/etc/docker/daemon.json'
-          sudo mkdir -p "${DOCKER_DATA_ROOT}"
-          jq --arg dataroot "${DOCKER_DATA_ROOT}" '. + {"data-root": $dataroot}' "${DOCKER_DAEMON_JSON}" > "/tmp/docker.json.tmp"
-          sudo mv "/tmp/docker.json.tmp" "${DOCKER_DAEMON_JSON}"
-          sudo systemctl restart docker
-
-    
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
-    
-
-      - name: Install deps
+      
+  
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
-    
+          sudo luet install -y toolchain/yq
+
       - name: Install Go
         uses: actions/setup-go@v2
-    
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -797,116 +1032,86 @@ jobs:
         run: |
           sudo -E make publish-repo
 
-  github-release-fedora:
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    
-    needs: build-fedora
-    
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download ISO
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-fedora.iso.zip
-          path: release
-      - name: Download vagrant box
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-fedora-vbox.box
-          path: release
-      - name: Download OVA image
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-fedora.ova
-          path: release
-      - name: Download QCOW image
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-fedora.qcow
-          path: release
-      - name: Release
-        uses: fnkr/github-action-ghr@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GHR_PATH: release/
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
-
   
-
+  
   
   docker-build-ubuntu:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: ubuntu
-
     steps:
+      
   
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
+
       - name: Build  🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source .envrc
           cos-build $FLAVOR
 
-
+  
+  
+  
   build-ubuntu:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: ubuntu
       FINAL_REPO: quay.io/costoolkit/releases-ubuntu
       DOWNLOAD_METADATA: false
       PUSH_CACHE: true
+      REPO_CACHE: quay.io/costoolkit/build-ubuntu-cache
     steps:
-  
-
+      
   
       - name: Install Go
         uses: actions/setup-go@v2
+
+      
   
-
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
 
-  
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      
   
-
-      - name: Install deps
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
+          sudo luet install -y toolchain/yq
 
-      - name: Validate 🌳
+      
+  
+  
+      - name: Run make validate
         run: |
-          make validate
+          sudo -E make validate
 
       - name: Build packages 🔧
         run: |
@@ -918,7 +1123,6 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
-  
       - name: Generate manifests
         run: |
           for f in build/*tar*; do
@@ -932,10 +1136,13 @@ jobs:
             BASE_NAME=`basename -s .package.tar.zst.mtree $f`
             sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
           done
+      
   
-      - name: Create repo
+  
+      - name: Run make create-repo
         run: |
           sudo -E make create-repo
+
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
@@ -943,64 +1150,78 @@ jobs:
           path: build
           if-no-files-found: error
 
+    
+    
+  
+  
+  
+  image-link-ubuntu:
+    runs-on: ubuntu-latest
+    needs: publish-ubuntu
+    steps:
+      - uses: actions/checkout@v2
+      
+  
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
 
+      - name: Generate link for ubuntu
+        run: |
+            source .github/helpers.sh
+            PACKAGE_VERSION=$(cos_package_version)
+            export COS_VERSION="${PACKAGE_VERSION/+/-}"
+            echo "quay.io/costoolkit/releases-ubuntu:cos-system-${COS_VERSION}" > images-ubuntu.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: images-ubuntu.txt
+          path: |
+            images-ubuntu.txt
 
   
   
-  
-  
- 
-  
-  
-  
- 
-
   
   publish-ubuntu:
     runs-on: ubuntu-latest
-    
-    needs: build-ubuntu
-    
+    needs:
+    - build-ubuntu
     env:
       FLAVOR: ubuntu
       FINAL_REPO: quay.io/costoolkit/releases-ubuntu
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
     steps:
+      
+  
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
           name: build-ubuntu
           path: build
-      - run: |
-          git fetch --prune --unshallow
-
-      - name: setup-docker
-        uses: docker-practice/actions-setup-docker@master
-
-      # We patch docker to use all the HD available in GH action free runners
-      - name: Patch Docker Daemon data-root
-        run: |
-          DOCKER_DATA_ROOT='/mnt/var/lib/docker'
-          DOCKER_DAEMON_JSON='/etc/docker/daemon.json'
-          sudo mkdir -p "${DOCKER_DATA_ROOT}"
-          jq --arg dataroot "${DOCKER_DATA_ROOT}" '. + {"data-root": $dataroot}' "${DOCKER_DAEMON_JSON}" > "/tmp/docker.json.tmp"
-          sudo mv "/tmp/docker.json.tmp" "${DOCKER_DAEMON_JSON}"
-          sudo systemctl restart docker
-
-    
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
-    
-
-      - name: Install deps
+      
+  
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
-    
+          sudo luet install -y toolchain/yq
+
       - name: Install Go
         uses: actions/setup-go@v2
-    
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -1013,46 +1234,9 @@ jobs:
         run: |
           sudo -E make publish-repo
 
-  github-release-ubuntu:
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    
-    needs: build-ubuntu
-    
-    steps:
-      - uses: actions/checkout@v2
-      - name: Download ISO
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-ubuntu.iso.zip
-          path: release
-      - name: Download vagrant box
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-ubuntu-vbox.box
-          path: release
-      - name: Download OVA image
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-ubuntu.ova
-          path: release
-      - name: Download QCOW image
-        uses: actions/download-artifact@v2
-        with:
-          name: cOS-ubuntu.qcow
-          path: release
-      - name: Release
-        uses: fnkr/github-action-ghr@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GHR_PATH: release/
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
 
   
-
-
-
+  
   # We need only a single vanilla image for any OS
   # Vanilla image is always based on openSUSE
   publish-vanilla-ami:
@@ -1061,12 +1245,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install deps
+      
+  
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
-      - name: Export cOS version
+          sudo luet install -y toolchain/yq
+
+      
+      - name: Export cos version
         run: |
-          echo "COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')" >> $GITHUB_ENV
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -1080,6 +1272,7 @@ jobs:
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Upload and publish vanilla image
         run: |
-          export git_sha="${GITHUB_SHA}"
+          export github_sha="${GITHUB_SHA}"
+          export COPY_AMI_ALL_REGIONS="true"
           make aws_vanilla_ami
 

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -1,4 +1,43 @@
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 name: Build cOS nightly
 
 on: 
@@ -11,77 +50,84 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
-
+  
+  
+  
   
   docker-build-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: opensuse
-
     steps:
+      
   
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
+
       - name: Build  🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source .envrc
           cos-build $FLAVOR
 
-
+  
+  
+  
   build-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: opensuse
       FINAL_REPO: quay.io/costoolkit/releases-opensuse
       DOWNLOAD_METADATA: false
       PUSH_CACHE: false
+      REPO_CACHE: quay.io/costoolkit/build-opensuse-cache
     steps:
-  
-
+      
   
       - name: Install Go
         uses: actions/setup-go@v2
+
+      
   
-
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
 
+      
   
-
-      - name: Install deps
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
+          sudo luet install -y toolchain/yq
 
-      - name: Validate 🌳
+      
+  
+  
+      - name: Run make validate
         run: |
-          make validate
+          sudo -E make validate
 
       - name: Build packages 🔧
         run: |
@@ -93,10 +139,13 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
+      
   
-      - name: Create repo
+  
+      - name: Run make create-repo
         run: |
           sudo -E make create-repo
+
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
@@ -104,21 +153,33 @@ jobs:
           path: build
           if-no-files-found: error
 
-
-
+    
   
   
   
-
+  
   iso-squashfs-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     needs: build-opensuse
     env:
       FINAL_REPO: quay.io/costoolkit/releases-opensuse
     steps:
+      
+  
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -128,31 +189,30 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y xorriso squashfs-tools
-          sudo -E make deps
+      
   
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
+
+      
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+
       - name: Build ISO from local build 🔧
         if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
         run: |
-          MANIFEST=manifest.yaml
-          cp -rf $MANIFEST $MANIFEST.remote
-          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
-          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
-          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
-          sudo -E MANIFEST=$MANIFEST.remote make local-iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          source .github/helpers.sh
+          create_remote_manifest manifest.yaml
+          sudo -E MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" MANIFEST=manifest.yaml.remote make local-iso
       - name: Build ISO from remote repositories 🔧
         if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
         run: |
-          sudo -E make iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          sudo -E YQ=/usr/bin/yq MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" make iso
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-squashfs-opensuse.iso.zip
@@ -160,6 +220,11 @@ jobs:
             *.iso
             *.sha256
           if-no-files-found: error
+
+  
+  
+  
+  
   qemu-squashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-squashfs-opensuse
@@ -172,9 +237,13 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
+          brew install yq@3
       - name: Build QEMU Image 🔧
         run: |
-          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -var='feature=vagrant' -only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-squashfs-opensuse.qcow
@@ -187,6 +256,11 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
+  
+  
   vbox-squashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-squashfs-opensuse
@@ -201,9 +275,15 @@ jobs:
       #   run: |
       #     brew tap hashicorp/tap
       #     brew install hashicorp/tap/packer
+      - name: Install deps
+        run: |
+            brew install yq@3
       - name: Build VBox Image 🔧
         run: |
-          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -only virtualbox-iso.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-squashfs-opensuse.ova
@@ -216,6 +296,9 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
   
   
   tests-squashfs-opensuse:
@@ -260,20 +343,33 @@ jobs:
           path: tests/serial_port1
           if-no-files-found: warn
 
+    
   
- 
   
   
-
+  
   iso-nonsquashfs-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     needs: build-opensuse
     env:
       FINAL_REPO: quay.io/costoolkit/releases-opensuse
     steps:
+      
+  
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -283,35 +379,34 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y xorriso squashfs-tools
-          sudo -E make deps
+      
   
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
+
       - name: Tweak manifest and drop squashfs recovery
         run: |
-          yq d -i manifest.yaml 'packages.isoimage(.==recovery/cos-img)'
-  
+          source .github/helpers.sh
+          drop_recovery manifest.yaml
+      
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+
       - name: Build ISO from local build 🔧
         if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
         run: |
-          MANIFEST=manifest.yaml
-          cp -rf $MANIFEST $MANIFEST.remote
-          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
-          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
-          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
-          sudo -E MANIFEST=$MANIFEST.remote make local-iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          source .github/helpers.sh
+          create_remote_manifest manifest.yaml
+          sudo -E MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" MANIFEST=manifest.yaml.remote make local-iso
       - name: Build ISO from remote repositories 🔧
         if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
         run: |
-          sudo -E make iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          sudo -E YQ=/usr/bin/yq MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" make iso
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-nonsquashfs-opensuse.iso.zip
@@ -319,6 +414,11 @@ jobs:
             *.iso
             *.sha256
           if-no-files-found: error
+
+  
+  
+  
+  
   qemu-nonsquashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-nonsquashfs-opensuse
@@ -331,9 +431,13 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
+          brew install yq@3
       - name: Build QEMU Image 🔧
         run: |
-          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -var='feature=vagrant' -only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-nonsquashfs-opensuse.qcow
@@ -346,6 +450,11 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
+  
+  
   vbox-nonsquashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-nonsquashfs-opensuse
@@ -360,9 +469,15 @@ jobs:
       #   run: |
       #     brew tap hashicorp/tap
       #     brew install hashicorp/tap/packer
+      - name: Install deps
+        run: |
+            brew install yq@3
       - name: Build VBox Image 🔧
         run: |
-          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -only virtualbox-iso.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-nonsquashfs-opensuse.ova
@@ -375,6 +490,9 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
   
   
   tests-nonsquashfs-opensuse:
@@ -420,21 +538,18 @@ jobs:
           if-no-files-found: warn
 
   
- 
-
   
-
   
-
   raw-images-opensuse:
     runs-on: ubuntu-latest
     container: opensuse/leap:15.3
-    needs: build-opensuse
+    needs:
+    - build-opensuse
 
     steps:
       - name: Install OS deps
         run: |
-          zypper in -y bc qemu-tools curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
+          zypper in -y bc qemu-tools sudo curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
       - uses: actions/checkout@v2
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -446,115 +561,143 @@ jobs:
           # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the continer
           rm -rf /var/lock
           mkdir -p /var/lock
-          make deps
+      
+  
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
+
+      
       - name: Export cos version
         run: |
-          echo "COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')" >> $GITHUB_ENV
-      - name: Build raw image
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+
+      
+  
+  
+      - name: Run make raw_disk
         run: |
-          make raw_disk
-      - name: Build Azure image
+          sudo -E make raw_disk
+
+      
+  
+  
+      - name: Run make azure_disk
         run: |
-          make azure_disk
-      - name: Build GCE image
+          sudo -E make azure_disk
+
+      
+  
+  
+      - name: Run make gce_disk
         run: |
-          make gce_disk
+          sudo -E make gce_disk
+
       - name: Rename images
         run: |
-          mv disk.raw cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
-          mv disk.vhd cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
-          mv disk.raw.tar.gz cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
+          mv disk.raw cOS-Vanilla-RAW-opensuse-${{ env.COS_VERSION }}.raw
+          mv disk.vhd cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.vhd
+          mv disk.raw.tar.gz cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.tar.gz
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          name: cOS-Vanilla-RAW-opensuse-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
+            cOS-Vanilla-RAW-opensuse-${{ env.COS_VERSION }}.raw
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          name: cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
+            cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.vhd
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-GCE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          name: cOS-Vanilla-GCE-opensuse-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
+            cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.tar.gz
           if-no-files-found: error
 
-    
   
-
+  
+  
   
   docker-build-fedora:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: fedora
-
     steps:
+      
   
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
+
       - name: Build  🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source .envrc
           cos-build $FLAVOR
 
-
+  
+  
+  
   build-fedora:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: fedora
       FINAL_REPO: quay.io/costoolkit/releases-fedora
       DOWNLOAD_METADATA: false
       PUSH_CACHE: false
+      REPO_CACHE: quay.io/costoolkit/build-fedora-cache
     steps:
-  
-
+      
   
       - name: Install Go
         uses: actions/setup-go@v2
+
+      
   
-
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
 
+      
   
-
-      - name: Install deps
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
+          sudo luet install -y toolchain/yq
 
-      - name: Validate 🌳
+      
+  
+  
+      - name: Run make validate
         run: |
-          make validate
+          sudo -E make validate
 
       - name: Build packages 🔧
         run: |
@@ -566,10 +709,13 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
+      
   
-      - name: Create repo
+  
+      - name: Run make create-repo
         run: |
           sudo -E make create-repo
+
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
@@ -577,91 +723,86 @@ jobs:
           path: build
           if-no-files-found: error
 
-
-
+    
+    
   
   
   
-  
- 
-  
-  
-  
- 
-
-  
-
-  
-
   
   docker-build-ubuntu:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: ubuntu
-
     steps:
+      
   
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
+
       - name: Build  🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source .envrc
           cos-build $FLAVOR
 
-
+  
+  
+  
   build-ubuntu:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: ubuntu
       FINAL_REPO: quay.io/costoolkit/releases-ubuntu
       DOWNLOAD_METADATA: false
       PUSH_CACHE: false
+      REPO_CACHE: quay.io/costoolkit/build-ubuntu-cache
     steps:
-  
-
+      
   
       - name: Install Go
         uses: actions/setup-go@v2
+
+      
   
-
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
 
+      
   
-
-      - name: Install deps
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
+          sudo luet install -y toolchain/yq
 
-      - name: Validate 🌳
+      
+  
+  
+      - name: Run make validate
         run: |
-          make validate
+          sudo -E make validate
 
       - name: Build packages 🔧
         run: |
@@ -673,10 +814,13 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
+      
   
-      - name: Create repo
+  
+      - name: Run make create-repo
         run: |
           sudo -E make create-repo
+
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
@@ -684,21 +828,5 @@ jobs:
           path: build
           if-no-files-found: error
 
-
-
-  
-  
-  
-  
- 
-  
-  
-  
- 
-
-  
-
-  
-
-
-
+    
+    

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -1,4 +1,43 @@
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 name: Build cOS Pull requests
 
 on: 
@@ -17,77 +56,84 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
-
+  
+  
+  
   
   docker-build-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: opensuse
-
     steps:
+      
   
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
+
       - name: Build  🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source .envrc
           cos-build $FLAVOR
 
-
+  
+  
+  
   build-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: opensuse
       FINAL_REPO: quay.io/costoolkit/releases-opensuse
       DOWNLOAD_METADATA: false
       PUSH_CACHE: false
+      REPO_CACHE: quay.io/costoolkit/build-opensuse-cache
     steps:
-  
-
+      
   
       - name: Install Go
         uses: actions/setup-go@v2
+
+      
   
-
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
 
+      
   
-
-      - name: Install deps
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
+          sudo luet install -y toolchain/yq
 
-      - name: Validate 🌳
+      
+  
+  
+      - name: Run make validate
         run: |
-          make validate
+          sudo -E make validate
 
       - name: Build packages 🔧
         run: |
@@ -99,10 +145,13 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
+      
   
-      - name: Create repo
+  
+      - name: Run make create-repo
         run: |
           sudo -E make create-repo
+
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
@@ -110,21 +159,33 @@ jobs:
           path: build
           if-no-files-found: error
 
-
-
+    
   
   
   
-
+  
   iso-squashfs-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     needs: build-opensuse
     env:
       FINAL_REPO: quay.io/costoolkit/releases-opensuse
     steps:
+      
+  
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -134,31 +195,30 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y xorriso squashfs-tools
-          sudo -E make deps
+      
   
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
+
+      
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+
       - name: Build ISO from local build 🔧
         if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
         run: |
-          MANIFEST=manifest.yaml
-          cp -rf $MANIFEST $MANIFEST.remote
-          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
-          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
-          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
-          sudo -E MANIFEST=$MANIFEST.remote make local-iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          source .github/helpers.sh
+          create_remote_manifest manifest.yaml
+          sudo -E MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" MANIFEST=manifest.yaml.remote make local-iso
       - name: Build ISO from remote repositories 🔧
         if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
         run: |
-          sudo -E make iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          sudo -E YQ=/usr/bin/yq MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" make iso
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-squashfs-opensuse.iso.zip
@@ -166,6 +226,11 @@ jobs:
             *.iso
             *.sha256
           if-no-files-found: error
+
+  
+  
+  
+  
   qemu-squashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-squashfs-opensuse
@@ -178,9 +243,13 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
+          brew install yq@3
       - name: Build QEMU Image 🔧
         run: |
-          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -var='feature=vagrant' -only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-squashfs-opensuse.qcow
@@ -193,6 +262,11 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
+  
+  
   vbox-squashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-squashfs-opensuse
@@ -207,9 +281,15 @@ jobs:
       #   run: |
       #     brew tap hashicorp/tap
       #     brew install hashicorp/tap/packer
+      - name: Install deps
+        run: |
+            brew install yq@3
       - name: Build VBox Image 🔧
         run: |
-          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -only virtualbox-iso.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-squashfs-opensuse.ova
@@ -222,6 +302,9 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
   
   
   tests-squashfs-opensuse:
@@ -266,20 +349,33 @@ jobs:
           path: tests/serial_port1
           if-no-files-found: warn
 
+    
   
- 
   
   
-
+  
   iso-nonsquashfs-opensuse:
+    
   
     runs-on: ubuntu-latest
   
+
     needs: build-opensuse
     env:
       FINAL_REPO: quay.io/costoolkit/releases-opensuse
     steps:
+      
+  
       - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: setup-docker
+        uses: docker-practice/actions-setup-docker@master
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -289,35 +385,34 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y xorriso squashfs-tools
-          sudo -E make deps
+      
   
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
+
       - name: Tweak manifest and drop squashfs recovery
         run: |
-          yq d -i manifest.yaml 'packages.isoimage(.==recovery/cos-img)'
-  
+          source .github/helpers.sh
+          drop_recovery manifest.yaml
+      
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+
       - name: Build ISO from local build 🔧
         if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/')
         run: |
-          MANIFEST=manifest.yaml
-          cp -rf $MANIFEST $MANIFEST.remote
-          yq w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].enable' true
-          yq w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
-          yq w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
-          yq w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
-          sudo -E MANIFEST=$MANIFEST.remote make local-iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          source .github/helpers.sh
+          create_remote_manifest manifest.yaml
+          sudo -E MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" MANIFEST=manifest.yaml.remote make local-iso
       - name: Build ISO from remote repositories 🔧
         if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/')
         run: |
-          sudo -E make iso
-          COS_VERSION=$(yq r packages/cos/collection.yaml 'version')
-          mv *.iso cOS-$COS_VERSION.iso
-          mv *.sha256 cOS-$COS_VERSION.iso.sha256
-
+          sudo -E YQ=/usr/bin/yq MAKEISO_ARGS="--output cOS-opensuse-${{ env.COS_VERSION }}" make iso
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-nonsquashfs-opensuse.iso.zip
@@ -325,6 +420,11 @@ jobs:
             *.iso
             *.sha256
           if-no-files-found: error
+
+  
+  
+  
+  
   qemu-nonsquashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-nonsquashfs-opensuse
@@ -337,9 +437,13 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
+          brew install yq@3
       - name: Build QEMU Image 🔧
         run: |
-          PACKER_ARGS="-var='accelerator=hvf' -var='feature=vagrant' -only qemu.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -var='feature=vagrant' -only qemu.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-nonsquashfs-opensuse.qcow
@@ -352,6 +456,11 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
+  
+  
   vbox-nonsquashfs-opensuse:
     runs-on: macos-10.15
     needs: iso-nonsquashfs-opensuse
@@ -366,9 +475,15 @@ jobs:
       #   run: |
       #     brew tap hashicorp/tap
       #     brew install hashicorp/tap/packer
+      - name: Install deps
+        run: |
+            brew install yq@3
       - name: Build VBox Image 🔧
         run: |
-          PACKER_ARGS="-var='feature=vagrant' -only virtualbox-iso.cos" make packer
+          export YQ=/usr/local/opt/yq@3/bin/yq
+          source .github/helpers.sh
+          COS_VERSION=$(cos_version)
+          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=opensuse' -only virtualbox-iso.cos" make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-nonsquashfs-opensuse.ova
@@ -381,6 +496,9 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+
+  
+  
   
   
   tests-nonsquashfs-opensuse:
@@ -426,21 +544,18 @@ jobs:
           if-no-files-found: warn
 
   
- 
-
   
-
   
-
   raw-images-opensuse:
     runs-on: ubuntu-latest
     container: opensuse/leap:15.3
-    needs: build-opensuse
+    needs:
+    - build-opensuse
 
     steps:
       - name: Install OS deps
         run: |
-          zypper in -y bc qemu-tools curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
+          zypper in -y bc qemu-tools sudo curl e2fsprogs dosfstools mtools squashfs gptfdisk make tar gzip xz which
       - uses: actions/checkout@v2
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -452,115 +567,143 @@ jobs:
           # Since some time /var/lock is a symlink to /run/lock, which doesn't exit in the continer
           rm -rf /var/lock
           mkdir -p /var/lock
-          make deps
+      
+  
+  
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install -y toolchain/yq
+
+      
       - name: Export cos version
         run: |
-          echo "COS_VERSION=$(yq r packages/cos/collection.yaml 'packages.[0].version')" >> $GITHUB_ENV
-      - name: Build raw image
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+
+      
+  
+  
+      - name: Run make raw_disk
         run: |
-          make raw_disk
-      - name: Build Azure image
+          sudo -E make raw_disk
+
+      
+  
+  
+      - name: Run make azure_disk
         run: |
-          make azure_disk
-      - name: Build GCE image
+          sudo -E make azure_disk
+
+      
+  
+  
+      - name: Run make gce_disk
         run: |
-          make gce_disk
+          sudo -E make gce_disk
+
       - name: Rename images
         run: |
-          mv disk.raw cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
-          mv disk.vhd cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
-          mv disk.raw.tar.gz cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
+          mv disk.raw cOS-Vanilla-RAW-opensuse-${{ env.COS_VERSION }}.raw
+          mv disk.vhd cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.vhd
+          mv disk.raw.tar.gz cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.tar.gz
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          name: cOS-Vanilla-RAW-opensuse-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-RAW-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.raw
+            cOS-Vanilla-RAW-opensuse-${{ env.COS_VERSION }}.raw
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          name: cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.vhd
+            cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.vhd
           if-no-files-found: error
       - uses: actions/upload-artifact@v2
         with:
-          name: cOS-Vanilla-GCE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}
+          name: cOS-Vanilla-GCE-opensuse-${{ env.COS_VERSION }}
           path: |
-            cOS-Vanilla-AZURE-${{ env.COS_VERSION }}-opensuse-${{ github.sha }}.tar.gz
+            cOS-Vanilla-AZURE-opensuse-${{ env.COS_VERSION }}.tar.gz
           if-no-files-found: error
 
-    
   
-
+  
+  
   
   docker-build-fedora:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: fedora
-
     steps:
+      
   
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
+
       - name: Build  🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source .envrc
           cos-build $FLAVOR
 
-
+  
+  
+  
   build-fedora:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: fedora
       FINAL_REPO: quay.io/costoolkit/releases-fedora
       DOWNLOAD_METADATA: false
       PUSH_CACHE: false
+      REPO_CACHE: quay.io/costoolkit/build-fedora-cache
     steps:
-  
-
+      
   
       - name: Install Go
         uses: actions/setup-go@v2
+
+      
   
-
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
 
+      
   
-
-      - name: Install deps
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
+          sudo luet install -y toolchain/yq
 
-      - name: Validate 🌳
+      
+  
+  
+      - name: Run make validate
         run: |
-          make validate
+          sudo -E make validate
 
       - name: Build packages 🔧
         run: |
@@ -572,10 +715,13 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
+      
   
-      - name: Create repo
+  
+      - name: Run make create-repo
         run: |
           sudo -E make create-repo
+
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
@@ -583,91 +729,86 @@ jobs:
           path: build
           if-no-files-found: error
 
-
-
+    
+    
   
   
   
-  
- 
-  
-  
-  
- 
-
-  
-
-  
-
   
   docker-build-ubuntu:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: ubuntu
-
     steps:
+      
   
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
+
       - name: Build  🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
           source .envrc
           cos-build $FLAVOR
 
-
+  
+  
+  
   build-ubuntu:
+    
   
     runs-on: ubuntu-latest
   
+
     env:
       FLAVOR: ubuntu
       FINAL_REPO: quay.io/costoolkit/releases-ubuntu
       DOWNLOAD_METADATA: false
       PUSH_CACHE: false
+      REPO_CACHE: quay.io/costoolkit/build-ubuntu-cache
     steps:
-  
-
+      
   
       - name: Install Go
         uses: actions/setup-go@v2
+
+      
   
-
       - uses: actions/checkout@v2
-
       - run: |
           git fetch --prune --unshallow
-
-  
       - name: setup-docker
         uses: docker-practice/actions-setup-docker@master
       - name: Release space from worker
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-  
 
+      
   
-
-      - name: Install deps
+  
+      - name: Run make deps
         run: |
           sudo -E make deps
+          sudo luet install -y toolchain/yq
 
-      - name: Validate 🌳
+      
+  
+  
+      - name: Run make validate
         run: |
-          make validate
+          sudo -E make validate
 
       - name: Build packages 🔧
         run: |
@@ -679,10 +820,13 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
+      
   
-      - name: Create repo
+  
+      - name: Run make create-repo
         run: |
           sudo -E make create-repo
+
       - name: Upload results
         uses: actions/upload-artifact@v2
         with:
@@ -690,21 +834,5 @@ jobs:
           path: build
           if-no-files-found: error
 
-
-
-  
-  
-  
-  
- 
-  
-  
-  
- 
-
-  
-
-  
-
-
-
+    
+    

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -3,6 +3,7 @@
 #
 #
 
+MAKEISO_ARGS?=
 MKSQUASHFS?=$(shell which mksquashfs 2> /dev/null)
 ifeq ("$(MKSQUASHFS)","")
 MKSQUASHFS="/usr/bin/mksquashfs"
@@ -76,7 +77,7 @@ endif
 ifneq ("$(ISO)","")
 	@echo "'$(ISO) exists, run 'make clean_iso' folled by 'make $@' to recreate"
 else
-	$(LUET) makeiso -- $(MANIFEST) --local $(DESTINATION)
+	$(LUET) makeiso -- $(MAKEISO_ARGS) $(MANIFEST) --local $(DESTINATION)
 endif
 
 .PHONY: iso
@@ -93,7 +94,7 @@ else
 	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].enable' true
 	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].type' 'docker'
 	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].urls[0]' $(FINAL_REPO)
-	$(LUET) makeiso $(MANIFEST).remote
+	$(LUET) makeiso -- $(MAKEISO_ARGS) $(MANIFEST).remote
 endif
 
 

--- a/packer/images.json.pkr.hcl
+++ b/packer/images.json.pkr.hcl
@@ -178,10 +178,10 @@ build {
 
   post-processor "vagrant" {
     only   = ["virtualbox-iso.cos", "qemu.cos"]
-    output = "cOS_${var.build}_${var.arch}_${var.flavor}.box"
+    output = "cOS_${var.flavor}_${var.build}_${var.arch}.box"
   }
   post-processor "compress" {
     only   = ["virtualbox-iso.cos", "qemu.cos"]
-    output = "cOS_${var.build}_${var.arch}_${var.flavor}.tar.gz"
+    output = "cOS_${var.flavor}_${var.build}_${var.arch}.tar.gz"
   }
 }

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -209,6 +209,7 @@ variable "gcp_cos_deploy_args" {
 variable "gcp_project_id" {
   type = string
   description = "Project to look for the image family"
+  default = env("GCP_PROJECT_ID")
 }
 
 variable "cos_version" {


### PR DESCRIPTION
- Split pipeline into template blocks
- Rework how versioning is constructed in the CI, adds a `helpers.sh` file to collect common code around versioning generation and it's used across the CI blocks
- Various minor fixes
- Release job now collects all artifacts including a txt file which is generated pointing to the generated final image of cOS
- Fixes packer builds https://github.com/rancher-sandbox/cOS-toolkit/pull/433/commits/118d8298e434bd5644a3fe51747c1d37616ae929

Part of #379 