### PR TITLE
Split meta packages

### DIFF
--- a/packages/meta/collection.yaml
+++ b/packages/meta/collection.yaml
@@ -1,11 +1,31 @@
 packages:
 - category: "meta"
-  name: "cos-minimal"
-  version: "0.6.1+1"
+  name: "toolchain"
+  description: "Meta package for cOS toolchain"
+  version: "0.6"
   requires:
   - category: toolchain
     name: yip
     version: ">=0"
+  - category: toolchain
+    name: luet
+    version: ">=0"
+- category: "meta"
+  name: "fips-toolchain"
+  description: "Meta package for cOS toolchain with fips support"
+  version: "0.6"
+  requires:
+  - category: toolchain-fips
+    name: yip
+    version: ">=0"
+  - category: toolchain-fips
+    name: luet
+    version: ">=0"
+- category: "meta"
+  name: "cos-modules"
+  description: "Meta package for cOS core modules. It includes installer, cos-setup, dracut and grub configuration"
+  version: "0.6"
+  requires:
   - category: utils
     name: installer
     version: ">=0"
@@ -17,41 +37,49 @@ packages:
     version: ">=0"
   - category: system
     name: grub2-config
-    version: ">=0"
-  - category: system
-    name: cloud-config
-    version: ">=0"
-  - category: toolchain
-    name: luet
     version: ">=0"
   - name: "base-dracut-modules"
     category: "system"
     version: ">=0"
 - category: "meta"
-  name: "cos-minimal-fips"
-  version: "0.6.1+1"
+  name: "cos-core"
+  description: "cOS core package. It includes toolchain and base grub/dracut configuration"
+  version: "0.6.7"
   requires:
-  - category: toolchain-fips
-    name: yip
+  - category: meta
+    name: toolchain
     version: ">=0"
-  - category: utils
-    name: installer
+  - category: meta
+    name: cos-modules
     version: ">=0"
-  - category: system
-    name: cos-setup
+- category: "meta"
+  name: "cos-core-fips"
+  version: "0.6.7"
+  requires:
+  - category: meta
+    name: fips-toolchain
     version: ">=0"
-  - category: system
-    name: immutable-rootfs
+  - category: meta
+    name: cos-modules
     version: ">=0"
-  - category: system
-    name: grub2-config
+- category: "meta"
+  name: "cos-minimal"
+  version: "0.6.7"
+  description: "cOS minimal package. It includes toolchain, grub/dracut configuration and a default cloud-init preset"
+  requires:
+  - category: meta
+    name: cos-core
     version: ">=0"
   - category: system
     name: cloud-config
     version: ">=0"
-  - category: toolchain-fips
-    name: luet
+- category: "meta"
+  name: "cos-minimal-fips"
+  version: "0.6.7"
+  requires:
+  - category: meta
+    name: cos-core-fips
     version: ">=0"
-  - name: "base-dracut-modules"
-    category: "system"
+  - category: system
+    name: cloud-config
     version: ">=0"


### PR DESCRIPTION
Create meta/cos-core packages to group common packages without a
default cloud-config. cos-minimal is kept untouched, providing a barely
minimum default which should default in order to have a bootable system.
meta/cos-core can be instead used when augmenting the derivative with
user-supplied cloud-configuration.

This change also re-orders meta to have packages sub-groups that are
easier to embed.

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>