### PR TITLE
ci: Require labels for certain jobs without failing

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -67,18 +67,29 @@
   {{{ $config := (datasource "config") }}}
   {{{- if $config.local_runner }}}
     runs-on: [{{{ join $config.runs_on ", "}}}]
-    if: contains(["mudler", "davidcassany", "itxaka", kkaempf", "cOS-cibot"], "${{ github.actor }}") || contains(github.event.pull_request.labels.*.name, 'safe to test')
   {{{- else }}}
     runs-on: ubuntu-latest
   {{{ end }}}
 {{{end}}}
 
-{{{define "needs"}}}
-    {{{ $config := (datasource "config") }}}
-    {{{if has $config "labels"}}}
-    needs:
-      - check-labels
-    {{{end}}}
+{{{- define "generate_labels"}}}
+{{{- $config := (datasource "config") }}}
+{{{- range $config.labels}}} && contains(github.event.pull_request.labels.*.name, '{{{ . }}}'){{{- end}}}
+{{{- end}}}
+
+{{{define "if_with_labels"}}}
+{{{ $config := (datasource "config") }}}
+{{{if has $config "labels"}}}
+  {{{- if $config.local_runner }}}
+    if: contains(fromJson('["mudler", "davidcassany", "itxaka", "kkaempf", "cOS-cibot"]'), github.actor) {{{- tmpl.Exec "generate_labels" }}}
+  {{{else}}}
+    if: always() && {{{- tmpl.Exec "generate_labels" }}}
+  {{{end}}}
+{{{else}}}
+  {{{- if $config.local_runner }}}
+    if: contains(fromJson('["mudler", "davidcassany", "itxaka", "kkaempf", "cOS-cibot"]'), github.actor)
+  {{{end}}}
+{{{end}}}
 {{{end}}}
 
 {{{define "docker_build_packages"}}}
@@ -86,7 +97,7 @@
   {{{ $flavor := . }}}
   docker-build-{{{ $flavor }}}:
     {{{ tmpl.Exec "runner" }}}
-    {{{ tmpl.Exec "needs" }}}
+    {{{tmpl.Exec "if_with_labels" }}}
     env:
       FLAVOR: {{{ $flavor }}}
       ARCH: {{{ $config.arch }}}
@@ -109,7 +120,7 @@
   {{{ $flavor := . }}}
   build-{{{ $flavor }}}-{{{ $config.arch }}}:
     {{{ tmpl.Exec "runner" }}}
-    {{{ tmpl.Exec "needs" }}}
+    {{{tmpl.Exec "if_with_labels" }}}
     env:
       LUET_ARCH: {{{ $config.arch }}}
       FLAVOR: {{{ $flavor }}}
@@ -688,6 +699,7 @@
   {{{ $dir := . }}}
   docker-build-example-{{{ $dir }}}:
     {{{ tmpl.Exec "runner" }}}
+    {{{tmpl.Exec "if_with_labels" }}}
     steps:
   {{{- if $config.local_runner }}}
       - run: |
@@ -713,19 +725,6 @@
             {{{ $dir }}}.tar
 {{{end}}}
 
-{{{define "check_labels"}}}
-{{{ $config := (datasource "config") }}}
-    {{{- if has $config "labels" }}}
-  check-labels:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mheap/github-action-required-labels@v1
-        with:
-          mode: exactly
-          count: {{{- if has $config "label_count" }}} {{{$config.label_count}}} {{{- else}}} {{{ len $config.labels }}} {{{- end}}}
-          labels: "{{{ join $config.labels  " "}}}"
-    {{{- end }}}
-{{{end}}}
 
 {{{define "toolchain_images_steps"}}}
 {{{ $tag := . }}}
@@ -771,7 +770,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-{{{tmpl.Exec "check_labels" }}}
 {{{- if (has $config "build_examples_dir") }}}
   {{{- range $config.build_examples_dir }}}
     {{{$dir:=.}}}

--- a/.github/config/pr.yaml
+++ b/.github/config/pr.yaml
@@ -47,8 +47,8 @@ arches:
     skip_images_flavor: [ "green","blue","orange" ]
     release_flavor: [ "green" ]
     arch: "arm64"
-    # list of labels to check in order to run jobs in this workflow
-    labels: [ "arm64" ]
+    # labels required for this job to run, list of labels. All will be required.
+    labels: ["arm64"]
 
     on:
       pull_request:

--- a/.github/workflows/build-master-arm64.yaml
+++ b/.github/workflows/build-master-arm64.yaml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build-green-arm64:
     runs-on: [self-hosted, arm64]
-    if: contains(["mudler", "davidcassany", "itxaka", kkaempf", "cOS-cibot"], "${{ github.actor }}") || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    if: contains(fromJson('["mudler", "davidcassany", "itxaka", "kkaempf", "cOS-cibot"]'), github.actor)
     env:
       LUET_ARCH: arm64
       FLAVOR: green

--- a/.github/workflows/build-pr-arm64.yaml
+++ b/.github/workflows/build-pr-arm64.yaml
@@ -8,19 +8,9 @@ concurrency:
   group: ci-Pull requests - arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  check-labels:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mheap/github-action-required-labels@v1
-        with:
-          mode: exactly
-          count: 1
-          labels: "arm64"
   build-green-arm64:
     runs-on: [self-hosted, arm64]
-    if: contains(["mudler", "davidcassany", "itxaka", kkaempf", "cOS-cibot"], "${{ github.actor }}") || contains(github.event.pull_request.labels.*.name, 'safe to test')
-    needs:
-      - check-labels
+    if: contains(fromJson('["mudler", "davidcassany", "itxaka", "kkaempf", "cOS-cibot"]'), github.actor) && contains(github.event.pull_request.labels.*.name, 'arm64')
     env:
       LUET_ARCH: arm64
       FLAVOR: green

--- a/.github/workflows/build-releases-arm64.yaml
+++ b/.github/workflows/build-releases-arm64.yaml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   build-green-arm64:
     runs-on: [self-hosted, arm64]
-    if: contains(["mudler", "davidcassany", "itxaka", kkaempf", "cOS-cibot"], "${{ github.actor }}") || contains(github.event.pull_request.labels.*.name, 'safe to test')
+    if: contains(fromJson('["mudler", "davidcassany", "itxaka", "kkaempf", "cOS-cibot"]'), github.actor)
     env:
       LUET_ARCH: arm64
       FLAVOR: green


### PR DESCRIPTION
Instead of checking and failing all the time, we can just use a if on
the main jobs that trigger the rest, as if those are skipped, the rest
should be and we wont get the ugly red X everywhere.

This also should allow us to use more labels in PRs

Signed-off-by: Itxaka <igarcia@suse.com>