### PR TITLE
arm64: disable manifest creation

### DIFF
--- a/.github/workflows/build-master-arm64.yaml
+++ b/.github/workflows/build-master-arm64.yaml
@@ -59,19 +59,6 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
-      - name: Generate manifests
-        run: |
-          for f in build/*tar*; do
-            [ -e "$f" ] || continue
-            sudo -E luet mtree -- generate $f -o "$f.mtree"
-          done
-      - name: Append manifests to metadata
-        run: |
-          for f in build/*mtree; do
-            [ -e "$f" ] || continue
-            BASE_NAME=`basename -s .package.tar.zst.mtree $f`
-            sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
-          done
       - name: Run make create-repo
         run: |
           sudo -E make create-repo

--- a/.github/workflows/build-releases-arm64.yaml
+++ b/.github/workflows/build-releases-arm64.yaml
@@ -59,19 +59,6 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
-      - name: Generate manifests
-        run: |
-          for f in build/*tar*; do
-            [ -e "$f" ] || continue
-            sudo -E luet mtree -- generate $f -o "$f.mtree"
-          done
-      - name: Append manifests to metadata
-        run: |
-          for f in build/*mtree; do
-            [ -e "$f" ] || continue
-            BASE_NAME=`basename -s .package.tar.zst.mtree $f`
-            sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
-          done
       - name: Run make create-repo
         run: |
           sudo -E make create-repo


### PR DESCRIPTION
Currently no version of luet-mtree is published for arm64 so ci cant
install.

Manually removed so we can regenerate the workflows afterwards

Signed-off-by: Itxaka <igarcia@suse.com>