### PR TITLE
immutable-rootfs: add newer packages for fs expansion

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: "0.7.0-2"
+    version: "0.7.0-3"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
+++ b/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
@@ -29,7 +29,7 @@ install() {
     # Include utilities required for cos-setup services,
     # probably a devoted cos-setup dracut module makes sense
     inst_multiple -o \
-        partprobe lsblk sgdisk mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat mkfs.xfs
+        partprobe lsblk sgdisk mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat mkfs.xfs blkid e2fsck resize2fs mount xfs_growfs umount
     inst_hook cmdline 30 "${moddir}/parse-cos-cmdline.sh"
     inst_script "${moddir}/cos-generator.sh" \
         "${systemdutildir}/system-generators/dracut-cos-generator"

--- a/packages/immutable-rootfs/definition.yaml
+++ b/packages/immutable-rootfs/definition.yaml
@@ -1,3 +1,3 @@
 name: "immutable-rootfs"
 category: "system"
-version: 0.2.0-7
+version: 0.2.0-8

--- a/packages/initrd/definition.yaml
+++ b/packages/initrd/definition.yaml
@@ -1,4 +1,4 @@
 name: "dracut-initrd"
 category: "system"
-version: 0.1.1-20
+version: 0.1.1-21
 description: "Dracut-based generated initrd"

--- a/packages/meta/collection.yaml
+++ b/packages/meta/collection.yaml
@@ -24,7 +24,7 @@ packages:
 - category: "meta"
   name: "cos-modules"
   description: "Meta package for cOS core modules. It includes installer, cos-setup, dracut and grub configuration"
-  version: "0.6"
+  version: "0.7"
   requires:
   - category: utils
     name: installer

--- a/packages/toolchain/collection.yaml
+++ b/packages/toolchain/collection.yaml
@@ -43,7 +43,7 @@ packages:
     name: "yip"
     upx: false
     fips: true
-    version: 0.9.12-3
+    version: 0.9.13
     labels:
       github.repo: "yip"
       github.owner: "mudler"
@@ -53,7 +53,7 @@ packages:
     name: "yip"
     upx: false
     fips: false
-    version: 0.9.12-4
+    version: 0.9.13
     labels:
       github.repo: "yip"
       github.owner: "mudler"


### PR DESCRIPTION
Due to changes to the yip plugin for layout, we need some extra binaries
in the immutable-rootfs to support expanding the fs if we grow a
partition

Closes #661 

Requires:
 - https://github.com/mudler/yip/pull/23
 - New yip release
 - Bumping the required yip package in this same PR

Signed-off-by: Itxaka <igarcia@suse.com>