### PR TITLE
jq: build arm64 version

### DIFF
--- a/packages/utils/jq/build.yaml
+++ b/packages/utils/jq/build.yaml
@@ -19,7 +19,7 @@ prelude:
 
 steps:
 - |
-  PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
+  PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && \
   mkdir -p /luetbuild/{{ ( index .Values.labels "github.repo" ) }} && \
   cd /luetbuild/{{ ( index .Values.labels "github.repo" ) }} && \
   git clone https://github.com/{{ ( index .Values.labels "github.owner" ) }}/{{ ( index .Values.labels "github.repo" ) }} && \

--- a/packages/utils/jq/build.yaml
+++ b/packages/utils/jq/build.yaml
@@ -18,8 +18,6 @@ prelude:
   {{end}}
 
 steps:
-{{ if .Values.arch }}
-  {{ if eq .Values.arch "aarch64" }}
 - |
   PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
   mkdir -p /luetbuild/{{ ( index .Values.labels "github.repo" ) }} && \
@@ -31,11 +29,3 @@ steps:
   mkdir -p /${PACKAGE_NAME}/usr/bin && \
   cp ./${PACKAGE_NAME} /${PACKAGE_NAME}/usr/bin/${PACKAGE_NAME} && \
   chmod +x /${PACKAGE_NAME}/usr/bin/${PACKAGE_NAME}
-  {{else}}
-- | 
-   PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && \
-   mkdir -p /${PACKAGE_NAME}/usr/bin && \
-   curl -L https://github.com/{{ ( index .Values.labels "github.owner" ) }}/{{ ( index .Values.labels "github.repo" ) }}/releases/download/${PACKAGE_NAME}-${PACKAGE_VERSION}/jq-linux64 -o /${PACKAGE_NAME}/usr/bin/${PACKAGE_NAME} && \
-   chmod +x /${PACKAGE_NAME}/usr/bin/${PACKAGE_NAME}
-  {{ end }}
-{{ end }}

--- a/packages/utils/jq/build.yaml
+++ b/packages/utils/jq/build.yaml
@@ -5,9 +5,37 @@ requires:
 
 package_dir: /{{.Values.name}}
 
+prelude:
+  {{ if .Values.distribution }}
+  {{if eq .Values.distribution "opensuse" }}
+- zypper install -y autoconf libtool git gcc make
+  {{else if eq .Values.distribution "fedora" }}
+- dnf install -y autoconf libtool git gcc make
+  {{else if eq .Values.distribution "ubuntu" }}
+- apt-get update
+- apt-get install -y autoconf libtool git gcc make
+  {{end}}
+  {{end}}
+
 steps:
+{{ if .Values.arch }}
+  {{ if eq .Values.arch "aarch64" }}
+- |
+  PACKAGE_VERSION=${PACKAGE_VERSION%\+*} && \
+  mkdir -p /luetbuild/{{ ( index .Values.labels "github.repo" ) }} && \
+  cd /luetbuild/{{ ( index .Values.labels "github.repo" ) }} && \
+  git clone https://github.com/{{ ( index .Values.labels "github.owner" ) }}/{{ ( index .Values.labels "github.repo" ) }} && \
+  cd {{ ( index .Values.labels "github.repo" ) }} && git checkout jq-"$PACKAGE_VERSION" -b build && \
+  git submodule update --init && autoreconf -fi && ./configure --with-oniguruma=builtin --disable-maintainer-mode && \
+  make LDFLAGS=-all-static && \
+  mkdir -p /${PACKAGE_NAME}/usr/bin && \
+  cp ./${PACKAGE_NAME} /${PACKAGE_NAME}/usr/bin/${PACKAGE_NAME} && \
+  chmod +x /${PACKAGE_NAME}/usr/bin/${PACKAGE_NAME}
+  {{else}}
 - | 
    PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && \
    mkdir -p /${PACKAGE_NAME}/usr/bin && \
    curl -L https://github.com/{{ ( index .Values.labels "github.owner" ) }}/{{ ( index .Values.labels "github.repo" ) }}/releases/download/${PACKAGE_NAME}-${PACKAGE_VERSION}/jq-linux64 -o /${PACKAGE_NAME}/usr/bin/${PACKAGE_NAME} && \
    chmod +x /${PACKAGE_NAME}/usr/bin/${PACKAGE_NAME}
+  {{ end }}
+{{ end }}

--- a/packages/utils/jq/definition.yaml
+++ b/packages/utils/jq/definition.yaml
@@ -1,6 +1,6 @@
 name: jq
 category: utils
-version: 1.6-23
+version: 1.6-24
 labels:
   github.repo: "jq"
   github.owner: "stedolan"


### PR DESCRIPTION
Default version was taking the x86_64 binary release from github for all
arches.

This patch downloads the git repo and builds the binary for arm64 if the
arch is set

Signed-off-by: Itxaka <igarcia@suse.com>