### PR TITLE
ci: Fix images link for x86_64

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -635,9 +635,9 @@
             echo "{{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}{{{- if ne $config.arch "x86_64"}}}-{{{$config.arch}}}{{{end}}}:cos-system-${COS_VERSION}" > images-{{{ $flavor }}}-{{{ $config.arch }}}.txt
       - uses: actions/upload-artifact@v2
         with:
-          name: images-{{{ $flavor }}}{{{- if ne $config.arch "x86_64"}}}-{{{$config.arch}}}{{{end}}}.txt
+          name: images-{{{ $flavor }}}-{{{$config.arch}}}.txt
           path: |
-            images-{{{ $flavor }}}{{{- if ne $config.arch "x86_64"}}}-{{{$config.arch}}}{{{end}}}.txt
+            images-{{{ $flavor }}}-{{{$config.arch}}}.txt
 {{{ end }}}
 
 {{{define "publish_vanilla"}}}

--- a/.github/workflows/build-master-x86_64.yaml
+++ b/.github/workflows/build-master-x86_64.yaml
@@ -417,9 +417,9 @@ jobs:
             echo "quay.io/costoolkit/releases-green:cos-system-${COS_VERSION}" > images-green-x86_64.txt
       - uses: actions/upload-artifact@v2
         with:
-          name: images-green.txt
+          name: images-green-x86_64.txt
           path: |
-            images-green.txt
+            images-green-x86_64.txt
   publish-green:
     runs-on: ubuntu-latest
     needs: tests-squashfs-green
@@ -661,9 +661,9 @@ jobs:
             echo "quay.io/costoolkit/releases-blue:cos-system-${COS_VERSION}" > images-blue-x86_64.txt
       - uses: actions/upload-artifact@v2
         with:
-          name: images-blue.txt
+          name: images-blue-x86_64.txt
           path: |
-            images-blue.txt
+            images-blue-x86_64.txt
   publish-blue:
     runs-on: ubuntu-latest
     needs:
@@ -806,9 +806,9 @@ jobs:
             echo "quay.io/costoolkit/releases-orange:cos-system-${COS_VERSION}" > images-orange-x86_64.txt
       - uses: actions/upload-artifact@v2
         with:
-          name: images-orange.txt
+          name: images-orange-x86_64.txt
           path: |
-            images-orange.txt
+            images-orange-x86_64.txt
   publish-orange:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/build-releases-x86_64.yaml
+++ b/.github/workflows/build-releases-x86_64.yaml
@@ -417,9 +417,9 @@ jobs:
             echo "quay.io/costoolkit/releases-green:cos-system-${COS_VERSION}" > images-green-x86_64.txt
       - uses: actions/upload-artifact@v2
         with:
-          name: images-green.txt
+          name: images-green-x86_64.txt
           path: |
-            images-green.txt
+            images-green-x86_64.txt
   publish-green:
     runs-on: ubuntu-latest
     needs: tests-squashfs-green
@@ -765,9 +765,9 @@ jobs:
             echo "quay.io/costoolkit/releases-blue:cos-system-${COS_VERSION}" > images-blue-x86_64.txt
       - uses: actions/upload-artifact@v2
         with:
-          name: images-blue.txt
+          name: images-blue-x86_64.txt
           path: |
-            images-blue.txt
+            images-blue-x86_64.txt
   publish-blue:
     runs-on: ubuntu-latest
     needs:
@@ -910,9 +910,9 @@ jobs:
             echo "quay.io/costoolkit/releases-orange:cos-system-${COS_VERSION}" > images-orange-x86_64.txt
       - uses: actions/upload-artifact@v2
         with:
-          name: images-orange.txt
+          name: images-orange-x86_64.txt
           path: |
-            images-orange.txt
+            images-orange-x86_64.txt
   publish-orange:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
They didnt include the arch but the artifact uploader and github releaser was looking for that

Signed-off-by: Itxaka <igarcia@suse.com>