### PR TITLE
ci: retain old package versions in the published tree

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -363,6 +363,7 @@
       ARCH: {{{ $config.arch }}}
       FINAL_REPO: {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}{{{- if ne $config.arch "x86_64"}}}-{{{$config.arch}}}{{{end}}}
       DOWNLOAD_METADATA: true
+      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       {{{- if has $config "luet_install_from_cos_repo" }}}
       LUET_INSTALL_FROM_COS_REPO: {{{ $config.luet_install_from_cos_repo }}}

--- a/.github/workflows/build-master-arm64.yaml
+++ b/.github/workflows/build-master-arm64.yaml
@@ -109,6 +109,7 @@ jobs:
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true
+      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
     steps:
       - run: |

--- a/.github/workflows/build-master-x86_64.yaml
+++ b/.github/workflows/build-master-x86_64.yaml
@@ -428,6 +428,7 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
+      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
     steps:
       - name: Install Go
@@ -673,6 +674,7 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
+      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
     steps:
       - name: Install Go
@@ -818,6 +820,7 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true
+      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
     steps:
       - name: Install Go

--- a/.github/workflows/build-releases-arm64.yaml
+++ b/.github/workflows/build-releases-arm64.yaml
@@ -109,6 +109,7 @@ jobs:
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true
+      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
     steps:
       - run: |

--- a/.github/workflows/build-releases-x86_64.yaml
+++ b/.github/workflows/build-releases-x86_64.yaml
@@ -428,6 +428,7 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
+      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
     steps:
       - name: Install Go
@@ -777,6 +778,7 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
+      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
     steps:
       - name: Install Go
@@ -922,6 +924,7 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true
+      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
     steps:
       - name: Install Go

--- a/make/Makefile.build
+++ b/make/Makefile.build
@@ -89,6 +89,7 @@ ifneq ($(shell id -u), 0)
 	@exit 1
 endif
 	$(LUET) create-repo $(PUBLISH_ARGS) --tree "$(TREE)" \
+	--from-metadata \
     --output $(FINAL_REPO) \
     --packages $(DESTINATION) \
     --name "cOS" \

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -56,6 +56,7 @@ ifneq ($(shell id -u), 0)
 endif
 	$(LUET) create-repo --tree "$(TREE)" \
     --output $(DESTINATION) \
+    --from-metadata \
     --packages $(DESTINATION) \
     --name "cOS" \
     --descr "cOS $(FLAVOR)" \


### PR DESCRIPTION
Adds DOWNLOAD_ALL to add old packages back in the index, and enables it
on the publishing pipeline. This will cause the tree to see the old
packages and make them available for installation.

```
--> BUILD --> PULL all metadata 
           -> Create repository (with `--from-metadata`) -> PUBLISH
```
Requires luet 0.17.10 https://github.com/mudler/luet/commit/e4fff77d4390a43552ecd02e4988f6eeb5d49139

Fixes #602

Blocked as requires luet 0.17.10 and needs some manual sanity check as it touches internals and could cause issues.. 

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>