### PR TITLE
Update yq to 4.x

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -55,7 +55,11 @@
         run: |
           sudo -E make {{{ $target }}}
   {{{- if eq $target "deps" }}}
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          wget https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
   {{{- end }}}
 {{{end}}}
 

--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -210,10 +210,10 @@
       - name: Install deps
         run: |
           brew install qemu
-          brew install yq@3
+          brew install yq
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor={{{ $flavor }}}' -var='feature=vagrant' -only qemu.cos" make packer
@@ -251,10 +251,10 @@
       #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
-            brew install yq@3
+            brew install yq
       - name: Build VBox Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor={{{ $flavor }}}' -only virtualbox-iso.cos" make packer

--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -57,7 +57,7 @@
   {{{- if eq $target "deps" }}}
           # sudo luet install -y toolchain/yq
           # Until we have yq4 in our repos:
-          wget https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
           sudo mv yq_linux_amd64 /usr/bin/yq
           sudo chmod +x /usr/bin/yq
   {{{- end }}}

--- a/.github/helpers.sh
+++ b/.github/helpers.sh
@@ -4,7 +4,7 @@ set -e
 YQ="${YQ:-/usr/bin/yq}"
 
 cos_package_version() {
-    echo $($YQ r packages/cos/collection.yaml 'packages.[0].version')
+    echo $($YQ e '.packages.[0].version' packages/cos/collection.yaml)
 }
 
 cos_version() {
@@ -15,14 +15,14 @@ cos_version() {
 create_remote_manifest() {
     MANIFEST=$1
     cp -rf $MANIFEST $MANIFEST.remote
-    $YQ w -i $MANIFEST.remote 'luet.repositories[0].name' 'cOS'
-    $YQ w -i $MANIFEST.remote 'luet.repositories[0].enable' true
-    $YQ w -i $MANIFEST.remote 'luet.repositories[0].priority' 90
-    $YQ w -i $MANIFEST.remote 'luet.repositories[0].type' 'docker'
-    $YQ w -i $MANIFEST.remote 'luet.repositories[0].urls[0]' $FINAL_REPO
+    $YQ e -i '.luet.repositories[0].name="cOS"' $MANIFEST.remote
+    $YQ e -i '.luet.repositories[0].enable=true' $MANIFEST.remote 
+    $YQ e -i '.luet.repositories[0].priority=90' $MANIFEST.remote 
+    $YQ e -i '.luet.repositories[0].type="docker"' $MANIFEST.remote 
+    $YQ e -i ".luet.repositories[0].urls[0]=\"$FINAL_REPO\"" $MANIFEST.remote 
 }
 
 drop_recovery() {
     MANIFEST=$1
-    $YQ d -i $MANIFEST 'packages.isoimage(.==recovery/cos-img)'
+    $YQ e -i 'del( .packages.isoimage[] | select(.=="recovery/cos-img") )' $MANIFEST 
 }

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -123,7 +123,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   
@@ -211,7 +215,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
       - name: Export cos version
@@ -253,10 +261,10 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
-          brew install yq@3
+          brew install yq
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -var='feature=vagrant' -only qemu.cos" make packer
@@ -293,10 +301,10 @@ jobs:
       #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
-            brew install yq@3
+            brew install yq
       - name: Build VBox Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -only virtualbox-iso.cos" make packer
@@ -401,7 +409,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -447,10 +459,10 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
-          brew install yq@3
+          brew install yq
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -var='feature=vagrant' -only qemu.cos" make packer
@@ -487,10 +499,10 @@ jobs:
       #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
-            brew install yq@3
+            brew install yq
       - name: Build VBox Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -only virtualbox-iso.cos" make packer
@@ -567,7 +579,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Generate link for green
         run: |
@@ -618,7 +634,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Install Go
         uses: actions/setup-go@v2
@@ -664,7 +684,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
       - name: Export cos version
@@ -789,7 +813,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   
@@ -851,7 +879,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Generate link for blue
         run: |
@@ -903,7 +935,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Install Go
         uses: actions/setup-go@v2
@@ -991,7 +1027,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   
@@ -1053,7 +1093,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Generate link for orange
         run: |
@@ -1105,7 +1149,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -120,7 +120,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   
@@ -195,7 +199,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
       - name: Export cos version
@@ -237,10 +245,10 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
-          brew install yq@3
+          brew install yq
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -var='feature=vagrant' -only qemu.cos" make packer
@@ -277,10 +285,10 @@ jobs:
       #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
-            brew install yq@3
+            brew install yq
       - name: Build VBox Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -only virtualbox-iso.cos" make packer
@@ -385,7 +393,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -431,10 +443,10 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
-          brew install yq@3
+          brew install yq
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -var='feature=vagrant' -only qemu.cos" make packer
@@ -471,10 +483,10 @@ jobs:
       #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
-            brew install yq@3
+            brew install yq
       - name: Build VBox Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -only virtualbox-iso.cos" make packer
@@ -567,7 +579,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
       - name: Export cos version
@@ -690,7 +706,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   
@@ -795,7 +815,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -126,7 +126,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   
@@ -201,7 +205,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
       - name: Export cos version
@@ -243,10 +251,10 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
-          brew install yq@3
+          brew install yq
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -var='feature=vagrant' -only qemu.cos" make packer
@@ -283,10 +291,10 @@ jobs:
       #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
-            brew install yq@3
+            brew install yq
       - name: Build VBox Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -only virtualbox-iso.cos" make packer
@@ -391,7 +399,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -437,10 +449,10 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
-          brew install yq@3
+          brew install yq
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -var='feature=vagrant' -only qemu.cos" make packer
@@ -477,10 +489,10 @@ jobs:
       #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
-            brew install yq@3
+            brew install yq
       - name: Build VBox Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -only virtualbox-iso.cos" make packer
@@ -573,7 +585,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
       - name: Export cos version
@@ -696,7 +712,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   
@@ -801,7 +821,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   

--- a/.github/workflows/build-releases.yaml
+++ b/.github/workflows/build-releases.yaml
@@ -123,7 +123,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   
@@ -211,7 +215,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
       - name: Export cos version
@@ -253,10 +261,10 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
-          brew install yq@3
+          brew install yq
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -var='feature=vagrant' -only qemu.cos" make packer
@@ -293,10 +301,10 @@ jobs:
       #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
-            brew install yq@3
+            brew install yq
       - name: Build VBox Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -only virtualbox-iso.cos" make packer
@@ -401,7 +409,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -447,10 +459,10 @@ jobs:
       - name: Install deps
         run: |
           brew install qemu
-          brew install yq@3
+          brew install yq
       - name: Build QEMU Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='accelerator=hvf' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -var='feature=vagrant' -only qemu.cos" make packer
@@ -487,10 +499,10 @@ jobs:
       #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
-            brew install yq@3
+            brew install yq
       - name: Build VBox Image 🔧
         run: |
-          export YQ=/usr/local/opt/yq@3/bin/yq
+          export YQ=/usr/local/bin/yq
           source .github/helpers.sh
           COS_VERSION=$(cos_version)
           PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=amd64' -var='flavor=green' -only virtualbox-iso.cos" make packer
@@ -567,7 +579,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Generate link for green
         run: |
@@ -618,7 +634,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Install Go
         uses: actions/setup-go@v2
@@ -658,7 +678,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
       - name: Export cos version
@@ -744,7 +768,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
       - name: Export cos version
@@ -815,7 +843,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Build AMI for green
         run: |
@@ -900,7 +932,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   
@@ -962,7 +998,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Generate link for blue
         run: |
@@ -1014,7 +1054,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Install Go
         uses: actions/setup-go@v2
@@ -1102,7 +1146,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
   
@@ -1164,7 +1212,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Generate link for orange
         run: |
@@ -1216,7 +1268,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       - name: Install Go
         uses: actions/setup-go@v2
@@ -1249,7 +1305,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install -y toolchain/yq
+          # sudo luet install -y toolchain/yq
+          # Until we have yq4 in our repos:
+          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
+          sudo mv yq_linux_amd64 /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
 
       
       - name: Export cos version

--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -39,7 +39,7 @@ _VALIDATE_OPTIONS?=-s
 #
 # extract packages from yaml spec
 #
-PACKAGES?=$(shell yq r -j $(MANIFEST) | jq -r '.packages[],.build | .[]' | sort -u)
+PACKAGES?=$(shell yq e -j $(MANIFEST) | jq -r '.packages[],.build | .[]' | sort -u)
 
 ifeq ("$(PACKAGES)","")
 	BUILD_ARGS+=--all

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -90,10 +90,11 @@ ifneq ("$(ISO)","")
 	@echo "'$(ISO) exists, run 'make clean_iso' folled by 'make $@' to recreate"
 else
 	cp -rf $(MANIFEST) $(MANIFEST).remote
-	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].name' 'cOS'
-	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].enable' true
-	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].type' 'docker'
-	$(YQ) w -i $(MANIFEST).remote 'luet.repositories[0].urls[0]' $(FINAL_REPO)
+	$(YQ) e -i '.luet.repositories[0].name="cOS"' $(MANIFEST).remote
+	$(YQ) e -i '.luet.repositories[0].enable=true' $(MANIFEST).remote
+	$(YQ) e -i '.luet.repositories[0].priority=90' $(MANIFEST).remote
+	$(YQ) e -i '.luet.repositories[0].type="docker"' $(MANIFEST).remote
+	$(YQ) e -i ".luet.repositories[0].urls[0]=\"$(FINAL_REPO)\"" $(MANIFEST).remote
 	$(LUET) makeiso -- $(MAKEISO_ARGS) $(MANIFEST).remote
 endif
 

