### PR TITLE
Partitioning layout

### DIFF
--- a/examples/standard/files/etc/cos/config
+++ b/examples/standard/files/etc/cos/config
@@ -37,3 +37,6 @@ COSIGN_EXPERIMENTAL=1
 # This can be set to file, URL, KMS URI or Kubernetes Secret
 # This is only used if COSIGN_EXPERIMENTAL is set to 0
 COSIGN_PUBLIC_KEY_LOCATION=""
+
+# Default size (in MB) of disk image files (.img) created during upgrades
+DEFAULT_IMAGE_SIZE=3240

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.2-2
+    version: "0.7.3"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -11,17 +11,13 @@ packages:
   - !!merge <<: *cos
     name: "cos-container"
     description: "cOS container image, used to build cOS derivatives from scratch"
-    version: 0.7.1-7
   - !!merge <<: *cos
     category: "recovery"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
-    version: 0.7.2-2
   - !!merge <<: *cos
     name: "cos-img"
     category: "recovery"
-    version: 0.7.2-2
   - !!merge <<: *cos
     name: "cos-squash"
     category: "recovery"
-    version: 0.7.2-2

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -14,7 +14,7 @@ RECOVERYSQUASHFS=${ISOMNT}/recovery.squashfs
 GRUBCONF=/etc/cos/grub.cfg
 
 # Default size (in MB) of disk image files (.img) created during upgrades
-COS_DEFAULT_IMAGE_SIZE=3240
+DEFAULT_IMAGE_SIZE=3240
 
 ## cosign signatures
 COSIGN_REPOSITORY="${COSIGN_REPOSITORY:-raccos/releases-:FLAVOR:}"
@@ -102,7 +102,7 @@ prepare_deploy_target() {
 
     mkdir -p ${STATEDIR}/cOS || true
     rm -rf ${STATEDIR}/cOS/active.img || true
-    dd if=/dev/zero of=${STATEDIR}/cOS/active.img bs=1M count=$COS_DEFAULT_IMAGE_SIZE
+    dd if=/dev/zero of=${STATEDIR}/cOS/active.img bs=1M count=$DEFAULT_IMAGE_SIZE
     mkfs.ext2 ${STATEDIR}/cOS/active.img
     mount -t ext2 -o loop ${STATEDIR}/cOS/active.img $TARGET
 }
