### PR TITLE
ci: Use the same go version across jobs

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -37,6 +37,8 @@
   {{{- else }}}
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
   {{{- end }}}
   {{{- if $config.local_runner }}}
       - name: Install make
@@ -284,8 +286,7 @@
       matrix:
         test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
+      {{{ tmpl.Exec "prepare_build" }}}
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -350,15 +351,7 @@
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
     {{{- end }}}
       {{{ tmpl.Exec "make" "deps" }}}
-    {{{- if $config.local_runner }}}
-      - name: Install Go
-        run: |
-          curl -L https://golang.org/dl/go1.16.5.linux-amd64.tar.gz -o go1.16.5.linux-amd64.tar.gz
-          sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
-    {{{- else }}}
-      - name: Install Go
-        uses: actions/setup-go@v2
-    {{{- end }}}
+    {{{ tmpl.Exec "prepare_build" }}}
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -521,8 +514,7 @@
     runs-on: macos-10.15
     needs: raw-images-{{{ $flavor }}}
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
+      {{{ tmpl.Exec "prepare_build" }}}
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -102,6 +102,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   
@@ -323,8 +325,13 @@ jobs:
       matrix:
         test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -515,8 +522,13 @@ jobs:
       matrix:
         test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -612,8 +624,13 @@ jobs:
           sudo -E make deps
           sudo luet install -y toolchain/yq
 
+    
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -716,8 +733,13 @@ jobs:
     runs-on: macos-10.15
     needs: raw-images-green
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools
@@ -800,6 +822,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   
@@ -933,8 +957,13 @@ jobs:
           sudo -E make deps
           sudo luet install -y toolchain/yq
 
+    
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -996,6 +1025,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   
@@ -1129,8 +1160,13 @@ jobs:
           sudo -E make deps
           sudo luet install -y toolchain/yq
 
+    
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -101,6 +101,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   
@@ -307,8 +309,13 @@ jobs:
       matrix:
         test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -499,8 +506,13 @@ jobs:
       matrix:
         test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -621,8 +633,13 @@ jobs:
     runs-on: macos-10.15
     needs: raw-images-green
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools
@@ -705,6 +722,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   
@@ -806,6 +825,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   

--- a/.github/workflows/build-pr.yaml
+++ b/.github/workflows/build-pr.yaml
@@ -107,6 +107,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   
@@ -313,8 +315,13 @@ jobs:
       matrix:
         test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -505,8 +512,13 @@ jobs:
       matrix:
         test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -627,8 +639,13 @@ jobs:
     runs-on: macos-10.15
     needs: raw-images-green
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools
@@ -711,6 +728,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   
@@ -812,6 +831,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   

--- a/.github/workflows/build-releases.yaml
+++ b/.github/workflows/build-releases.yaml
@@ -102,6 +102,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   
@@ -323,8 +325,13 @@ jobs:
       matrix:
         test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -515,8 +522,13 @@ jobs:
       matrix:
         test: ["test-features", "test-smoke", "test-fallback", "test-recovery", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local", "test-deploys-images"]
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -612,8 +624,13 @@ jobs:
           sudo -E make deps
           sudo luet install -y toolchain/yq
 
+    
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -801,8 +818,13 @@ jobs:
     runs-on: macos-10.15
     needs: raw-images-green
     steps:
+      
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools
@@ -920,6 +942,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   
@@ -1053,8 +1077,13 @@ jobs:
           sudo -E make deps
           sudo luet install -y toolchain/yq
 
+    
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -1116,6 +1145,8 @@ jobs:
   
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
 
       
   
@@ -1249,8 +1280,13 @@ jobs:
           sudo -E make deps
           sudo luet install -y toolchain/yq
 
+    
+  
       - name: Install Go
         uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
+
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
Use the prepare_build template to setup the proper go version across all
jobs

This also fixes the test dependencies issue that is arising on the latests PRs (they are defaulting to go 1.15 somehow???)

Signed-off-by: Itxaka <igarcia@suse.com>