### PR TITLE
ci: enable manifest and luet repo for arm64

### DIFF
--- a/.github/config/master.yaml
+++ b/.github/config/master.yaml
@@ -44,7 +44,6 @@ arches:
     skip_images_flavor: [ "green", "blue","orange" ]
     release_flavor: [ ]
     arch: "arm64"
-    luet_install_from_cos_repo: false
 
     on:
       push:

--- a/.github/config/pr.yaml
+++ b/.github/config/pr.yaml
@@ -47,7 +47,6 @@ arches:
     arch: "arm64"
     # list of labels to check in order to run jobs in this workflow
     labels: [ "arm64" ]
-    luet_install_from_cos_repo: false
 
     on:
       pull_request:

--- a/.github/config/releases.yaml
+++ b/.github/config/releases.yaml
@@ -45,7 +45,6 @@ arches:
     skip_images_flavor: [ "green", "blue","orange" ]
     release_flavor: [ "green" ]
     arch: "arm64"
-    luet_install_from_cos_repo: false
 
     on:
       push:

--- a/.github/workflows/build-master-arm64.yaml
+++ b/.github/workflows/build-master-arm64.yaml
@@ -18,7 +18,6 @@ jobs:
       DOWNLOAD_METADATA: false
       PUSH_CACHE: true
       REPO_CACHE: quay.io/costoolkit/build-green-cache-arm64
-      LUET_INSTALL_FROM_COS_REPO: false
       # For non x86_64 archs, skip the *-fips build as there are no golang releases in other arches
       SKIP_PACKAGES: "build/golang-fips toolchain-fips/yip toolchain-fips/luet-makeiso toolchain-fips/luet live/grub2 live/syslinux live/systemd-boot live/boot"
     steps:
@@ -59,6 +58,19 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
+      - name: Generate manifests
+        run: |
+          for f in build/*tar*; do
+            [ -e "$f" ] || continue
+            sudo -E luet mtree -- generate $f -o "$f.mtree"
+          done
+      - name: Append manifests to metadata
+        run: |
+          for f in build/*mtree; do
+            [ -e "$f" ] || continue
+            BASE_NAME=`basename -s .package.tar.zst.mtree $f`
+            sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
+          done
       - name: Run make create-repo
         run: |
           sudo -E make create-repo
@@ -98,7 +110,6 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-pr-arm64.yaml
+++ b/.github/workflows/build-pr-arm64.yaml
@@ -29,7 +29,6 @@ jobs:
       DOWNLOAD_METADATA: false
       PUSH_CACHE: false
       REPO_CACHE: quay.io/costoolkit/build-green-cache-arm64
-      LUET_INSTALL_FROM_COS_REPO: false
       # For non x86_64 archs, skip the *-fips build as there are no golang releases in other arches
       SKIP_PACKAGES: "build/golang-fips toolchain-fips/yip toolchain-fips/luet-makeiso toolchain-fips/luet live/grub2 live/syslinux live/systemd-boot live/boot"
     steps:

--- a/.github/workflows/build-releases-arm64.yaml
+++ b/.github/workflows/build-releases-arm64.yaml
@@ -18,7 +18,6 @@ jobs:
       DOWNLOAD_METADATA: false
       PUSH_CACHE: true
       REPO_CACHE: quay.io/costoolkit/build-green-cache-arm64
-      LUET_INSTALL_FROM_COS_REPO: false
       # For non x86_64 archs, skip the *-fips build as there are no golang releases in other arches
       SKIP_PACKAGES: "build/golang-fips toolchain-fips/yip toolchain-fips/luet-makeiso toolchain-fips/luet live/grub2 live/syslinux live/systemd-boot live/boot"
     steps:
@@ -59,6 +58,19 @@ jobs:
           ./.github/build
           ls -liah $PWD/build
           sudo chmod -R 777 $PWD/build
+      - name: Generate manifests
+        run: |
+          for f in build/*tar*; do
+            [ -e "$f" ] || continue
+            sudo -E luet mtree -- generate $f -o "$f.mtree"
+          done
+      - name: Append manifests to metadata
+        run: |
+          for f in build/*mtree; do
+            [ -e "$f" ] || continue
+            BASE_NAME=`basename -s .package.tar.zst.mtree $f`
+            sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
+          done
       - name: Run make create-repo
         run: |
           sudo -E make create-repo
@@ -98,7 +110,6 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true
@@ -149,7 +160,6 @@ jobs:
     env:
       FLAVOR: green
       ARCH: arm64
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - uses: actions/checkout@v2
       - name: Run make deps


### PR DESCRIPTION
Now that we have published the artifacts, we can rely again in the cos
repo to install luet and packages in the system with the side effect of
being able to enable the manifest generation for arm64

Signed-off-by: Itxaka <igarcia@suse.com>