### PR TITLE
ci: Add test for deploying from raw image

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -514,16 +514,18 @@
           if-no-files-found: error
 {{{ end }}}
 
-{{{define "raw_image_test"}}}
+{{{define "raw_image_test_deploy"}}}
   {{{ $config := (datasource "config") }}}
   {{{ $flavor := . }}}
-  raw-image-test-{{{ $flavor }}}:
+  tests-raw-disk-deploy-{{{ $flavor }}}:
     runs-on: macos-10.15
     needs: raw-images-{{{ $flavor }}}
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
       - uses: actions/checkout@v2
-      - name: Install yq
-        run: brew install yq
+      - name: Install deps
+        run: brew install yq cdrtools
       - name: Export cos version
         run: |
           export YQ=/usr/local/bin/yq
@@ -533,21 +535,28 @@
         uses: actions/download-artifact@v2
         with:
           name: cOS-Vanilla-RAW-{{{ $flavor }}}-${{ env.COS_VERSION }}
-      {{{ tmpl.Exec "make" "raw_disk_test" }}}
+      - name: Run tests 🔧
+        run: |
+          export GOPATH="/Users/runner/go"
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
+          sudo -E make raw_disk_test_deploy
       - name: Change serial log ownership
-        if: always()
+        if: failure()
         run: |
           USER_ID=$(id -u)
           GROUP_ID=$(id -g)
           sudo chown $USER_ID:$GROUP_ID serial_port1.log
           sudo chmod 777 serial_port1.log
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
-          name: serial_output_raw_image_test
+          name: cOS-raw_disk_test_deploy-{{{ $flavor }}}.serial.zip
           path: serial_port1.log
           if-no-files-found: warn
 {{{ end }}}
+
 {{{define "ami_publish"}}}
   {{{ $config := (datasource "config") }}}
   {{{ $flavor := . }}}
@@ -687,7 +696,7 @@ jobs:
 
     {{{- if not (has $config.skip_images_flavor $flavor) }}}
   {{{tmpl.Exec "raw_image" $flavor}}}
-  {{{tmpl.Exec "raw_image_test" $flavor}}}
+  {{{tmpl.Exec "raw_image_test_deploy" $flavor}}}
 
       {{{- if $config.publish_cloud }}}
   {{{tmpl.Exec "ami_publish" $flavor}}}

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -39,6 +39,7 @@
 
 
 
+
 name: Build cOS master
 
 on: 
@@ -711,13 +712,15 @@ jobs:
   
   
   
-  raw-image-test-green:
+  tests-raw-disk-deploy-green:
     runs-on: macos-10.15
     needs: raw-images-green
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
       - uses: actions/checkout@v2
-      - name: Install yq
-        run: brew install yq
+      - name: Install deps
+        run: brew install yq cdrtools
       - name: Export cos version
         run: |
           export YQ=/usr/local/bin/yq
@@ -727,24 +730,24 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: cOS-Vanilla-RAW-green-${{ env.COS_VERSION }}
-      
-  
-  
-      - name: Run make raw_disk_test
+      - name: Run tests 🔧
         run: |
-          sudo -E make raw_disk_test
-
+          export GOPATH="/Users/runner/go"
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
+          sudo -E make raw_disk_test_deploy
       - name: Change serial log ownership
-        if: always()
+        if: failure()
         run: |
           USER_ID=$(id -u)
           GROUP_ID=$(id -g)
           sudo chown $USER_ID:$GROUP_ID serial_port1.log
           sudo chmod 777 serial_port1.log
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
-          name: serial_output_raw_image_test
+          name: cOS-raw_disk_test_deploy-green.serial.zip
           path: serial_port1.log
           if-no-files-found: warn
 

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -39,6 +39,7 @@
 
 
 
+
 name: Build cOS nightly
 
 on: 
@@ -616,13 +617,15 @@ jobs:
   
   
   
-  raw-image-test-green:
+  tests-raw-disk-deploy-green:
     runs-on: macos-10.15
     needs: raw-images-green
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
       - uses: actions/checkout@v2
