### PR TITLE
ci: change triggers for github_runner job

### DIFF
--- a/.github/workflows/build-github-runner.yaml
+++ b/.github/workflows/build-github-runner.yaml
@@ -3,8 +3,8 @@ name: Build the github runner image and push to quay.io
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    paths:
+      - .github/docker/ghrunner/**
 
 jobs:
 


### PR DESCRIPTION
Currently there is no point in running it on PRs, especially because we
cant access the proper secrets for the workflow to work.

It also doesnt make sense to run it on each master push, instead just
run it when something has changed in the job files and its a push to
master

Signed-off-by: Itxaka <igarcia@suse.com>