### PR TITLE
Upload ami id text file on release

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -395,6 +395,9 @@
     - tests-nonsquashfs-{{{ $flavor }}}
     - tests-squashfs-{{{ $flavor }}}
     {{{- end }}}
+    {{{- if $config.publish_cloud }}}
+    - publish-vanilla-ami
+    {{{- end }}}
     steps:
       - uses: actions/checkout@v2
       {{{ tmpl.Exec "make" "deps" }}}
@@ -439,6 +442,12 @@
         with:
           name: images-{{{ $flavor }}}.txt
           path: release
+      {{{- if $config.publish_cloud }}}
+      - uses: actions/download-artifact@v2
+        with:
+          name: ami-id-vanilla-${{ env.COS_VERSION }}.txt
+          path: release
+      {{{- end }}}
       - name: Release
         uses: fnkr/github-action-ghr@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -625,6 +634,11 @@
           export COS_VERSION="${COS_VERSION/+/-}"
           export AWS_DISK_NAME="cOS-Vanilla-$COS_VERSION"
           make aws_vanilla_ami
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ami-id-vanilla-${{ env.COS_VERSION }}.txt
+          path: |
+            ami_id.txt
 {{{ end }}}
 
 name: Build cOS {{{$config.pipeline}}}

--- a/.github/workflows/build-releases.yaml
+++ b/.github/workflows/build-releases.yaml
@@ -641,6 +641,7 @@ jobs:
     - image-link-green
     - tests-nonsquashfs-green
     - tests-squashfs-green
+    - publish-vanilla-ami
     steps:
       - uses: actions/checkout@v2
       
@@ -696,6 +697,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: images-green.txt
+          path: release
+      - uses: actions/download-artifact@v2
+        with:
+          name: ami-id-vanilla-${{ env.COS_VERSION }}.txt
           path: release
       - name: Release
         uses: fnkr/github-action-ghr@v1
@@ -1298,4 +1303,9 @@ jobs:
           export COS_VERSION="${COS_VERSION/+/-}"
           export AWS_DISK_NAME="cOS-Vanilla-$COS_VERSION"
           make aws_vanilla_ami
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ami-id-vanilla-${{ env.COS_VERSION }}.txt
+          path: |
+            ami_id.txt
 

--- a/images/aws_upload.sh
+++ b/images/aws_upload.sh
@@ -64,6 +64,7 @@ echo "Making AMI public"
 aws ec2 modify-image-attribute --image-id "${ami_id}" --launch-permission "Add=[{Group=all}]"
 
 echo "AMI Created: ${ami_id}"
+echo "${ami_id},${AWS_DEFAULT_REGION}" >> ami_id.txt
 
 
 if [[ "${COPY_AMI_ALL_REGIONS}" == "true" ]]
@@ -106,5 +107,6 @@ if [[ "${COPY_AMI_ALL_REGIONS}" == "true" ]]
     aws ec2 modify-image-attribute --image-id "${ami_copy_id}" --region "${reg}" --launch-permission "Add=[{Group=all}]"
 
     echo "AMI Copied: ${ami_copy_id}"
+    echo "${ami_copy_id},${reg}" >> ami_id.txt
   done
 fi


### PR DESCRIPTION
Output the ami id to a file that then is uploaded to when publishing a
release we can download it and attach it to the release

Closes #457 

Signed-off-by: Itxaka <igarcia@suse.com>