### PR TITLE
ci: publish job should not use luet_arch

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -360,7 +360,6 @@
     {{{- end }}}
     env:
       FLAVOR: {{{ $flavor }}}
-      LUET_ARCH: {{{ $config.arch }}}
       ARCH: {{{ $config.arch }}}
       FINAL_REPO: {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}{{{- if ne $config.arch "x86_64"}}}-{{{$config.arch}}}{{{end}}}
       DOWNLOAD_METADATA: true

--- a/.github/workflows/build-master-arm64.yaml
+++ b/.github/workflows/build-master-arm64.yaml
@@ -94,7 +94,6 @@ jobs:
     - build-green
     env:
       FLAVOR: green
-      LUET_ARCH: arm64
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true

--- a/.github/workflows/build-master.yaml
+++ b/.github/workflows/build-master.yaml
@@ -425,7 +425,6 @@ jobs:
     needs: tests-squashfs-green
     env:
       FLAVOR: green
-      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
@@ -671,7 +670,6 @@ jobs:
     - build-blue
     env:
       FLAVOR: blue
-      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
@@ -817,7 +815,6 @@ jobs:
     - build-orange
     env:
       FLAVOR: orange
-      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true

--- a/.github/workflows/build-releases-arm64.yaml
+++ b/.github/workflows/build-releases-arm64.yaml
@@ -94,7 +94,6 @@ jobs:
     - build-green
     env:
       FLAVOR: green
-      LUET_ARCH: arm64
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true

--- a/.github/workflows/build-releases.yaml
+++ b/.github/workflows/build-releases.yaml
@@ -425,7 +425,6 @@ jobs:
     needs: tests-squashfs-green
     env:
       FLAVOR: green
-      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
@@ -776,7 +775,6 @@ jobs:
     - build-blue
     env:
       FLAVOR: blue
-      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
@@ -922,7 +920,6 @@ jobs:
     - build-orange
     env:
       FLAVOR: orange
-      LUET_ARCH: x86_64
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true


### PR DESCRIPTION
Its running on ubuntu so it should default to x86_64

Signed-off-by: Itxaka <igarcia@suse.com>