### PR TITLE
Add STRICT_MODE

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "cos"
     category: "system"
-    version: "0.6.4"
+    version: "0.6.5"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -9,7 +9,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos"
     category: "recovery"
-    version: "0.6.4"
+    version: "0.6.5"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
     labels:
@@ -17,7 +17,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos-container"
     category: "system"
-    version: "0.6.4"
+    version: "0.6.5"
     brand_name: "cOS"
     description: "cOS container image, used to build cOS derivatives from scratch"
     labels:

--- a/packages/cos/recovery-img/definition.yaml
+++ b/packages/cos/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: "0.6.4"
+version: "0.6.5"
 brand_name: "cOS"

--- a/packages/cos/recovery-img/squash/definition.yaml
+++ b/packages/cos/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: "0.6.4"
+version: "0.6.5"

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.13"
+version: "0.14"

--- a/packages/installer/deploy.sh
+++ b/packages/installer/deploy.sh
@@ -106,7 +106,11 @@ upgrade() {
     rm -rf $upgrade_state_dir || true
     mkdir -p $temp_upgrade
 
-    cos-setup before-deploy > /dev/null || true
+    if [ "$STRICT_MODE" = "true" ]; then
+      cos-setup before-deploy
+    else 
+      cos-setup before-deploy || true
+    fi
 
     # FIXME: XDG_RUNTIME_DIR is for containerd, by default that points to /run/user/<uid>
     # which might not be sufficient to unpack images. Use /usr/local/tmp until we get a separate partition
@@ -134,8 +138,12 @@ upgrade() {
 
     SELinux_relabel
 
-    cos-setup after-deploy > /dev/null || true
-
+    if [ "$STRICT_MODE" = "true" ]; then
+      cos-setup after-deploy
+    else 
+      cos-setup after-deploy || true
+    fi
+    
     rm -rf $upgrade_state_dir
     umount $TARGET || true
 }
@@ -207,6 +215,9 @@ while [ "$#" -gt 0 ]; do
         --no-verify)
             VERIFY=false
             ;;
+        --strict)
+            STRICT_MODE=true
+            ;;
         --force)
             FORCE=true
             ;;
@@ -226,6 +237,10 @@ while [ "$#" -gt 0 ]; do
     esac
     shift 1
 done
+
+if [ -e /etc/cos/config ]; then
+    source /etc/cos/config
+fi
 
 find_upgrade_channel
 

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -322,6 +322,9 @@ while [ "$#" -gt 0 ]; do
         --poweroff)
             COS_INSTALL_POWER_OFF=true
             ;;
+        --strict)
+            STRICT_MODE=true
+            ;;
         --debug)
             set -x
             COS_INSTALL_DEBUG=true
@@ -360,6 +363,10 @@ if [ -e /etc/os-release ]; then
     source /etc/os-release
 fi
 
+if [ -e /etc/cos/config ]; then
+    source /etc/cos/config
+fi
+
 if [ -z "$COS_INSTALL_DEVICE" ]; then
     usage
 fi
@@ -369,7 +376,11 @@ validate_device
 
 trap cleanup exit
 
-cos-setup before-install > /dev/null || true
+if [ "$STRICT_MODE" = "true" ]; then
+  cos-setup before-install
+else 
+  cos-setup before-install || true
+fi
 
 setup_style
 do_format
@@ -384,7 +395,13 @@ umount_target 2>/dev/null
 prepare_recovery
 prepare_passive
 
-cos-setup after-install > /dev/null || true
+if [ "$STRICT_MODE" = "true" ]; then
+  cos-setup after-install
+else 
+  cos-setup after-install || true
+fi
+
+cos-rebrand
 
 if [ -n "$INTERACTIVE" ]; then
     exit 0

--- a/packages/installer/reset.sh
+++ b/packages/installer/reset.sh
@@ -159,7 +159,15 @@ find_partitions
 
 do_mount
 
-cos-setup before-reset > /dev/null || true
+if [ -e /etc/cos/config ]; then
+    source /etc/cos/config
+fi
+
+if [ "$STRICT_MODE" = "true" ]; then
+  cos-setup before-reset
+else 
+  cos-setup before-reset || true
+fi
 
 if [ -n "$PERSISTENCE_RESET" ] && [ "$PERSISTENCE_RESET" == "true" ]; then
     reset
@@ -169,4 +177,8 @@ copy_active
 
 install_grub
 
-cos-setup after-reset > /dev/null || true
+if [ "$STRICT_MODE" = "true" ]; then
+  cos-setup after-reset
+else 
+  cos-setup after-reset || true
+fi


### PR DESCRIPTION
This allows to fail in case the cloud-init stages are failing to execute. Also introduce `/etc/cos/config` for a general config place where to place customizations

Fixes #516
Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>