### PR TITLE
Grub branding

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "cos"
     category: "system"
-    version: "0.6.4"
+    version: "0.6.5"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -9,7 +9,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos"
     category: "recovery"
-    version: "0.6.4"
+    version: "0.6.5"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
     labels:
@@ -17,7 +17,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos-container"
     category: "system"
-    version: "0.6.4"
+    version: "0.6.5"
     brand_name: "cOS"
     description: "cOS container image, used to build cOS derivatives from scratch"
     labels:

--- a/packages/cos/recovery-img/definition.yaml
+++ b/packages/cos/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: "0.6.4"
+version: "0.6.5"
 brand_name: "cOS"

--- a/packages/cos/recovery-img/squash/definition.yaml
+++ b/packages/cos/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: "0.6.4"
+version: "0.6.5"

--- a/packages/installer/build.yaml
+++ b/packages/installer/build.yaml
@@ -9,3 +9,4 @@ steps:
 - cp -rfv reset.sh /usr/sbin/cos-reset && chmod +x /usr/sbin/cos-reset
 - cp -rfv deploy.sh /usr/sbin/cos-deploy && chmod +x /usr/sbin/cos-deploy
 - cp -rfv suc-upgrade.sh /usr/sbin/suc-upgrade && chmod +x /usr/sbin/suc-upgrade
+- cp -rfv rebrand.sh /usr/sbin/cos-rebrand && chmod +x /usr/sbin/cos-rebrand

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.13"
+version: "0.14"

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,3 +1,3 @@
 name: "installer"
 category: "utils"
-version: "0.14"
+version: "0.15"

--- a/packages/installer/deploy.sh
+++ b/packages/installer/deploy.sh
@@ -143,7 +143,7 @@ upgrade() {
     else 
       cos-setup after-deploy || true
     fi
-    
+
     rm -rf $upgrade_state_dir
     umount $TARGET || true
 }
@@ -256,6 +256,8 @@ mount_image
 upgrade
 
 set_active_passive
+
+cos-rebrand
 
 echo "Flush changes to disk"
 sync

--- a/packages/installer/deploy.sh
+++ b/packages/installer/deploy.sh
@@ -106,7 +106,11 @@ upgrade() {
     rm -rf $upgrade_state_dir || true
     mkdir -p $temp_upgrade
 
-    cos-setup before-deploy > /dev/null || true
+    if [ "$STRICT_MODE" = "true" ]; then
+      cos-setup before-deploy
+    else 
+      cos-setup before-deploy || true
+    fi
 
     # FIXME: XDG_RUNTIME_DIR is for containerd, by default that points to /run/user/<uid>
     # which might not be sufficient to unpack images. Use /usr/local/tmp until we get a separate partition
@@ -134,8 +138,12 @@ upgrade() {
 
     SELinux_relabel
 
-    cos-setup after-deploy > /dev/null || true
-
+    if [ "$STRICT_MODE" = "true" ]; then
+      cos-setup after-deploy
+    else 
+      cos-setup after-deploy || true
+    fi
+    
     rm -rf $upgrade_state_dir
     umount $TARGET || true
 }
@@ -207,6 +215,9 @@ while [ "$#" -gt 0 ]; do
         --no-verify)
             VERIFY=false
             ;;
+        --strict)
+            STRICT_MODE=true
+            ;;
         --force)
             FORCE=true
             ;;
@@ -226,6 +237,10 @@ while [ "$#" -gt 0 ]; do
     esac
     shift 1
 done
+
+if [ -e /etc/cos/config ]; then
+    source /etc/cos/config
+fi
 
 find_upgrade_channel
 

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -322,6 +322,9 @@ while [ "$#" -gt 0 ]; do
         --poweroff)
             COS_INSTALL_POWER_OFF=true
             ;;
+        --strict)
+            STRICT_MODE=true
+            ;;
         --debug)
             set -x
             COS_INSTALL_DEBUG=true
@@ -360,6 +363,10 @@ if [ -e /etc/os-release ]; then
     source /etc/os-release
 fi
 
+if [ -e /etc/cos/config ]; then
+    source /etc/cos/config
+fi
+
 if [ -z "$COS_INSTALL_DEVICE" ]; then
     usage
 fi
