### PR TITLE
ci: Fix LUET_ARCH in arm64 jobs

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -360,6 +360,7 @@
     {{{- end }}}
     env:
       FLAVOR: {{{ $flavor }}}
+      LUET_ARCH: {{{ $config.arch }}}
       ARCH: {{{ $config.arch }}}
       FINAL_REPO: {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}{{{- if ne $config.arch "x86_64"}}}-{{{$config.arch}}}{{{end}}}
       DOWNLOAD_METADATA: true
@@ -424,6 +425,7 @@
     {{{- end }}}
     env:
       FLAVOR: {{{ $flavor }}}
+      LUET_ARCH: {{{ $config.arch }}}
       ARCH: {{{ $config.arch }}}
     {{{- if has $config "luet_install_from_cos_repo" }}}
       LUET_INSTALL_FROM_COS_REPO: {{{ $config.luet_install_from_cos_repo }}}

--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -369,18 +369,18 @@
       LUET_INSTALL_FROM_COS_REPO: {{{ $config.luet_install_from_cos_repo }}}
       {{{- end }}}
     steps:
+      {{{ tmpl.Exec "prepare_build" }}}
       {{{ tmpl.Exec "prepare_worker" }}}
+      {{{- if or $config.publishing_pipeline $config.push_cache }}}
+      - name: Login to Quay Registry
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      {{{- end }}}
+      {{{ tmpl.Exec "make" "deps" }}}
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
           name: build-{{{ $flavor }}}-{{{ $config.arch }}}
           path: build
-    {{{- if or $config.publishing_pipeline $config.push_cache }}}
-      - name: Login to Quay Registry
-        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
-    {{{- end }}}
-      {{{ tmpl.Exec "make" "deps" }}}
-    {{{ tmpl.Exec "prepare_build" }}}
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-master-arm64.yaml
+++ b/.github/workflows/build-master-arm64.yaml
@@ -94,6 +94,7 @@ jobs:
     - build-green
     env:
       FLAVOR: green
+      LUET_ARCH: arm64
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true

--- a/.github/workflows/build-master-arm64.yaml
+++ b/.github/workflows/build-master-arm64.yaml
@@ -101,20 +101,6 @@ jobs:
       DOWNLOAD_ONLY: true
       LUET_INSTALL_FROM_COS_REPO: false
     steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: build-green-arm64
-          path: build
-      - name: Login to Quay Registry
-        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
-      - name: Run make deps
-        run: |
-          sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - run: |
           sudo rm -rf build || true
           sudo rm -rf bin || true
@@ -130,6 +116,20 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get install -y make
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Login to Quay Registry
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install --no-spinner -y toolchain/yq
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-green-arm64
+          path: build
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -431,6 +431,10 @@ jobs:
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
       - uses: actions/checkout@v2
       - run: |
           git fetch --prune --unshallow
@@ -438,21 +442,17 @@ jobs:
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: build-green-x86_64
-          path: build
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Go
-        uses: actions/setup-go@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
         with:
-            go-version: '^1.16'
+          name: build-green-x86_64
+          path: build
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -677,6 +677,10 @@ jobs:
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
       - uses: actions/checkout@v2
       - run: |
           git fetch --prune --unshallow
@@ -684,21 +688,17 @@ jobs:
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: build-blue-x86_64
-          path: build
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Go
-        uses: actions/setup-go@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
         with:
-            go-version: '^1.16'
+          name: build-blue-x86_64
+          path: build
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -823,6 +823,10 @@ jobs:
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
       - uses: actions/checkout@v2
       - run: |
           git fetch --prune --unshallow
@@ -830,21 +834,17 @@ jobs:
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: build-orange-x86_64
-          path: build
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Go
-        uses: actions/setup-go@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
         with:
-            go-version: '^1.16'
+          name: build-orange-x86_64
+          path: build
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -425,6 +425,7 @@ jobs:
     needs: tests-squashfs-green
     env:
       FLAVOR: green
