### PR TITLE
Add runner CIDR to sec group when building aws

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -518,6 +518,9 @@
     steps:
       - uses: actions/checkout@v2
       {{{ tmpl.Exec "make" "deps" }}}
+      - name: Public IP
+        id: ip
+        uses: haythem/public-ip@v1.2
       - name: Build AMI for {{{ $flavor }}}
         run: |
             source .github/helpers.sh
@@ -527,6 +530,7 @@
             export PKR_VAR_cos_deploy_args="cos-deploy {{{ if (ne $flavor "green") }}}--no-verify {{{ end }}}--docker-image {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor={{{ $flavor }}}
             export PKR_VAR_git_sha="${GITHUB_SHA}"
+            export PKR_VAR_aws_temporary_security_group_source_cidr="${{ steps.ip.outputs.ipv4 }}/32"
             make packer-aws
 {{{ end }}}
 

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -119,11 +119,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   
@@ -209,11 +205,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
       - name: Export cos version
@@ -401,11 +393,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -571,11 +559,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Generate link for green
         run: |
@@ -624,11 +608,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Install Go
         uses: actions/setup-go@v2
@@ -674,11 +654,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
       - name: Export cos version
@@ -799,11 +775,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   
@@ -865,11 +837,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Generate link for blue
         run: |
@@ -919,11 +887,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Install Go
         uses: actions/setup-go@v2
@@ -1007,11 +971,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   
@@ -1073,11 +1033,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Generate link for orange
         run: |
@@ -1127,11 +1083,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -116,11 +116,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   
@@ -193,11 +189,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
       - name: Export cos version
@@ -385,11 +377,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -571,11 +559,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
       - name: Export cos version
@@ -694,11 +678,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   
@@ -799,11 +779,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -122,11 +122,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   
@@ -199,11 +195,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
       - name: Export cos version
@@ -391,11 +383,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -577,11 +565,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
       - name: Export cos version
@@ -700,11 +684,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   
@@ -805,11 +785,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   

--- a/.github/workflows/build-releases.yaml
+++ b/.github/workflows/build-releases.yaml
@@ -119,11 +119,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   
@@ -209,11 +205,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
       - name: Export cos version
@@ -401,11 +393,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -571,11 +559,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Generate link for green
         run: |
@@ -624,11 +608,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Install Go
         uses: actions/setup-go@v2
@@ -668,11 +648,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
       - name: Export cos version
@@ -758,11 +734,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
       - name: Export cos version
@@ -833,12 +805,11 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
+      - name: Public IP
+        id: ip
+        uses: haythem/public-ip@v1.2
       - name: Build AMI for green
         run: |
             source .github/helpers.sh
@@ -848,6 +819,7 @@ jobs:
             export PKR_VAR_cos_deploy_args="cos-deploy --docker-image quay.io/costoolkit/releases-green:cos-system-${COS_VERSION}"
             export PKR_VAR_flavor=green
             export PKR_VAR_git_sha="${GITHUB_SHA}"
+            export PKR_VAR_aws_temporary_security_group_source_cidr="${{ steps.ip.outputs.ipv4 }}/32"
             make packer-aws
 
   
@@ -918,11 +890,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   
@@ -984,11 +952,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Generate link for blue
         run: |
@@ -1038,11 +1002,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Install Go
         uses: actions/setup-go@v2
@@ -1126,11 +1086,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
   
@@ -1192,11 +1148,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Generate link for orange
         run: |
@@ -1246,11 +1198,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       - name: Install Go
         uses: actions/setup-go@v2
@@ -1283,11 +1231,7 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          # sudo luet install -y toolchain/yq
-          # Until we have yq4 in our repos:
-          curl -L https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_linux_amd64 -o yq_linux_amd64
-          sudo mv yq_linux_amd64 /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
+          sudo luet install -y toolchain/yq
 
       
       - name: Export cos version

--- a/packer/images.json.pkr.hcl
+++ b/packer/images.json.pkr.hcl
@@ -8,6 +8,7 @@ source "amazon-ebs" "cos" {
   secret_key      = var.aws_secret_key
   ssh_password    = var.root_password
   ssh_username    = var.root_username
+  temporary_security_group_source_cidrs = [var.aws_temporary_security_group_source_cidr ]
   source_ami_filter {
     filters = {
       name                = var.aws_source_ami_filter_name

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -80,6 +80,12 @@ variable "aws_user_data_file" {
   description = "Path to the user-data file to boot the base AMI with"
 }
 
+variable "aws_temporary_security_group_source_cidr" {
+  type = string
+  default = "0.0.0.0/0"
+  description = "A IPv4 CIDR to be authorized access to the instance, when packer is creating a temporary security group."
+}
+
 variable "azure_client_id" {
   type = string
   default = env("AZURE_CLIENT_ID")


### PR DESCRIPTION
So only the local runner has access to the building vm

yq changes appear because we forgot to run the pipelines when it was merged so we get them in this PR as a freebie :D

Closes #409 

Signed-off-by: Itxaka <igarcia@suse.com>