### PR TITLE
ci: specify package tree to be able to resolve templates

### DIFF
--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -99,7 +99,7 @@ serve-repo: $(LUET)
 	LUET_NOLOCK=true $(LUET) serve-repo --port 8000 --dir $(DESTINATION)
 
 autobump: $(LUET)
-	TREE_DIR=$(ROOT_DIR) $(LUET) autobump-github
+	TREE_DIR=$(ROOT_DIR)/packages $(LUET) autobump-github
 
 validate: $(LUET)
 	$(LUET) tree validate --tree $(TREE) $(_VALIDATE_OPTIONS)


### PR DESCRIPTION
This fixes the autobump job: https://github.com/rancher-sandbox/cOS-toolkit/runs/3311810974?check_suite_focus=true

Shared templates are by convention inside the `templates` folder in the package tree. If we specify the cwd as tree that doesn't hold anymore.

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>