### PR TITLE
autobump: Fix selinux packages

### DIFF
--- a/packages/selinux/collection.yaml
+++ b/packages/selinux/collection.yaml
@@ -8,6 +8,7 @@ packages:
       github.tag: "0.3.testing.0"
       package.checksum: "6c6a23a146dfecf8fd834689e11da3e3841be3ce624fd5044811c9f95c5fcd17"
       autobump.version_contains: "stable"
+      autobump.string_replace: '{ "\\.stable": "" }'
       autobump.strategy: "github_tag"
   - name: "rancher"
     category: "selinux"
@@ -18,4 +19,5 @@ packages:
       github.tag: "0.2-rc1.testing.1"
       package.checksum: "1b0537f5c372b3b965c91bd7dffdec3c377e6de27cb15c26659c65114a89a64f"
       autobump.version_contains: "production"
+      autobump.string_replace: '{ "\\.production": "" }'
       autobump.strategy: "github_tag"


### PR DESCRIPTION
Becuase both packages have a lot of pre-release releases we need to
choose a version that contains the proper keywords to bump to a
stable/production version.

This patch adds the autobump.string_replace so the version ends up with a valid semver format.

This also fails but works so...no idea

Signed-off-by: Itxaka <igarcia@suse.com>