--- a/packages/toolchain/yq/build.yaml
+++ b/packages/toolchain/yq/build.yaml
@@ -21,7 +21,7 @@ prelude:
 - |
   PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
   mkdir -p /luetbuild/go/src/github.com/mikefarah && cd /luetbuild/go/src/github.com/mikefarah && \
-  git clone https://github.com/mikefarah/yq && cd yq && git checkout "${PACKAGE_VERSION}" -b build
+  git clone https://github.com/mikefarah/yq && cd yq && git checkout "v${PACKAGE_VERSION}" -b build
 steps:
   - |
     PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \

--- a/packages/toolchain/yq/definition.yaml
+++ b/packages/toolchain/yq/definition.yaml
@@ -1,6 +1,6 @@
 name: "yq"
 category: "toolchain"
-version: 3.4.1+19
+version: "4.11.2"
 arch: "amd64"
 uri:
   - https://github.com/mikefarah/yq
@@ -8,3 +8,6 @@ license: "MIT"
 labels:
   autobump.revdeps: "true"
   autobump.revbump_related: "system/cos recovery/cos recovery/cos-img recovery/cos-squash"
+  github.repo: "yq"
+  github.owner: "mikefarah"
+  autobump.strategy: "release"


### PR DESCRIPTION
Replaces yq 3.x with yq4.x.

This is part 1 of 2 of the series. As yq is used in the CI and shipped as part of this repo I need a follow up to pinpont `yq` to the CI.

See #470 


