### PR TITLE
ci: Drop yq from VM in autobump pipeline

### DIFF
--- a/.github/workflows/autobump.yaml
+++ b/.github/workflows/autobump.yaml
@@ -34,6 +34,7 @@ jobs:
           RESET_BRANCH: ${{ matrix.upstream_branch }}
         name: Autobump ${{matrix.name}}
         run: |
+                sudo rm -rf /usr/local/bin/yq
                 curl https://get.mocaccino.org/luet/get_luet_root.sh | sudo sh
                 sudo luet install -y repository/mocaccino-extra
                 sudo luet install -y system/luet-extensions system/luet-devkit utils/jq utils/yq vcs/hub


### PR DESCRIPTION
Fixes the autobump job. Apparently Github added `yq` to the VMs and that's version 4. Ties to #157 
Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>