-      - name: Install yq
-        run: brew install yq
+      - name: Install deps
+        run: brew install yq cdrtools
       - name: Export cos version
         run: |
           export YQ=/usr/local/bin/yq
@@ -632,24 +635,24 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: cOS-Vanilla-RAW-green-${{ env.COS_VERSION }}
-      
-  
-  
-      - name: Run make raw_disk_test
+      - name: Run tests 🔧
         run: |
-          sudo -E make raw_disk_test
-
+          export GOPATH="/Users/runner/go"
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
+          sudo -E make raw_disk_test_deploy
       - name: Change serial log ownership
-        if: always()
+        if: failure()
         run: |
           USER_ID=$(id -u)
           GROUP_ID=$(id -g)
           sudo chown $USER_ID:$GROUP_ID serial_port1.log
           sudo chmod 777 serial_port1.log
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
-          name: serial_output_raw_image_test
+          name: cOS-raw_disk_test_deploy-green.serial.zip
           path: serial_port1.log
           if-no-files-found: warn
 

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -39,6 +39,7 @@
 
 
 
+
 name: Build cOS Pull requests
 
 on: 
@@ -622,13 +623,15 @@ jobs:
   
   
   
-  raw-image-test-green:
+  tests-raw-disk-deploy-green:
     runs-on: macos-10.15
     needs: raw-images-green
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
       - uses: actions/checkout@v2
-      - name: Install yq
-        run: brew install yq
+      - name: Install deps
+        run: brew install yq cdrtools
       - name: Export cos version
         run: |
           export YQ=/usr/local/bin/yq
@@ -638,24 +641,24 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: cOS-Vanilla-RAW-green-${{ env.COS_VERSION }}
-      
-  
-  
-      - name: Run make raw_disk_test
+      - name: Run tests 🔧
         run: |
-          sudo -E make raw_disk_test
-
+          export GOPATH="/Users/runner/go"
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
+          sudo -E make raw_disk_test_deploy
       - name: Change serial log ownership
-        if: always()
+        if: failure()
         run: |
           USER_ID=$(id -u)
           GROUP_ID=$(id -g)
           sudo chown $USER_ID:$GROUP_ID serial_port1.log
           sudo chmod 777 serial_port1.log
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
-          name: serial_output_raw_image_test
+          name: cOS-raw_disk_test_deploy-green.serial.zip
           path: serial_port1.log
           if-no-files-found: warn
 

--- a/.github/workflows/build-releases.yaml
+++ b/.github/workflows/build-releases.yaml
@@ -39,6 +39,7 @@
 
 
 
+
 name: Build cOS releases
 
 on: 
@@ -796,13 +797,15 @@ jobs:
   
   
   
-  raw-image-test-green:
+  tests-raw-disk-deploy-green:
     runs-on: macos-10.15
     needs: raw-images-green
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
       - uses: actions/checkout@v2
-      - name: Install yq
-        run: brew install yq
+      - name: Install deps
+        run: brew install yq cdrtools
       - name: Export cos version
         run: |
           export YQ=/usr/local/bin/yq
@@ -812,24 +815,24 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: cOS-Vanilla-RAW-green-${{ env.COS_VERSION }}
-      
-  
-  
-      - name: Run make raw_disk_test
+      - name: Run tests 🔧
         run: |
-          sudo -E make raw_disk_test
-
+          export GOPATH="/Users/runner/go"
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          PATH=$PATH:$GOPATH/bin
+          sudo -E make raw_disk_test_deploy
       - name: Change serial log ownership
-        if: always()
+        if: failure()
         run: |
           USER_ID=$(id -u)
           GROUP_ID=$(id -g)
           sudo chown $USER_ID:$GROUP_ID serial_port1.log
           sudo chmod 777 serial_port1.log
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
-          name: serial_output_raw_image_test
+          name: cOS-raw_disk_test_deploy-green.serial.zip
           path: serial_port1.log
           if-no-files-found: warn
 

--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -96,18 +96,27 @@ $(GINKGO):
 
 
 #
