### PR TITLE
ci: fixup invalid char for toolchain image tags

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -735,8 +735,10 @@
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Build  🔧
         run: |
-          docker build -t quay.io/costoolkit/toolchain:{{{$tag}}} .
-          docker push quay.io/costoolkit/toolchain:{{{$tag}}}
+          tag="{{{$tag}}}"
+          export P_VERSION="${tag/+/-}"
+          docker build -t quay.io/costoolkit/toolchain:$P_VERSION
+          docker push quay.io/costoolkit/toolchain:$P_VERSION
 {{{end}}}
 
 {{{define "toolchain_images"}}}

--- a/.github/workflows/build-master-x86_64.yaml
+++ b/.github/workflows/build-master-x86_64.yaml
@@ -877,8 +877,10 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Build  🔧
         run: |
-          docker build -t quay.io/costoolkit/toolchain:${{ env.COS_VERSION }} .
-          docker push quay.io/costoolkit/toolchain:${{ env.COS_VERSION }}
+          tag="${{ env.COS_VERSION }}"
+          export P_VERSION="${tag/+/-}"
+          docker build -t quay.io/costoolkit/toolchain:$P_VERSION
+          docker push quay.io/costoolkit/toolchain:$P_VERSION
   build-toolchain-latest:
     if: "!startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
@@ -903,5 +905,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Build  🔧
         run: |
-          docker build -t quay.io/costoolkit/toolchain:latest .
-          docker push quay.io/costoolkit/toolchain:latest
+          tag="latest"
+          export P_VERSION="${tag/+/-}"
+          docker build -t quay.io/costoolkit/toolchain:$P_VERSION
+          docker push quay.io/costoolkit/toolchain:$P_VERSION

--- a/.github/workflows/build-releases-x86_64.yaml
+++ b/.github/workflows/build-releases-x86_64.yaml
@@ -981,8 +981,10 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Build  🔧
         run: |
-          docker build -t quay.io/costoolkit/toolchain:${{ env.COS_VERSION }} .
-          docker push quay.io/costoolkit/toolchain:${{ env.COS_VERSION }}
+          tag="${{ env.COS_VERSION }}"
+          export P_VERSION="${tag/+/-}"
+          docker build -t quay.io/costoolkit/toolchain:$P_VERSION
+          docker push quay.io/costoolkit/toolchain:$P_VERSION
   build-toolchain-latest:
     if: "!startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
@@ -1007,8 +1009,10 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Build  🔧
         run: |
-          docker build -t quay.io/costoolkit/toolchain:latest .
-          docker push quay.io/costoolkit/toolchain:latest
+          tag="latest"
+          export P_VERSION="${tag/+/-}"
+          docker build -t quay.io/costoolkit/toolchain:$P_VERSION
+          docker push quay.io/costoolkit/toolchain:$P_VERSION
   # We need only a single vanilla image for any OS
   # Vanilla image is always based on openSUSE
   publish-vanilla-ami:


### PR DESCRIPTION
'+' is not valid, replacing with '-'

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>