### PR TITLE
grub-artifacts: add provides to respect old packages

### DIFF
--- a/packages/grub2/collection.yaml
+++ b/packages/grub2/collection.yaml
@@ -4,4 +4,7 @@ packages:
     version: 0.0.2+1
   - name: "grub2-config"
     category: "system"
-    version: 0.0.11+1
+    version: 0.0.11+2
+    provides:
+    - name: "grub-config"
+      category: "system"


### PR DESCRIPTION
When moving to the new name of grub2-config, the old package grub-config
is no longer present which will cause breakage on grub-config consumers.

This just adds the provides stanza so consumers will get redirected to
the newer grub2-config package

Closes #604

Signed-off-by: Itxaka <igarcia@suse.com>