### PR TITLE
ci: split docker builds into itw own workflow

### DIFF
--- a/.github/config/pr-docker.yaml
+++ b/.github/config/pr-docker.yaml
@@ -1,0 +1,30 @@
+---
+
+arches:
+  x86_64:
+    local_runner: false
+    pipeline: "Pull requests - docker"
+    push_cache: false
+    publishing_pipeline: false
+    publish_toolchain: false
+    publish_cloud: false
+    skip_build: true
+    skip_docker_build: false
+    repository: "releases" # releases for prod
+    cache_repository: "build"
+    organization: "quay.io/costoolkit"
+    skip_tests: true
+    flavors: ["green", "blue", "orange"]
+    skip_tests_flavor: ["green","blue","orange"]
+    skip_images_flavor: ["green","blue","orange"]
+    release_flavor: ["green"]
+    arch: "x86_64"
+    on:
+      pull_request:
+        paths:
+          - 'conf/**'
+          - 'packages/**'
+          - 'make/**'
+          - '.github/**'
+          - 'Makefile'
+          - 'tests/**'

--- a/.github/config/pr.yaml
+++ b/.github/config/pr.yaml
@@ -9,7 +9,7 @@ arches:
     publish_toolchain: false
     publish_cloud: false
     skip_build: false
-    skip_docker_build: false
+    skip_docker_build: true
     repository: "releases" # releases for prod
     cache_repository: "build"
     organization: "quay.io/costoolkit"

--- a/.github/workflows/build-pr-docker-x86_64.yaml
+++ b/.github/workflows/build-pr-docker-x86_64.yaml
@@ -1,0 +1,68 @@
+name: Build cOS Pull requests - docker
+on: 
+ pull_request:
+   paths:
+     - conf/**
+     - packages/**
+     - make/**
+     - .github/**
+     - Makefile
+     - tests/**
+concurrency:
+  group: ci-Pull requests - docker-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+jobs:
+  docker-build-green:
+    runs-on: ubuntu-latest
+    env:
+      FLAVOR: green
+      ARCH: x86_64
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+      - name: Build  🔧
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          source .envrc
+          cos-build $FLAVOR
+  docker-build-blue:
+    runs-on: ubuntu-latest
+    env:
+      FLAVOR: blue
+      ARCH: x86_64
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+      - name: Build  🔧
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          source .envrc
+          cos-build $FLAVOR
+  docker-build-orange:
+    runs-on: ubuntu-latest
+    env:
+      FLAVOR: orange
+      ARCH: x86_64
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+      - name: Build  🔧
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          source .envrc
+          cos-build $FLAVOR

--- a/.github/workflows/build-pr-x86_64.yaml
+++ b/.github/workflows/build-pr-x86_64.yaml
@@ -12,24 +12,6 @@ concurrency:
   group: ci-Pull requests-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  docker-build-green:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: green
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR
   build-green-x86_64:
     runs-on: ubuntu-latest
     env:
@@ -490,24 +472,6 @@ jobs:
           name: cOS-raw_disk_test_deploy-green.serial.zip
           path: serial_port1.log
           if-no-files-found: warn
-  docker-build-blue:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: blue
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR
   build-blue-x86_64:
     runs-on: ubuntu-latest
     env:
@@ -556,24 +520,6 @@ jobs:
           name: build-blue-x86_64
           path: build
           if-no-files-found: error
-  docker-build-orange:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: orange
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR
   build-orange-x86_64:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Docker builds take way too much time. If for some reason we need to
relaunch the workflow it means that they need to be also rebuild from
scratch which makes no sense at all.

This patch splits them into theyr own workflow so our main PR workflow
sts ligther and can be retriggered without affecting others

Signed-off-by: Itxaka <igarcia@suse.com>