### PR TITLE
Fix recovery upgrades

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "cos"
     category: "system"
-    version: 0.5.8+4
+    version: 0.5.8+6
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -9,7 +9,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos"
     category: "recovery"
-    version: 0.5.8+4
+    version: 0.5.8+6
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
     labels:
@@ -17,7 +17,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos-container"
     category: "system"
-    version: 0.5.8+5
+    version: 0.5.8+6
     brand_name: "cOS"
     description: "cOS container image, used to build cOS derivatives from scratch"
     labels:

--- a/packages/cos/recovery-img/definition.yaml
+++ b/packages/cos/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: 0.5.8+5
+version: 0.5.8+6
 brand_name: "cOS"

--- a/packages/cos/recovery-img/squash/definition.yaml
+++ b/packages/cos/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: 0.5.8+5
+version: 0.5.8+6

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: 0.8+9
+version: "0.9"

--- a/packages/installer/deploy.sh
+++ b/packages/installer/deploy.sh
@@ -40,6 +40,10 @@ find_upgrade_channel() {
         source /etc/cos-upgrade-image
     fi
 
+    if [ -n "$NO_CHANNEL" ] && [ $NO_CHANNEL == true ]; then
+        CHANNEL_UPGRADES=false
+    fi
+
     if [ -n "$IMAGE" ]; then
         UPGRADE_IMAGE=$IMAGE
         echo "Upgrading to image $UPGRADE_IMAGE"
@@ -184,12 +188,10 @@ usage()
     exit 1
 }
 
-find_upgrade_channel
-
 while [ "$#" -gt 0 ]; do
     case $1 in
         --docker-image)
-            CHANNEL_UPGRADES=false
+            NO_CHANNEL=true
             ;;
         --no-verify)
             VERIFY=false
@@ -207,12 +209,14 @@ while [ "$#" -gt 0 ]; do
             if [ "$#" -gt 2 ]; then
                 usage
             fi
-            UPGRADE_IMAGE=$1
+            IMAGE=$1
             break
             ;;
     esac
     shift 1
 done
+
+find_upgrade_channel
 
 trap cleanup exit
 

--- a/packages/installer/upgrade.sh
+++ b/packages/installer/upgrade.sh
@@ -58,17 +58,22 @@ find_upgrade_channel() {
         source /etc/cos-upgrade-image
     fi
 
+    if [ -n "$NO_CHANNEL" ] && [ $NO_CHANNEL == true ]; then
+        CHANNEL_UPGRADES=false
+    fi
+
     if [ -n "$IMAGE" ]; then
         UPGRADE_IMAGE=$IMAGE
         echo "Upgrading to image $UPGRADE_IMAGE"
-    fi
+    else
 
-    if [ -z "$UPGRADE_IMAGE" ]; then
-        UPGRADE_IMAGE="system/cos"
-    fi
+        if [ -z "$UPGRADE_IMAGE" ]; then
+            UPGRADE_IMAGE="system/cos"
+        fi
 
-    if [ -n "$UPGRADE_RECOVERY" ] && [ $UPGRADE_RECOVERY == true ] && [ -n "$RECOVERY_IMAGE" ]; then
-        UPGRADE_IMAGE=$RECOVERY_IMAGE
+        if [ -n "$UPGRADE_RECOVERY" ] && [ $UPGRADE_RECOVERY == true ] && [ -n "$RECOVERY_IMAGE" ]; then
+            UPGRADE_IMAGE=$RECOVERY_IMAGE
+        fi
     fi
 }
 
@@ -264,15 +269,13 @@ usage()
     exit 1
 }
 
-find_upgrade_channel
-
 while [ "$#" -gt 0 ]; do
     case $1 in
         --docker-image)
-            CHANNEL_UPGRADES=false
+            NO_CHANNEL=true
             ;;
         --directory)
-            CHANNEL_UPGRADES=false
+            NO_CHANNEL=true
             DIRECTORY=true
             ;;
         --recovery)
@@ -292,12 +295,14 @@ while [ "$#" -gt 0 ]; do
                 usage
             fi
             INTERACTIVE=true
-            UPGRADE_IMAGE=$1
+            IMAGE=$1
             break
             ;;
     esac
     shift 1
 done
+
+find_upgrade_channel
 
 trap cleanup exit
 
@@ -326,7 +331,6 @@ else
 fi
 
 echo "Flush changes to disk"
-sync
 sync
 
 if [ -n "$INTERACTIVE" ] && [ $INTERACTIVE == false ]; then


### PR DESCRIPTION
This commit fixes a bug related environment variables setting for
cos-upgrade command. `cos-upgrade --recovery` was not using
the recovery/cos image for upgrades since at the time the upgrade image
was evaluated and decided the `RECOVERY_UPGRADE` variable was not set
yet.

Signed-off-by: David Cassany <dcassany@suse.com>