### PR TITLE
makefile: check yq version for package list

### DIFF
--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -39,7 +39,12 @@ _VALIDATE_OPTIONS?=-s
 #
 # extract packages from yaml spec
 #
-PACKAGES?=$(shell yq e -j $(MANIFEST) | jq -r '.packages[],.build | .[]' | sort -u)
+YQ_VERSION=$(shell yq -V | cut -d " " -f 3 | cut -d "." -f 1)
+ifeq ("$(YQ_VERSION)", "3")
+	PACKAGES?=$(shell yq r -j $(MANIFEST) | jq -r '.packages[],.build | .[]' | sort -u)
+else
+	PACKAGES?=$(shell yq e -j $(MANIFEST) | jq -r '.packages[],.build | .[]' | sort -u)
+endif
 
 ifeq ("$(PACKAGES)","")
 	BUILD_ARGS+=--all


### PR DESCRIPTION
Because yq version 3 and 4 differ in the cli arguments if you are using
version 3, the packages list will be empty and everything will be built.

Instead have a small check in the makefile to run the proper yq command
based on the major yq version on build

Signed-off-by: Itxaka <igarcia@suse.com>