### PR TITLE
ci: use time param for reboot

### DIFF
--- a/tests/recovery-raw-disk/recovery_raw_disk_test.go
+++ b/tests/recovery-raw-disk/recovery_raw_disk_test.go
@@ -26,7 +26,7 @@ var _ = Describe("cOS Recovery deploy tests", func() {
 			err = s.ChangeBoot(sut.Active)
 			Expect(err).ToNot(HaveOccurred())
 
-			s.Reboot()
+			s.Reboot(sut.TimeoutRawDiskTest)
 			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
 		})
 	})

--- a/tests/sut/sut.go
+++ b/tests/sut/sut.go
@@ -187,10 +187,10 @@ func (s *SUT) command(cmd string, timeout bool) (string, error) {
 }
 
 // Reboot reboots the system under test
-func (s *SUT) Reboot() {
+func (s *SUT) Reboot(t ...int) {
 	s.command("reboot", true)
 	time.Sleep(10 * time.Second)
-	s.EventuallyConnects(180)
+	s.EventuallyConnects(t...)
 }
 
 func (s *SUT) clientConfig() *ssh.ClientConfig {


### PR DESCRIPTION
Currently we had the reboot function on SUT with a hardcoded timeout
which was hitting its limits on the raw disk test

This modifies the reboot function so it acceps a timeout and passes it
to the EventuallyConnects function

Signed-off-by: Itxaka <igarcia@suse.com>