### PR TITLE
Add cloud config stages for installation/upgrade/deploy

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "cos"
     category: "system"
-    version: 0.6.2+1
+    version: "0.6.3"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -9,7 +9,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos"
     category: "recovery"
-    version: 0.6.2+1
+    version: "0.6.3"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
     labels:
@@ -17,7 +17,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos-container"
     category: "system"
-    version: "0.6.2"
+    version: "0.6.3"
     brand_name: "cOS"
     description: "cOS container image, used to build cOS derivatives from scratch"
     labels:

--- a/packages/cos/recovery-img/definition.yaml
+++ b/packages/cos/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: 0.6.2+1
+version: "0.6.3"
 brand_name: "cOS"

--- a/packages/cos/recovery-img/squash/definition.yaml
+++ b/packages/cos/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: 0.6.2+1
+version: "0.6.3"

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.10"
+version: "0.11"

--- a/packages/installer/deploy.sh
+++ b/packages/installer/deploy.sh
@@ -100,6 +100,8 @@ upgrade() {
     rm -rf $upgrade_state_dir || true
     mkdir -p $temp_upgrade
 
+    cos-setup before-deploy > /dev/null || true
+
     # FIXME: XDG_RUNTIME_DIR is for containerd, by default that points to /run/user/<uid>
     # which might not be sufficient to unpack images. Use /usr/local/tmp until we get a separate partition
     # for the state
@@ -125,6 +127,8 @@ upgrade() {
     fi
 
     SELinux_relabel
+
+    cos-setup after-deploy > /dev/null || true
 
     rm -rf $upgrade_state_dir
     umount $TARGET || true

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -369,6 +369,8 @@ validate_device
 
 trap cleanup exit
 
+cos-setup before-install > /dev/null || true
+
 setup_style
 do_format
 do_mount
@@ -381,6 +383,8 @@ umount_target 2>/dev/null
 
 prepare_recovery
 prepare_passive
+
+cos-setup after-install > /dev/null || true
 
 if [ -n "$INTERACTIVE" ]; then
     exit 0

--- a/packages/installer/reset.sh
+++ b/packages/installer/reset.sh
@@ -159,6 +159,8 @@ find_partitions
 
 do_mount
 
+cos-setup before-reset > /dev/null || true
+
 if [ -n "$PERSISTENCE_RESET" ] && [ "$PERSISTENCE_RESET" == "true" ]; then
     reset
 fi
@@ -166,3 +168,5 @@ fi
 copy_active
 
 install_grub
+
+cos-setup after-reset > /dev/null || true

--- a/packages/installer/upgrade.sh
+++ b/packages/installer/upgrade.sh
@@ -157,6 +157,8 @@ upgrade() {
     rm -rf $upgrade_state_dir || true
     mkdir -p $temp_upgrade
 
+    cos-setup before-upgrade > /dev/null || true
+
     # FIXME: XDG_RUNTIME_DIR is for containerd, by default that points to /run/user/<uid>
     # which might not be sufficient to unpack images. Use /usr/local/tmp until we get a separate partition
     # for the state
@@ -190,6 +192,8 @@ upgrade() {
 
     chmod 755 $TARGET
     SELinux_relabel
+
+    cos-setup after-upgrade > /dev/null || true
 
     rm -rf $upgrade_state_dir
     umount $TARGET || true


### PR DESCRIPTION
Adds after-install, after-deploy, after-upgrade, before-install,
before-deploy, before-upgrade as cloud-config stages. This means that
now cloud configuration files can hook into those stages as well for
further customization.

Fixes #154

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>