### PR TITLE
tests: introduce GatherAllLogs function

### DIFF
--- a/tests/deploys-images/deploy_test.go
+++ b/tests/deploys-images/deploy_test.go
@@ -17,10 +17,7 @@ var _ = Describe("cOS Deploy tests", func() {
 	AfterEach(func() {
 		// Try to gather mtree logs on failure
 		if CurrentGinkgoTestDescription().Failed {
-			s.GatherLog("/tmp/image-mtree-check.log")
-			s.GatherLog("/tmp/luet_mtree_failures.log")
-			s.GatherLog("/tmp/luet_mtree.log")
-			s.GatherLog("/tmp/luet.log")
+			s.GatherAllLogs()
 		}
 		if CurrentGinkgoTestDescription().Failed == false {
 			s.Reset()

--- a/tests/fallback/fallback_test.go
+++ b/tests/fallback/fallback_test.go
@@ -15,6 +15,9 @@ var _ = Describe("cOS booting fallback tests", func() {
 		s.EventuallyConnects()
 	})
 	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			s.GatherAllLogs()
+		}
 		if CurrentGinkgoTestDescription().Failed == false {
 			s.Reset()
 		}

--- a/tests/features/feature_test.go
+++ b/tests/features/feature_test.go
@@ -15,6 +15,12 @@ var _ = Describe("cOS Feature tests", func() {
 		s.EventuallyConnects(360)
 	})
 
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			s.GatherAllLogs()
+		}
+	})
+
 	Context("After install", func() {
 		It("can enable a persistent k3s install", func() {
 

--- a/tests/recovery-raw-disk/recovery_raw_disk_test.go
+++ b/tests/recovery-raw-disk/recovery_raw_disk_test.go
@@ -15,6 +15,12 @@ var _ = Describe("cOS Recovery deploy tests", func() {
 		s.EventuallyConnects(sut.TimeoutRawDiskTest)
 	})
 
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			s.GatherAllLogs()
+		}
+	})
+
 	Context("after running recovery from the raw_disk image", func() {
 		It("uses cos-deploy to install", func() {
 			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Recovery))

--- a/tests/recovery/recovery_test.go
+++ b/tests/recovery/recovery_test.go
@@ -15,6 +15,12 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 		s.EventuallyConnects()
 	})
 
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			s.GatherAllLogs()
+		}
+	})
+
 	Context("upgrading COS_ACTIVE from the recovery partition", func() {
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed == false {

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -13,6 +13,12 @@ var _ = Describe("cOS Smoke tests", func() {
 		s.EventuallyConnects()
 	})
 
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			s.GatherAllLogs()
+		}
+	})
+
 	Context("After install", func() {
 		It("can boot into passive", func() {
 			err := s.ChangeBootOnce(sut.Passive)

--- a/tests/upgrades-images-signed/upgrade_test.go
+++ b/tests/upgrades-images-signed/upgrade_test.go
@@ -17,10 +17,7 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 	AfterEach(func() {
 		// Try to gather mtree logs on failure
 		if CurrentGinkgoTestDescription().Failed {
-			s.GatherLog("/tmp/image-mtree-check.log")
-			s.GatherLog("/tmp/luet_mtree_failures.log")
-			s.GatherLog("/tmp/luet_mtree.log")
-			s.GatherLog("/tmp/luet.log")
+			s.GatherAllLogs()
 		}
 		if CurrentGinkgoTestDescription().Failed == false {
 			s.Reset()

--- a/tests/upgrades-images-unsigned/upgrade_test.go
+++ b/tests/upgrades-images-unsigned/upgrade_test.go
@@ -17,6 +17,9 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 	})
 
 	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			s.GatherAllLogs()
+		}
 		if CurrentGinkgoTestDescription().Failed == false {
 			s.Reset()
 		}

--- a/tests/upgrades-local/upgrade_test.go
+++ b/tests/upgrades-local/upgrade_test.go
@@ -15,6 +15,12 @@ var _ = Describe("cOS Upgrade tests - local upgrades", func() {
 		s.EventuallyConnects(360)
 	})
 
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			s.GatherAllLogs()
+		}
+	})
+
 	Context("After install can upgrade and reset", func() {
 		When("specifying a directory to upgrade from", func() {
 			It("upgrades from the specified path", func() {


### PR DESCRIPTION
Instead of adding to each test the files that we waznt to gather, we can
centralize everything in a single function for easy expansion.

GatherAllLogs expands the gathering to service files, full journalctl,
dmesg, uname, disks and users.

closes #674 

Signed-off-by: Itxaka <igarcia@suse.com>