### PR TITLE
Revert to go 1.16.x

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "cos"
     category: "system"
-    version: 0.6.7+2
+    version: 0.6.7+3
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -9,7 +9,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos"
     category: "recovery"
-    version: 0.6.7+2
+    version: 0.6.7+3
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
     labels:
@@ -17,7 +17,7 @@ packages:
       autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - name: "cos-container"
     category: "system"
-    version: "0.6.7+1"
+    version: "0.6.7+3"
     brand_name: "cOS"
     description: "cOS container image, used to build cOS derivatives from scratch"
     labels:

--- a/packages/cos/recovery-img/definition.yaml
+++ b/packages/cos/recovery-img/definition.yaml
@@ -1,4 +1,4 @@
 name: "cos-img"
 category: "recovery"
-version: 0.6.7+2
+version: 0.6.7+3
 brand_name: "cOS"

--- a/packages/cos/recovery-img/squash/definition.yaml
+++ b/packages/cos/recovery-img/squash/definition.yaml
@@ -1,3 +1,3 @@
 name: "cos-squash"
 category: "recovery"
-version: 0.6.7+2
+version: 0.6.7+3

--- a/packages/golang/collection.yaml
+++ b/packages/golang/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "golang"
     category: "build"
-    version: "1.17"
+    version: "1.16.6+8"
     base_url: https://golang.org/dl
     hidden: true # No need to make it installable for now
     labels:
@@ -14,9 +14,9 @@ packages:
         curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
       autobump.version_hook: |
         curl -s -L 'https://golang.org/VERSION?m=text' | sed 's/go//g'
-      package.version: "1.17"
+      package.version: "1.16.6"
       autobump.checksum_hook: "curl -q -L https://storage.googleapis.com/golang/go{{.Values.labels.package.version}}.linux-{{.Values.labels.autobump.arch}}.tar.gz.sha256"
-      package.checksum: "6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d"
+      package.checksum: "be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d"
   - name: "golang-fips"
     category: "build"
     version: "1.16.7b7"

--- a/packages/toolchain/collection.yaml
+++ b/packages/toolchain/collection.yaml
@@ -53,7 +53,7 @@ packages:
     name: "yip"
     upx: false
     fips: false
-    version: 0.9.8+4
+    version: 0.9.8+5
     labels:
       github.repo: "yip"
       github.owner: "mudler"


### PR DESCRIPTION
See: https://github.com/rancher-sandbox/cOS-toolkit/pull/490/commits/43763c47d293bffebfcd3f48b78252824af0db46

This is a blocker for harvester, so that's why the revert. I'll create a separate issue to track why golang 1.17 makes everything fail, and moreover why CI didn't failed at all...  (#562)

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>