### PR TITLE
Delete EBS root volumes by default

### DIFF
--- a/packer/images.json.pkr.hcl
+++ b/packer/images.json.pkr.hcl
@@ -19,6 +19,7 @@ source "amazon-ebs" "cos" {
     owners      = var.aws_source_ami_filter_owners
   }
   launch_block_device_mappings {
+    delete_on_termination = var.aws_launch_volume_delete_on_terminate
     device_name = var.aws_launch_volume_name
     volume_size = var.aws_launch_volume_size
   }

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -62,6 +62,12 @@ variable "aws_source_ami_filter_virtualization-type" {
   description = "Type of virtualization type to filter the search for the base AMI"
 }
 
+variable "aws_launch_volume_delete_on_terminate" {
+  type = bool
+  default = true
+  description = "Indicates whether the EBS volume is deleted on instance termination. Check https://www.packer.io/docs/builders/amazon/ebs#block-devices-configuration for full details"
+}
+
 variable "aws_launch_volume_name" {
   type = string
   default = "/dev/sda1"


### PR DESCRIPTION
By default set DeleteOnTermination so that EBS root volumes are deleted
with the EC2 instance. This is the default value of most public AMIs.