### PR TITLE
ci: remove luet_arch from github-release job

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -424,7 +424,6 @@
     {{{- end }}}
     env:
       FLAVOR: {{{ $flavor }}}
-      LUET_ARCH: {{{ $config.arch }}}
       ARCH: {{{ $config.arch }}}
     {{{- if has $config "luet_install_from_cos_repo" }}}
       LUET_INSTALL_FROM_COS_REPO: {{{ $config.luet_install_from_cos_repo }}}

--- a/.github/workflows/build-releases-arm64.yaml
+++ b/.github/workflows/build-releases-arm64.yaml
@@ -148,7 +148,6 @@ jobs:
     - image-link-green
     env:
       FLAVOR: green
-      LUET_ARCH: arm64
       ARCH: arm64
       LUET_INSTALL_FROM_COS_REPO: false
     steps:

--- a/.github/workflows/build-releases.yaml
+++ b/.github/workflows/build-releases.yaml
@@ -478,7 +478,6 @@ jobs:
     - publish-vanilla-ami
     env:
       FLAVOR: green
-      LUET_ARCH: x86_64
       ARCH: x86_64
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Its run from ubuntu so it doesnt need the arch

Signed-off-by: Itxaka <igarcia@suse.com>