-# ------------ test for raw images  ------------
+# ------------ test for raw image  ------------
 #
 
 RAW?=$(shell ls $(ROOT_DIR)/*.raw 2> /dev/null)
 
-raw_disk_test: as_root $(VBOXMANAGE)
+raw_disk_test_deploy: create_vm_from_raw_image $(GINKGO)
+	# run tests
+	cd $(ROOT_DIR)/tests && $(GINKGO) $(GINKGO_ARGS) ./recovery-raw-disk
+
+create_vm_from_raw_image: as_root $(VBOXMANAGE)
 ifeq ("$(RAW)","")
 	@echo "Raw image does not exists, please run make raw_disk first"
 	@exit 1
 else
 	# transform the raw image
 	VBoxManage convertdd $(RAW) sda.vdi --format VDI
+	# increase disk size to 15Gb
+	VBoxManage modifymedium disk sda.vdi --compact --resize 16000
+	# creatre user-data iso (NoCloud)
+	cp packer/user-data/aws.yaml user-data
+	mkisofs -o cidata.iso -V CIDATA -J -r user-data
 	# create vm
 	VBoxManage createvm --name "test" --register
 	# increase memory, otherwise grub fails to boot
@@ -118,16 +127,16 @@ else
 	VBoxManage storagectl "test" --name "sata controller" --add sata
 	# attach the disk to the machine
 	VBoxManage storageattach "test" --storagectl "sata controller" --port 0 --device 0 --type hdd --medium $(ROOT_DIR)/sda.vdi
+	# attach the user-data iso
+	VBoxManage storageattach "test" --storagectl "sata controller" --port 1 --device 0 --type dvddrive --medium $(ROOT_DIR)/cidata.iso
 	# startvm and detach
 	VBoxManage startvm "test" --type headless
-	# sleep for a bit to let the recovery boot
-	sleep 300
-	# search for the welcome message, use .* between in front of "cOS" to avoid failing due to control characters (cOS recovery is in green color)
-	grep -q "Welcome to.*cOS recovery" $(ROOT_DIR)/serial_port1.log
 endif
 
 clean_raw_disk_test: as_root
 	VBoxManage controlvm "test" poweroff &>/dev/null || true
 	VBoxManage unregistervm "test" --delete &>/dev/null || true
 	rm $(ROOT_DIR)/sda.vdi &>/dev/null || true
+	rm $(ROOT_DIR)/user-data &>/dev/null || true
+	rm $(ROOT_DIR)/cidata.iso &>/dev/null || true
 	rm $(ROOT_DIR)/serial_port1.log  &>/dev/null || true

--- a/tests/recovery-raw-disk/recovery_raw_disk_test.go
+++ b/tests/recovery-raw-disk/recovery_raw_disk_test.go
@@ -1,0 +1,33 @@
+package cos_test
+
+import (
+	"github.com/rancher-sandbox/cOS/tests/sut"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("cOS Recovery deploy tests", func() {
+	var s *sut.SUT
+
+	BeforeEach(func() {
+		s = sut.NewSUT()
+		s.EventuallyConnects()
+	})
+
+	Context("after running recovery from the raw_disk image", func() {
+		It("uses cos-deploy to install", func() {
+			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Recovery))
+
+			out, err := s.Command("cos-deploy")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
+
+			err = s.ChangeBoot(sut.Active)
+			Expect(err).ToNot(HaveOccurred())
+
+			s.Reboot()
+			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
+		})
+	})
+})

--- a/tests/recovery-raw-disk/tests_suite_test.go
+++ b/tests/recovery-raw-disk/tests_suite_test.go
@@ -1,0 +1,13 @@
+package cos_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTests(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "cOS Recovery test Suite")
+}


### PR DESCRIPTION
Recent events have shown that we do not test cos-deploy from a raw image
as well as we should.

This patch adds a simple test and preparation of a vm based of the raw
image so we can test the the default cos-deploy stanza works as expected
and lays the base so we can expand it with more tests in the future.

Unfortunately as this test is fully modifying the disk image we can only
test one thing per time, once we modify the disk the pristine state that
we started with is gone, so we should probably create one work per test
that we want.

This also means that we can drop the normal raw-image-test that only
checks if we can boot from the raw image properly as this new test already
checks that part.

Signed-off-by: Itxaka <igarcia@suse.com>