### PR TITLE
Implement support for persistent state a area

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "cos"
     category: "system"
-    version: "0.6.6"
+    version: "0.6.7"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -9,7 +9,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos"
     category: "recovery"
-    version: "0.6.6"
+    version: "0.6.7"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
     labels:
@@ -17,7 +17,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos-container"
     category: "system"
-    version: "0.6.6"
+    version: "0.6.7"
     brand_name: "cOS"
     description: "cOS container image, used to build cOS derivatives from scratch"
     labels:

--- a/packages/cos/recovery-img/definition.yaml
+++ b/packages/cos/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: "0.6.6"
+version: "0.6.7"
 brand_name: "cOS"

--- a/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
+++ b/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
@@ -24,7 +24,7 @@ install() {
     declare initdir="${initdir}"
 
     inst_multiple \
-        mount mountpoint yip cos-setup sort findmnt rmdir findmnt
+        mount mountpoint yip cos-setup sort findmnt rmdir findmnt rsync
 
     # Include utilities required for cos-setup services,
     # probably a devoted cos-setup dracut module makes sense

--- a/packages/immutable-rootfs/definition.yaml
+++ b/packages/immutable-rootfs/definition.yaml
@@ -1,3 +1,3 @@
 name: "immutable-rootfs"
 category: "system"
-version: 0.1.1+13
+version: 0.2.0


### PR DESCRIPTION
This commit adds the concept of a persistent state area in
immutable-rootfs package. It adds support for adding an additional
non ephemereal overlayfs on top of configurable locations,
alternatively, instead of using overlayfs in can simple bind mount
a mirrored location from a persistent area.

Fixes #430

Signed-off-by: David Cassany <dcassany@suse.com>