### PR TITLE
Allow to specify additional cloud-config paths

### DIFF
--- a/examples/standard/files/etc/cos/config
+++ b/examples/standard/files/etc/cos/config
@@ -10,7 +10,8 @@ CHANNEL_UPGRADES=false
 # Default container image used for upgrades. ( defaults to system/cos with channel CHANNEL_UPGRADES enabled )
 UPGRADE_IMAGE="quay.io/mudler/cos-test:cos-standard"
 
-# Default recovery image to use when upgrading the recovery partition.  ( defaults to system/cos with channel CHANNEL_UPGRADES enabled )
+# Default recovery image to use when upgrading the recovery partition
+# ( defaults to recovery/cos in vanilla cOS images with channel CHANNEL_UPGRADES enabled. Otherwise it defaults to UPGRADE_IMAGE ).
 RECOVERY_IMAGE="quay.io/mudler/cos-test:cos-standard"
 
 # GRUB entry to display on boot. ( defaults: cOS )

--- a/examples/standard/files/etc/cos/config
+++ b/examples/standard/files/etc/cos/config
@@ -15,3 +15,7 @@ RECOVERY_IMAGE="quay.io/mudler/cos-test:cos-standard"
 
 # GRUB entry to display on boot. ( defaults: cOS )
 GRUB_ENTRY_NAME="example"
+
+# Space separated list of additional paths that are used to
+# source cloud-config from. ( defaults paths are: /system/oem /oem/ /usr/local/cloud-config/ )
+CLOUD_INIT_PATHS=""

--- a/packages/cos-setup/cos-setup
+++ b/packages/cos-setup/cos-setup
@@ -1,5 +1,21 @@
 #!/bin/sh
 
+# Load any configuration file if present
+if [ -e /etc/environment ]; then
+    source /etc/environment
+fi
+
+if [ -e /etc/os-release ]; then
+    source /etc/os-release
+fi
+
+if [ -e /etc/cos/config ]; then
+  source /etc/cos/config
+fi
+
+# Default paths wether to search for cloud config file
+declare cloud_init_paths=("/system/oem" "/oem/" "/usr/local/cloud-config/")
+
 # Runs a supplied stage from cmdline args and local folders
 # it emit also "stage.before" and "stage.after" to able to hook
 # into different stages. E.g. if one depends on another for network setup
@@ -14,7 +30,11 @@ for x in "$@"; do
     esac
 done
 
-for dir in "/system/oem" "/oem/" "/usr/local/cloud-config/"; do
+if [ -n "${CLOUD_INIT_PATHS}" ]; then
+    cloud_init_paths+=(${CLOUD_INIT_PATHS})
+fi
+
+for dir in "${cloud_init_paths[@]}"; do
     if [ -d "$dir" ]; then
         yip -s "$STAGE".before "$dir"
         yip -s "$STAGE" "$dir"

--- a/packages/cos-setup/definition.yaml
+++ b/packages/cos-setup/definition.yaml
@@ -1,6 +1,6 @@
 name: cos-setup
 category: system
-version: 0.3.0+13
+version: "0.4"
 requires:
   - name: "yip"
     category: "toolchain"

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "cos"
     category: "system"
-    version: "0.6.7"
+    version: "0.6.7+1"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -9,7 +9,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos"
     category: "recovery"
-    version: "0.6.7"
+    version: "0.6.7+1"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
     labels:
@@ -17,7 +17,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos-container"
     category: "system"
-    version: "0.6.7"
+    version: "0.6.7+1"
     brand_name: "cOS"
     description: "cOS container image, used to build cOS derivatives from scratch"
     labels:

--- a/packages/cos/recovery-img/definition.yaml
+++ b/packages/cos/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: "0.6.7"
+version: "0.6.7+1"
 brand_name: "cOS"

--- a/packages/cos/recovery-img/squash/definition.yaml
+++ b/packages/cos/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: "0.6.6"
+version: "0.6.7+1"


### PR DESCRIPTION
Introduce a new config option that allows to list additional paths
to scan for cloud-config files.

Fixes: https://github.com/rancher-sandbox/cOS-toolkit/issues/238

TODO: update docs