### PR TITLE
make: Default to building virtualbox with packer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ export MANIFEST?=$(ROOT_DIR)/manifest.yaml
 #
 # Arguments to packer for creating the ISO
 #
-PACKER_ARGS?=
+PACKER_ARGS?=-only virtualbox-iso.cos
 
 #
 # Used by .iso, .test, and .run


### PR DESCRIPTION
As PACKER_ARGS is not defined with sane values, if for some reason
packer is called from without the makefile (like calling prepare-test
with no box files around) it would trigger a build on ALL the availabel
providers, i.e. AWS, Azure, etc... which is bad. Especially if you have
your creds loaded in the shell.

This patch makes it default to the virtualbox-iso provider by default if
no args are passed

Signed-off-by: Itxaka <igarcia@suse.com>