### PR TITLE
installer: User arch variables for installation

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: "0.7.0-1"
+    version: "0.7.0-2"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,4 +1,4 @@
 name: "installer"
 category: "utils"
-version: "0.17"
+version: "0.17.1"
 description: "Installer, Upgrade and reset utilities to manage cOS derivatives"

--- a/packages/installer/installer.sh
+++ b/packages/installer/installer.sh
@@ -9,6 +9,11 @@ ISOBOOT=${ISOMNT}/boot
 TARGET=/run/cos/target
 RECOVERYDIR=/run/cos/recovery
 RECOVERYSQUASHFS=${ISOMNT}/recovery.squashfs
+ARCH=$(uname -p)
+
+if [ "${ARCH}" == "aarch64" ]; then
+  ARCH="arm64"
+fi
 
 source /usr/lib/cos/functions.sh
 
@@ -265,7 +270,7 @@ install_grub()
     fi
 
     if [ "$COS_INSTALL_FORCE_EFI" = "true" ] || [ -e /sys/firmware/efi ]; then
-        GRUB_TARGET="--target=x86_64-efi --efi-directory=${TARGET}/boot/efi"
+        GRUB_TARGET="--target=${ARCH}-efi --efi-directory=${TARGET}/boot/efi"
     fi
 
     mkdir ${TARGET}/proc || true

--- a/packages/installer/reset.sh
+++ b/packages/installer/reset.sh
@@ -3,6 +3,12 @@ set -e
 
 source /usr/lib/cos/functions.sh
 
+ARCH=$(uname -p)
+
+if [ "${ARCH}" == "aarch64" ]; then
+  ARCH="arm64"
+fi
+
 is_booting_from_squashfs() {
     if cat /proc/cmdline | grep -q "COS_RECOVERY"; then
         return 0
@@ -82,7 +88,7 @@ cleanup()
 install_grub()
 {
     if [ "$COS_INSTALL_FORCE_EFI" = "true" ] || [ -e /sys/firmware/efi ]; then
-        GRUB_TARGET="--target=x86_64-efi --efi-directory=${STATEDIR}/boot/efi"
+        GRUB_TARGET="--target=${ARCH}-efi --efi-directory=${STATEDIR}/boot/efi"
     fi
     #mount -o remount,rw ${STATE} /boot/grub2
     grub2-install ${GRUB_TARGET} --root-directory=${STATEDIR} --boot-directory=${STATEDIR} --removable ${DEVICE}

--- a/packages/installer/upgrade.sh
+++ b/packages/installer/upgrade.sh
@@ -4,6 +4,10 @@ set -e
 source /usr/lib/cos/functions.sh
 
 CHANNEL_UPGRADES="${CHANNEL_UPGRADES:-true}"
+ARCH=$(uname -p)
+if [ "${ARCH}" == "aarch64" ]; then
+  ARCH="arm64"
+fi
 
 # 1. Identify active/passive partition
 # 2. Install upgrade in passive partition
@@ -255,7 +259,12 @@ switch_active() {
 
 switch_recovery() {
     if is_squashfs; then
-        mksquashfs $TARGET ${STATEDIR}/cOS/transition.squashfs -b 1024k -comp xz -Xbcj x86
+        if [[ "${ARCH}" == "arm64" ]]; then
+          XZ_FILTER="arm"
+        else
+          XZ_FILTER="x86"
+        fi
+        mksquashfs $TARGET ${STATEDIR}/cOS/transition.squashfs -b 1024k -comp xz -Xbcj ${XZ_FILTER}
         mv ${STATEDIR}/cOS/transition.squashfs ${STATEDIR}/cOS/recovery.squashfs
         rm -rf $TARGET
     else


### PR DESCRIPTION
Use the current ARCH for things like installing grub.

Also changes the squashfs filter for compression depending on arch

Fixes #718 ... I think...

Signed-off-by: Itxaka <igarcia@suse.com>