### PR TITLE
Bump cOS to 0.6.1

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "cos"
     category: "system"
-    version: 0.6.0+2
+    version: "0.6.1"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -9,7 +9,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos"
     category: "recovery"
-    version: 0.6.0+2
+    version: "0.6.1"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
     labels:
@@ -17,7 +17,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos-container"
     category: "system"
-    version: 0.6.0+2
+    version: "0.6.1"
     brand_name: "cOS"
     description: "cOS container image, used to build cOS derivatives from scratch"
     labels:

--- a/packages/cos/recovery-img/definition.yaml
+++ b/packages/cos/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: 0.6.0+2
+version: "0.6.1"
 brand_name: "cOS"

--- a/packages/cos/recovery-img/squash/definition.yaml
+++ b/packages/cos/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: 0.6.0+2
+version: "0.6.1"


### PR DESCRIPTION
This is a bugfix release (https://github.com/rancher-sandbox/cOS-toolkit/commit/50e2590fae8a9c861b96968757474700f929d520)

Mostly featuring base-images and packages updates (luet 0.17.2). 
This release should also contain the GCE asset and the ISO with the correct name

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>