### PR TITLE
ci: Add cloud checker for leftover instances

### DIFF
--- a/.github/cloud-cleaner.sh
+++ b/.github/cloud-cleaner.sh
@@ -1,5 +1,9 @@
-LAUNCH_DATE=$(date --date="-8 hours" "+%Y-%m-%dT%H:%M")
+HOURS=${HOURS:-8}
+LAUNCH_DATE=$(date --date="-${HOURS} hours" "+%Y-%m-%dT%H:%M")
+
 regions=( $( aws ec2 describe-regions | jq '.Regions[].RegionName' -r ) )
+
+echo "Checking instances that started before ${LAUNCH_DATE}"
 
 for region in "${regions[@]}"; do
   echo "Checking instances on region ${region}"

--- a/.github/cloud-cleaner.sh
+++ b/.github/cloud-cleaner.sh
@@ -1,0 +1,12 @@
+LAUNCH_DATE=$(date --date="-8 hours" "+%Y-%m-%dT%H:%M")
+regions=( $( aws ec2 describe-regions | jq '.Regions[].RegionName' -r ) )
+
+for region in "${regions[@]}"; do
+  echo "Checking instances on region ${region}"
+  export AWS_DEFAULT_REGION=${region}
+  instances=$( aws ec2 describe-instances --query "Reservations[].Instances[?LaunchTime<=\`$LAUNCH_DATE\`][].{id: InstanceId, type: InstanceType, launched: LaunchTime, region: Placement.AvailabilityZone, tags: Tags}"|jq '.[]' )
+  if [ ! -z "${instances}" ]; then
+    echo "Adding instances to file: ${instances}"
+    echo "${instances}" >> instances.txt
+  fi
+done

--- a/.github/workflows/cloud-cleaner.yaml
+++ b/.github/workflows/cloud-cleaner.yaml
@@ -1,0 +1,23 @@
+name: Cloud cleaner
+
+on:
+  schedule:
+    - cron:  '0 */8 * * *' # every 8 hours
+jobs:
+  clean:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+    steps:
+      - name: Get instances
+        run: |
+          .github/cloud-cleaner.sh
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          name: instances.txt
+          path: instances.txt
+          if-no-files-found: warning
+      # this is where we would put a webhook to the slack channel IF WE HAD ONE

--- a/.github/workflows/cloud-cleaner.yaml
+++ b/.github/workflows/cloud-cleaner.yaml
@@ -3,6 +3,12 @@ name: Cloud cleaner
 on:
   schedule:
     - cron:  '0 */8 * * *' # every 8 hours
+  workflow_dispatch:
+    inputs:
+      hours:
+        description: "Hours to check from the current time for running instances"
+        required: false
+        default: "8"
 jobs:
   clean:
     runs-on: ubuntu-latest
@@ -10,6 +16,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      HOURS: ${{ github.event.inputs.hours }}
     steps:
       - name: Get instances
         run: |


### PR DESCRIPTION
First part is just checking and storing the instances we have running
for more than 8 hours on each region

Signed-off-by: Itxaka <igarcia@suse.com>