### PR TITLE
make: fix FINAL_REPO order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,7 @@ ifeq ("$(MTREE)","")
 MTREE="/usr/bin/luet-mtree"
 endif
 
-#
-# Output for "make publish-repo" and base for "make iso"
-#
-ifneq ($(strip $(ARCH)), x86_64)
-	FINAL_REPO?=quay.io/costoolkit/releases-$(FLAVOR)-$(ARCH)
-else
-	FINAL_REPO?=quay.io/costoolkit/releases-$(FLAVOR)
-endif
+
 
 #
 # Location of package tree
@@ -73,6 +66,15 @@ FLAVOR?=green
 #
 
 ARCH?=x86_64
+
+#
+# Output for "make publish-repo" and base for "make iso"
+#
+ifneq ($(strip $(ARCH)), x86_64)
+	FINAL_REPO?=quay.io/costoolkit/releases-$(FLAVOR)-$(ARCH)
+else
+	FINAL_REPO?=quay.io/costoolkit/releases-$(FLAVOR)
+endif
 
 #
 # folder for build artefacts


### PR DESCRIPTION
It makes sense to first define your var and then check fir its value
rather than the reverse. Otherwise your var will always be empty :/

Only affected local runs of `publish-repo` and `iso`

Signed-off-by: Itxaka <igarcia@suse.com>