### PR TITLE
Add cos-minimal meta package

### DIFF
--- a/examples/standard/Dockerfile
+++ b/examples/standard/Dockerfile
@@ -66,13 +66,7 @@ COPY conf/luet.yaml /etc/luet/luet.yaml
 # Copy luet from the official images
 COPY --from=luet /usr/bin/luet /usr/bin/luet
 
-RUN luet install -y \
-    toolchain/yip \
-    utils/installer \
-    system/cos-setup \
-    system/immutable-rootfs \
-    system/grub-config \
-    system/cloud-config \
+RUN luet install -y meta/cos-minimal \
     utils/k9s \
     utils/nerdctl
 

--- a/packages/meta/collection.yaml
+++ b/packages/meta/collection.yaml
@@ -1,0 +1,26 @@
+packages:
+- category: "meta"
+  name: "cos-minimal"
+  version: "0.6.1"
+  requires:
+  - category: toolchain
+    name: yip
+    version: ">=0"
+  - category: utils
+    name: installer
+    version: ">=0"
+  - category: system
+    name: cos-setup
+    version: ">=0"
+  - category: system
+    name: immutable-rootfs
+    version: ">=0"
+  - category: system
+    name: grub-config
+    version: ">=0"
+  - category: system
+    name: cloud-config
+    version: ">=0"
+  - category: toolchain
+    name: luet
+    version: ">=0"


### PR DESCRIPTION
Adds meta/cos-minimal package which requires the minimal set of packages
in order to have a minimal functioning cOS derivative.

This is also in the long-term very handy if we are going to have a
separate set of packages which are fips-enabled (#491)

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>