### PR TITLE
ci: Increase timeout on test raw

### DIFF
--- a/tests/recovery-raw-disk/recovery_raw_disk_test.go
+++ b/tests/recovery-raw-disk/recovery_raw_disk_test.go
@@ -12,7 +12,7 @@ var _ = Describe("cOS Recovery deploy tests", func() {
 
 	BeforeEach(func() {
 		s = sut.NewSUT()
-		s.EventuallyConnects()
+		s.EventuallyConnects(sut.TimeoutRawDiskTest)
 	})
 
 	Context("after running recovery from the raw_disk image", func() {

--- a/tests/sut/sut.go
+++ b/tests/sut/sut.go
@@ -23,6 +23,8 @@ const (
 	Active      = iota
 	Recovery    = iota
 	UnknownBoot = iota
+
+	TimeoutRawDiskTest = 600  // Timeout to connect for recovery_raw_disk_test
 )
 
 type SUT struct {


### PR DESCRIPTION
Currently the github runners performance is not stable enough to let the
auto retry on the test framework to work as expected in the given time
(180s)

This patch bumps the timeout to 300 seconds instead which should be more
than enough for the VM to come up.

Signed-off-by: Itxaka <igarcia@suse.com>