### PR TITLE
ci: Fix locating the aarch efi file

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -260,7 +260,7 @@
           {{{if eq $config.arch "arm64" }}}
           export PKR_VAR_accelerator=none
           export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware="/usr/local/Cellar/qemu/6.1.0/share/qemu/edk2-aarch64-code.fd"
+          export PKR_VAR_firmware=$(find /usr/local/Cellar/qemu/ -name  edk2-aarch64-code.fd -print -quit)
           PACKER_ARGS="-only qemu.cos-arm64" make packer
           {{{else}}}
           export PKR_VAR_accelerator=hvf

--- a/.github/workflows/build-pr-green-arm64.yaml
+++ b/.github/workflows/build-pr-green-arm64.yaml
@@ -135,7 +135,7 @@ jobs:
           export PKR_VAR_feature=vagrant
           export PKR_VAR_accelerator=none
           export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware="/usr/local/Cellar/qemu/6.1.0/share/qemu/edk2-aarch64-code.fd"
+          export PKR_VAR_firmware=$(find /usr/local/Cellar/qemu/ -name  edk2-aarch64-code.fd -print -quit)
           PACKER_ARGS="-only qemu.cos-arm64" make packer
       - uses: actions/upload-artifact@v2
         with:
@@ -222,7 +222,7 @@ jobs:
           export PKR_VAR_feature=vagrant
           export PKR_VAR_accelerator=none
           export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware="/usr/local/Cellar/qemu/6.1.0/share/qemu/edk2-aarch64-code.fd"
+          export PKR_VAR_firmware=$(find /usr/local/Cellar/qemu/ -name  edk2-aarch64-code.fd -print -quit)
           PACKER_ARGS="-only qemu.cos-arm64" make packer
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Instead of hardcoding the path, which will fail once a new qemu version
is released, use a simple find to locate the proper version
automatically.

Signed-off-by: Itxaka <igarcia@suse.com>