### PR TITLE
ci: Drop label checking for arm64 jobs

### DIFF
--- a/.github/config/pr.yaml
+++ b/.github/config/pr.yaml
@@ -46,7 +46,7 @@ arches:
     release_flavor: [ "green" ]
     arch: "arm64"
     # list of labels to check in order to run jobs in this workflow
-    labels: [ "arm64" ]
+    # labels: [ "arm64" ]
 
     on:
       pull_request:

--- a/.github/workflows/build-pr-arm64.yaml
+++ b/.github/workflows/build-pr-arm64.yaml
@@ -8,19 +8,9 @@ concurrency:
   group: ci-Pull requests - arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  check-labels:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mheap/github-action-required-labels@v1
-        with:
-          mode: exactly
-          count: 1
-          labels: "arm64"
   build-green:
     runs-on: [self-hosted, arm64]
     if: contains(["mudler", "davidcassany", "itxaka", kkaempf", "cOS-cibot"], "${{ github.actor }}") || contains(github.event.pull_request.labels.*.name, 'safe to test')
-    needs:
-      - check-labels
     env:
       LUET_ARCH: arm64
       FLAVOR: green


### PR DESCRIPTION
This defeates automation for automatic PRs for bumps

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>