### PR TITLE
ci: Add new instance to exclude list

### DIFF
--- a/.github/workflows/cloud-cleaner.yaml
+++ b/.github/workflows/cloud-cleaner.yaml
@@ -10,7 +10,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      EXCLUDE_LIST: "i-07853668c7deeee4a"
+      EXCLUDE_LIST: "i-06da6bc86d50d5612"
       DO_CLEANUP: "true"
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I screwed up the old instance yesterday while hacking away at the arm64 tests so we need to prepare a new one. 

This patch adds it to the exclude list so its not cleaned automatically

Signed-off-by: Itxaka <igarcia@suse.com>