### PR TITLE
Customize grub menu

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.1-7
+    version: "0.7.2"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -16,12 +16,9 @@ packages:
     category: "recovery"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
-    version: 0.7.1-7
   - !!merge <<: *cos
     name: "cos-img"
     category: "recovery"
-    version: 0.7.1-7
   - !!merge <<: *cos
     name: "cos-squash"
     category: "recovery"
-    version: 0.7.1-7

--- a/packages/grub2/build.yaml
+++ b/packages/grub2/build.yaml
@@ -21,16 +21,16 @@ steps:
 - cp config/grub_efi.cfg /EFI/BOOT/grub.cfg
   {{if .Values.distribution}}
     {{if eq .Values.distribution "opensuse"}}
-  {{if .Values.arch }}
-    {{if eq .Values.arch "x86_64"}}
+      {{if .Values.arch }}
+        {{if eq .Values.arch "x86_64"}}
 - cp /usr/share/grub2/x86_64-efi/grub.efi /EFI/BOOT/bootx64.efi
-    {{end}}
-    {{if eq .Values.arch "aarch64"}}
+        {{end}}
+       {{if eq .Values.arch "aarch64"}}
 - cp /usr/share/grub2/arm64-efi/grub.efi /EFI/BOOT/bootaa64.efi
-    {{end}}
-  {{end}}
-  {{else if eq .Values.distribution "fedora"}}
-    {{if eq .Values.arch "x86_64"}}
+       {{end}}
+     {{end}}
+    {{else if eq .Values.distribution "fedora"}}
+      {{if eq .Values.arch "x86_64"}}
 - grub2-mkimage -O x86_64-efi -o /EFI/BOOT/bootx64.efi -c /EFI/BOOT/grub.cfg -p /grub2 -d /usr/lib/grub/x86_64-efi {{.Values.efi_modules}}
     {{else if eq .Values.arch "aarch64"}}
 - mkdir -p /EFI/fedora
@@ -40,9 +40,9 @@ steps:
   {{else if eq .Values.distribution "ubuntu"}}
     {{if eq .Values.arch "x86_64"}}
 - grub-mkimage -O x86_64-efi -o /EFI/BOOT/bootx64.efi -c /EFI/BOOT/grub.cfg -p /grub2 -d /usr/lib/grub/x86_64-efi {{.Values.efi_modules}} linuxefi
-    {{else if eq .Values.arch "aarch64"}}
+      {{else if eq .Values.arch "aarch64"}}
 - grub-mkimage -O arm64-efi -o /EFI/BOOT/bootaa64.efi -c /EFI/BOOT/grub.cfg -p /grub2 -d /usr/lib/grub/arm64-efi {{.Values.efi_modules_arm64}}
-    {{end}}
+      {{end}}
     {{end}}
   {{end}}
 {{end}}

--- a/packages/grub2/collection.yaml
+++ b/packages/grub2/collection.yaml
@@ -7,7 +7,7 @@ packages:
         version: ">0.0.2"
   - name: "grub2-config"
     category: "system"
-    version: 0.0.13-8
+    version: "0.0.14"
     provides:
       - name: "grub-config"
         version: ">0.0.12"

--- a/packages/grub2/config/grub.cfg
+++ b/packages/grub2/config/grub.cfg
@@ -57,7 +57,7 @@ menuentry "${display_name}" --id cos {
   loopback loop0 /$img
   set root=($root)
   source (loop0)/etc/cos/bootargs.cfg
-  linux (loop0)$kernel $kernelcmd ${extra_cmdline}
+  linux (loop0)$kernel $kernelcmd ${extra_cmdline} ${extra_active_cmdline}
   initrd (loop0)$initramfs
 }
 
@@ -68,7 +68,7 @@ menuentry "${display_name} (fallback)" --id fallback {
   loopback loop0 /$img
   set root=($root)
   source (loop0)/etc/cos/bootargs.cfg
-  linux (loop0)$kernel $kernelcmd ${extra_cmdline}
+  linux (loop0)$kernel $kernelcmd ${extra_cmdline} ${extra_passive_cmdline}
   initrd (loop0)$initramfs
 }
 
@@ -84,7 +84,7 @@ menuentry "${display_name} recovery" --id recovery {
   loopback loop0 /$img
   set root=($root)
   source (loop0)/etc/cos/bootargs.cfg
-  linux (loop0)$kernel $kernelcmd ${extra_cmdline}
+  linux (loop0)$kernel $kernelcmd ${extra_cmdline} ${extra_recovery_cmdline}
   initrd (loop0)$initramfs
 }
 

--- a/packages/grub2/config/grub.cfg
+++ b/packages/grub2/config/grub.cfg
@@ -1,12 +1,26 @@
 set timeout=10
 
+# Load custom env file
 set env_file="/grubenv"
 search --file --set=env_blk "${env_file}"