+      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
@@ -670,6 +671,7 @@ jobs:
     - build-blue
     env:
       FLAVOR: blue
+      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
@@ -815,6 +817,7 @@ jobs:
     - build-orange
     env:
       FLAVOR: orange
+      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true

--- a/.github/workflows/build-releases-arm64.yaml
+++ b/.github/workflows/build-releases-arm64.yaml
@@ -94,6 +94,7 @@ jobs:
     - build-green
     env:
       FLAVOR: green
+      LUET_ARCH: arm64
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true
@@ -148,6 +149,7 @@ jobs:
     - image-link-green
     env:
       FLAVOR: green
+      LUET_ARCH: arm64
       ARCH: arm64
       LUET_INSTALL_FROM_COS_REPO: false
     steps:

--- a/.github/workflows/build-releases-arm64.yaml
+++ b/.github/workflows/build-releases-arm64.yaml
@@ -101,20 +101,6 @@ jobs:
       DOWNLOAD_ONLY: true
       LUET_INSTALL_FROM_COS_REPO: false
     steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: build-green-arm64
-          path: build
-      - name: Login to Quay Registry
-        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
-      - name: Run make deps
-        run: |
-          sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - run: |
           sudo rm -rf build || true
           sudo rm -rf bin || true
@@ -130,6 +116,20 @@ jobs:
         run: |
             sudo apt-get update
             sudo apt-get install -y make
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Login to Quay Registry
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+          sudo luet install --no-spinner -y toolchain/yq
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-green-arm64
+          path: build
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-releases.yaml
+++ b/.github/workflows/build-releases.yaml
@@ -431,6 +431,10 @@ jobs:
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
       - uses: actions/checkout@v2
       - run: |
           git fetch --prune --unshallow
@@ -438,21 +442,17 @@ jobs:
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: build-green-x86_64
-          path: build
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Go
-        uses: actions/setup-go@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
         with:
-            go-version: '^1.16'
+          name: build-green-x86_64
+          path: build
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -782,6 +782,10 @@ jobs:
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
       - uses: actions/checkout@v2
       - run: |
           git fetch --prune --unshallow
@@ -789,21 +793,17 @@ jobs:
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: build-blue-x86_64
-          path: build
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Go
-        uses: actions/setup-go@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
         with:
-            go-version: '^1.16'
+          name: build-blue-x86_64
+          path: build
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin
@@ -928,6 +928,10 @@ jobs:
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+            go-version: '^1.16'
       - uses: actions/checkout@v2
       - run: |
           git fetch --prune --unshallow
@@ -935,21 +939,17 @@ jobs:
         run: |
           sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
           sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Download result for build
-        uses: actions/download-artifact@v2
-        with:
-          name: build-orange-x86_64
-          path: build
       - name: Login to Quay Registry
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Go
-        uses: actions/setup-go@v2
+      - name: Download result for build
+        uses: actions/download-artifact@v2
         with:
-            go-version: '^1.16'
+          name: build-orange-x86_64
+          path: build
       - name: Grab metadata from remotes
         run: |
           export PATH=$PATH:/usr/local/go/bin

--- a/.github/workflows/build-releases.yaml
+++ b/.github/workflows/build-releases.yaml
@@ -425,6 +425,7 @@ jobs:
     needs: tests-squashfs-green
     env:
       FLAVOR: green
+      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
@@ -478,6 +479,7 @@ jobs:
     - publish-vanilla-ami
     env:
       FLAVOR: green
+      LUET_ARCH: x86_64
       ARCH: x86_64
     steps:
       - uses: actions/checkout@v2
@@ -774,6 +776,7 @@ jobs:
     - build-blue
     env:
       FLAVOR: blue
+      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
@@ -919,6 +922,7 @@ jobs:
     - build-orange
     env:
       FLAVOR: orange
+      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true


### PR DESCRIPTION
It was defaulting to x86_64 in publish and github-release jobs thus
failing

Signed-off-by: Itxaka <igarcia@suse.com>