@@ -369,7 +376,11 @@ validate_device
 
 trap cleanup exit
 
-cos-setup before-install > /dev/null || true
+if [ "$STRICT_MODE" = "true" ]; then
+  cos-setup before-install
+else 
+  cos-setup before-install || true
+fi
 
 setup_style
 do_format
@@ -384,7 +395,13 @@ umount_target 2>/dev/null
 prepare_recovery
 prepare_passive
 
-cos-setup after-install > /dev/null || true
+if [ "$STRICT_MODE" = "true" ]; then
+  cos-setup after-install
+else 
+  cos-setup after-install || true
+fi
+
+cos-rebrand
 
 if [ -n "$INTERACTIVE" ]; then
     exit 0

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -395,13 +395,13 @@ umount_target 2>/dev/null
 prepare_recovery
 prepare_passive
 
+cos-rebrand
+
 if [ "$STRICT_MODE" = "true" ]; then
   cos-setup after-install
 else 
   cos-setup after-install || true
 fi
-
-cos-rebrand
 
 if [ -n "$INTERACTIVE" ]; then
     exit 0

--- a/packages/installer/rebrand.sh
+++ b/packages/installer/rebrand.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# This script allows to rebrand cOS
+
+is_mounted() {
+  mountpoint -q $1
+}
+
+rebrand_grub_menu() {
+
+	local grub_entry="$1"
+
+	STATEDIR=$(blkid -L COS_STATE)
+	mkdir -p /run/boot
+	
+	if ! is_mounted; then
+	   mount $STATEDIR /run/boot
+	fi
+	local grub_file=/run/boot/grub2/grub.cfg
+
+	if [ ! -e "$grub_file" ]; then
+	   grub_file="/run/boot/grub/grub.cfg"
+	fi
+
+	if [ ! -e "$grub_file" ]; then
+	   echo "Grub config file not found"
+	   exit 1
+	fi
+
+	sed -i "s/menuentry \"cOS/menuentry \"$grub_entry/g" "$grub_file"
+}
+
+cleanup2()
+{
+    sync
+    umount ${STATEDIR}
+}
+
+cleanup()
+{
+    EXIT=$?
+    cleanup2 2>/dev/null || true
+    return $EXIT
+}
+
+if [ -e "/etc/cos/config" ]; then
+  source /etc/cos/config
+fi
+
+grub_entry="${GRUB_ENTRY_NAME:-cOS}"
+
+trap cleanup exit
+
+rebrand_grub_menu "$grub_entry"

--- a/packages/installer/reset.sh
+++ b/packages/installer/reset.sh
@@ -177,6 +177,8 @@ copy_active
 
 install_grub
 
+cos-rebrand
+
 if [ "$STRICT_MODE" = "true" ]; then
   cos-setup after-reset
 else 

--- a/packages/installer/reset.sh
+++ b/packages/installer/reset.sh
@@ -159,7 +159,15 @@ find_partitions
 
 do_mount
 
-cos-setup before-reset > /dev/null || true
+if [ -e /etc/cos/config ]; then
+    source /etc/cos/config
+fi
+
+if [ "$STRICT_MODE" = "true" ]; then
+  cos-setup before-reset
+else 
+  cos-setup before-reset || true
+fi
 
 if [ -n "$PERSISTENCE_RESET" ] && [ "$PERSISTENCE_RESET" == "true" ]; then
     reset
@@ -169,4 +177,8 @@ copy_active
 
 install_grub
 
-cos-setup after-reset > /dev/null || true
+if [ "$STRICT_MODE" = "true" ]; then
+  cos-setup after-reset
+else 
+  cos-setup after-reset || true
+fi


### PR DESCRIPTION
Supersedes #517.

Adds `STRICT_MODE` to improve UX of after/before install/deploy/reset stages and introduces a general `cos-rebrand` script that can be reused down the line for other cases too, at the moment allows to customize the menu entry of grub after install.

It is sufficient to write to `/etc/cos/config`:

```Dockerfile
RUN echo "GRUB_ENTRY_NAME=foo" > /etc/cos/config
```