+
+# Load custom env file
+set oem_env_file="/grub_oem_env"
+search --file --set=oem_blk "${oem_env_file}"
+
+# Load custom config file
+set custom_menu="/grubmenu"
+search --file --set=menu_blk "${custom_menu}"
+
+if [ "${oem_blk}" ] ; then
+  load_env -f "(${oem_blk})${oem_env_file}"
+fi
 
 if [ "${env_blk}" ] ; then
   load_env -f "(${env_blk})${env_file}"
 fi
 
+# Save default
 if [ "${next_entry}" ]; then
   set default="${next_entry}"
   set next_entry=
@@ -15,7 +29,20 @@ else
   set default="${saved_entry}"
 fi
 
-set fallback="0 1 2"
+## Display a default menu entry if set
+if [ "${default_menu_entry}" ]; then
+  set display_name="${default_menu_entry}"
+else
+  set display_name="cOS"
+fi
+
+## Set a default fallback if set
+if [ "${default_fallback}" ]; then
+  set fallback="${default_fallback}"
+else
+  set fallback="0 1 2"
+fi
+
 set gfxmode=auto
 set gfxpayload=keep
 insmod all_video
@@ -23,29 +50,29 @@ insmod gfxterm
 insmod loopback
 insmod squash4
 
-menuentry "cOS" --id cos {
+menuentry "${display_name}" --id cos {
   search.fs_label COS_STATE root
   set img=/cOS/active.img
   set label=COS_ACTIVE
   loopback loop0 /$img
   set root=($root)
   source (loop0)/etc/cos/bootargs.cfg
-  linux (loop0)$kernel $kernelcmd
+  linux (loop0)$kernel $kernelcmd ${extra_cmdline}
   initrd (loop0)$initramfs
 }
 
-menuentry "cOS (fallback)" --id fallback {
+menuentry "${display_name} (fallback)" --id fallback {
   search.fs_label COS_STATE root
   set img=/cOS/passive.img
   set label=COS_PASSIVE
   loopback loop0 /$img
   set root=($root)
   source (loop0)/etc/cos/bootargs.cfg
-  linux (loop0)$kernel $kernelcmd
+  linux (loop0)$kernel $kernelcmd ${extra_cmdline}
   initrd (loop0)$initramfs
 }
 
-menuentry "cOS recovery" --id recovery {
+menuentry "${display_name} recovery" --id recovery {
   if search.file /cOS/recovery.squashfs ; then
     set img=/cOS/recovery.squashfs
     set recoverylabel=COS_RECOVERY
@@ -57,6 +84,10 @@ menuentry "cOS recovery" --id recovery {
   loopback loop0 /$img
   set root=($root)
   source (loop0)/etc/cos/bootargs.cfg
-  linux (loop0)$kernel $kernelcmd
+  linux (loop0)$kernel $kernelcmd ${extra_cmdline}
   initrd (loop0)$initramfs
 }
+
+if [ "${menu_blk}" ]; then
+  source "(${menu_blk})${custom_menu}"
+fi

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -4,7 +4,7 @@ set -e
 PROG=$0
 
 ## Installer
-PROGS="dd curl mkfs.ext4 mkfs.vfat fatlabel parted partprobe grub2-install"
+PROGS="dd curl mkfs.ext4 mkfs.vfat fatlabel parted partprobe grub2-install grub2-editenv"
 DISTRO=/run/rootfsbase
 ISOMNT=/run/initramfs/live
 ISOBOOT=${ISOMNT}/boot
@@ -961,23 +961,7 @@ rebrand_grub_menu() {
 	   mount $STATEDIR /run/boot
 	fi
 
-	local grub_file=/run/boot/grub2/grub.cfg
-
-	# https://github.com/rancher-sandbox/cOS-toolkit/issues/537
-	if [ ! -e "$grub_file" ]; then
-	   grub_file="/run/boot/grub/grub.cfg"
-	fi
-
-	if [ ! -e "$grub_file" ]; then
-	   grub_file="/etc/cos/grub.cfg"
-	fi
-
-	if [ ! -e "$grub_file" ]; then
-	   echo "Grub config file not found"
-	   exit 1
-	fi
-
-	sed -i "s/menuentry \"cOS/menuentry \"$grub_entry/g" "$grub_file"
+    grub2-editenv /run/boot/grub_oem_env set default_menu_entry=$grub_entry
 
     umount /run/boot
 }


### PR DESCRIPTION
This PR adds in the GRUB configuration context:

- a `extra_cmdline` that can be specified as grub env config to specify additional booting kernel parameters (applied to all entries, `extra_active_cmdline`, `extra_passive_cmdline` and `extra_recovery_cmdline` for specific entrypoints)
- a `display_name` var that can be specified to tweak the default booting menu entry (in place of the current sed logic)
- a way to add additional config to the grub menu. If a file `/grubmenu` is found (e.g. in `COS_STATE`) it is sourced, and eventual menuentries declared inside are displayed in the boot menu
- a way to customize the fallback logic

It still needs tests and docs to be updated too