@@ -110,7 +110,7 @@ prepare_deploy_target() {
 prepare_target() {
     mkdir -p ${STATEDIR}/cOS || true
     rm -rf ${STATEDIR}/cOS/transition.img || true
-    dd if=/dev/zero of=${STATEDIR}/cOS/transition.img bs=1M count=$COS_DEFAULT_IMAGE_SIZE
+    dd if=/dev/zero of=${STATEDIR}/cOS/transition.img bs=1M count=$DEFAULT_IMAGE_SIZE
     mkfs.ext2 ${STATEDIR}/cOS/transition.img
     mount -t ext2 -o loop ${STATEDIR}/cOS/transition.img $TARGET
 }
@@ -341,7 +341,7 @@ do_mount()
 
     mkdir -p ${STATEDIR}/cOS
     # TODO: Size should be tweakable
-    dd if=/dev/zero of=${STATEDIR}/cOS/active.img bs=1M count=$COS_DEFAULT_IMAGE_SIZE
+    dd if=/dev/zero of=${STATEDIR}/cOS/active.img bs=1M count=$DEFAULT_IMAGE_SIZE
     mkfs.ext2 ${STATEDIR}/cOS/active.img -L COS_ACTIVE
     sync
     LOOP=$(losetup --show -f ${STATEDIR}/cOS/active.img)
@@ -894,7 +894,7 @@ copy_active() {
         
         TARGET=$loop_dir
         # TODO: Size should be tweakable
-        dd if=/dev/zero of=${STATEDIR}/cOS/transition.img bs=1M count=$COS_DEFAULT_IMAGE_SIZE
+        dd if=/dev/zero of=${STATEDIR}/cOS/transition.img bs=1M count=$DEFAULT_IMAGE_SIZE
         mkfs.ext2 ${STATEDIR}/cOS/transition.img -L COS_PASSIVE
         sync
         LOOP=$(losetup --show -f ${STATEDIR}/cOS/transition.img)

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -199,9 +199,19 @@ prepare_passive() {
 part_probe() {
     local dev=$1
     partprobe ${dev} 2>/dev/null || true
+
+    sync
     sleep 2
 
     dmsetup remove_all 2>/dev/null || true
+}
+
+blkid_probe() {
+    OEM=$(blkid -L COS_OEM || true)
+    STATE=$(blkid -L COS_STATE || true)
+    RECOVERY=$(blkid -L COS_RECOVERY || true)
+    BOOT=$(blkid -L COS_GRUB || true)
+    PERSISTENT=$(blkid -L COS_PERSISTENT || true)
 }
 
 do_format()
@@ -211,10 +221,7 @@ do_format()
         if [ -z "$STATE" ] && [ -n "$DEVICE" ]; then
             tune2fs -L COS_STATE $DEVICE
         fi
-        OEM=$(blkid -L COS_OEM || true)
-        STATE=$(blkid -L COS_STATE || true)
-        RECOVERY=$(blkid -L COS_RECOVERY || true)
-        BOOT=$(blkid -L COS_GRUB || true)
+        blkid_probe
         return 0
     fi
 
@@ -249,10 +256,7 @@ do_format()
 
         part_probe $DEVICE
 
-        OEM=$(blkid -L COS_OEM || true)
-        STATE=$(blkid -L COS_STATE || true)
-        RECOVERY=$(blkid -L COS_RECOVERY || true)
-        BOOT=$(blkid -L COS_GRUB || true)
+        blkid_probe
 
         return 0
     fi

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -13,6 +13,9 @@ RECOVERYDIR=/run/cos/recovery
 RECOVERYSQUASHFS=${ISOMNT}/recovery.squashfs
 GRUBCONF=/etc/cos/grub.cfg
 
+# Default size (in MB) of disk image files (.img) created during upgrades
+COS_DEFAULT_IMAGE_SIZE=3240
+
 ## cosign signatures
 COSIGN_REPOSITORY="${COSIGN_REPOSITORY:-raccos/releases-:FLAVOR:}"
 COSIGN_EXPERIMENTAL="${COSIGN_EXPERIMENTAL:-1}"
@@ -99,7 +102,7 @@ prepare_deploy_target() {
 
     mkdir -p ${STATEDIR}/cOS || true
     rm -rf ${STATEDIR}/cOS/active.img || true
-    dd if=/dev/zero of=${STATEDIR}/cOS/active.img bs=1M count=3240
+    dd if=/dev/zero of=${STATEDIR}/cOS/active.img bs=1M count=$COS_DEFAULT_IMAGE_SIZE
     mkfs.ext2 ${STATEDIR}/cOS/active.img
     mount -t ext2 -o loop ${STATEDIR}/cOS/active.img $TARGET
 }
@@ -107,7 +110,7 @@ prepare_deploy_target() {
 prepare_target() {
     mkdir -p ${STATEDIR}/cOS || true
     rm -rf ${STATEDIR}/cOS/transition.img || true
-    dd if=/dev/zero of=${STATEDIR}/cOS/transition.img bs=1M count=3240
+    dd if=/dev/zero of=${STATEDIR}/cOS/transition.img bs=1M count=$COS_DEFAULT_IMAGE_SIZE
     mkfs.ext2 ${STATEDIR}/cOS/transition.img
     mount -t ext2 -o loop ${STATEDIR}/cOS/transition.img $TARGET
 }
@@ -118,7 +121,7 @@ usage()
     echo ""
     echo "Example: $PROG-install /dev/vda"
     echo "  install:"
-    echo "  [--force-efi] [--force-gpt] [--iso https://.../OS.iso] [--debug] [--tty TTY] [--poweroff] [--no-format] [--config https://.../config.yaml] DEVICE"
+    echo "  [--partition-layout /path/to/config/file.yaml ] [--force-efi] [--force-gpt] [--iso https://.../OS.iso] [--debug] [--tty TTY] [--poweroff] [--no-format] [--config https://.../config.yaml] DEVICE"
     echo ""
     echo "  upgrade:"
     echo "  [--strict] [--recovery] [--no-verify] [--no-cosign] [--directory] [--docker-image] (IMAGE/DIRECTORY)"
@@ -193,13 +196,20 @@ prepare_passive() {
     sync
 }
 
+part_probe() {
+    local dev=$1
+    partprobe ${dev} 2>/dev/null || true
+    sleep 2
+
+    dmsetup remove_all 2>/dev/null || true
+}
+
 do_format()
 {
     if [ "$COS_INSTALL_NO_FORMAT" = "true" ]; then
         STATE=$(blkid -L COS_STATE || true)
         if [ -z "$STATE" ] && [ -n "$DEVICE" ]; then
             tune2fs -L COS_STATE $DEVICE
-            STATE=$(blkid -L COS_STATE)
         fi
         OEM=$(blkid -L COS_OEM || true)
         STATE=$(blkid -L COS_STATE || true)
@@ -213,7 +223,44 @@ do_format()
     dd if=/dev/zero of=${DEVICE} bs=1M count=1
     parted -s ${DEVICE} mklabel ${PARTTABLE}
 
-    # TODO: Size should be tweakable
+    # Partitioning via cloud-init config file
+    if [ -n "$COS_PARTITION_LAYOUT" ]; then
+        if [ "$PARTTABLE" = "gpt" ] && [ "$BOOTFLAG" == "esp" ]; then
+            parted -s ${DEVICE} mkpart primary fat32 0% 50MB # efi
+            parted -s ${DEVICE} set 1 ${BOOTFLAG} on
+            PREFIX=${DEVICE}
+            if [ ! -e ${PREFIX}${STATE_NUM} ]; then
+                PREFIX=${DEVICE}p
+            fi
+            BOOT=${PREFIX}1
+            mkfs.vfat -F 32 ${BOOT}
+            fatlabel ${BOOT} COS_GRUB
+        elif [ "$PARTTABLE" = "gpt" ] && [ "$BOOTFLAG" == "bios_grub" ]; then
+            parted -s ${DEVICE} mkpart primary 0% 1MB # BIOS boot partition for GRUB
+            parted -s ${DEVICE} set 1 ${BOOTFLAG} on
+        else
+            BOOT_STATE=true
+        fi
+
+        yip -s partitioning $COS_PARTITION_LAYOUT
+
+        part_probe $DEVICE
+
+        OEM=$(blkid -L COS_OEM || true)
+        STATE=$(blkid -L COS_STATE || true)
+        RECOVERY=$(blkid -L COS_RECOVERY || true)
+        BOOT=$(blkid -L COS_GRUB || true)
+
+        ID=${STATE/$DEVICE/} # Gets the device number, e.g. /dev/sda2 -> 2
+        ID=${ID/p/} # Remove an eventual p e.g /dev/mmcblk0p1 
+        if [ -n "$BOOT_STATE" ]; then
+            parted -s ${DEVICE} set $ID ${BOOTFLAG} on
+        fi
+
+        return 0
+    fi
+
+    # Standard partitioning
     if [ "$PARTTABLE" = "gpt" ] && [ "$BOOTFLAG" == "esp" ]; then
         BOOT_NUM=1
         OEM_NUM=2
@@ -251,10 +298,7 @@ do_format()
         parted -s ${DEVICE} set 2 ${BOOTFLAG} on
     fi
 
-    partprobe ${DEVICE} 2>/dev/null || true
-    sleep 2
-
-    dmsetup remove_all 2>/dev/null || true
+    part_probe $DEVICE
 
     PREFIX=${DEVICE}
     if [ ! -e ${PREFIX}${STATE_NUM} ]; then
@@ -297,7 +341,7 @@ do_mount()
 
     mkdir -p ${STATEDIR}/cOS
     # TODO: Size should be tweakable
-    dd if=/dev/zero of=${STATEDIR}/cOS/active.img bs=1M count=3240
+    dd if=/dev/zero of=${STATEDIR}/cOS/active.img bs=1M count=$COS_DEFAULT_IMAGE_SIZE
     mkfs.ext2 ${STATEDIR}/cOS/active.img -L COS_ACTIVE
     sync
     LOOP=$(losetup --show -f ${STATEDIR}/cOS/active.img)
@@ -850,7 +894,7 @@ copy_active() {
         
         TARGET=$loop_dir
         # TODO: Size should be tweakable
-        dd if=/dev/zero of=${STATEDIR}/cOS/transition.img bs=1M count=3240
+        dd if=/dev/zero of=${STATEDIR}/cOS/transition.img bs=1M count=$COS_DEFAULT_IMAGE_SIZE
         mkfs.ext2 ${STATEDIR}/cOS/transition.img -L COS_PASSIVE
         sync
         LOOP=$(losetup --show -f ${STATEDIR}/cOS/transition.img)
@@ -1193,6 +1237,10 @@ install() {
             --config)
                 shift 1
                 COS_INSTALL_CONFIG_URL=$1
+                ;;
+            --partition-layout)
+                shift 1
+                COS_PARTITION_LAYOUT=$1
                 ;;
             --iso)
                 shift 1

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,4 +1,4 @@
 name: "installer"
 category: "utils"
-version: 0.20-1
+version: "0.21"
 description: "Installer, Upgrade and reset utilities to manage cOS derivatives"

--- a/packages/toolchain/collection.yaml
+++ b/packages/toolchain/collection.yaml
@@ -43,7 +43,7 @@ packages:
     name: "yip"
     upx: false
     fips: true
-    version: "0.9.20"
+    version: "0.9.21"
     labels:
       github.repo: "yip"
       github.owner: "mudler"
@@ -53,7 +53,7 @@ packages:
     name: "yip"
     upx: false
     fips: false
-    version: "0.9.20"
+    version: "0.9.21"
     labels:
       github.repo: "yip"
       github.owner: "mudler"


### PR DESCRIPTION
This makes the installer to accept a cloud-init file, - only with GPT partition types - like the following:

```yaml
stages:
   partitioning:
     - name: "Repart disk"
       layout:
         device:
           path: /dev/sda
         add_partitions:
           - fsLabel: COS_STATE
             size: 8192
             pLabel: state
           - fsLabel: COS_OEM
             size: 10
             pLabel: oem
           - fsLabel: COS_RECOVERY
             # default filesystem is ext2 if omitted
             filesystem: ext4
             size: 40000
             pLabel: recovery
           - fsLabel: COS_PERSISTENT
             pLabel: persistent
             # default filesystem is ext2 if omitted
             filesystem: ext4
             size: 40000
```

Of course, it can be also used to create additional partitions, or either create those into a different device (by setting `path`), having more stages, etc.

That can be supplied to the installer with `cos-installer --partition-layout <file> <device>`

![VirtualBox_cOS teststt_04_11_2021_12_55_21](https://user-images.githubusercontent.com/2420543/140309439-693086c7-11b4-4cf8-8161-abd7f1a2c4b9.png)

