### PR TITLE
ci: bump cos version to sync with recovery

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.2-1
+    version: 0.7.2-2
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:


### PR DESCRIPTION
Becuase our tests check the version under os-release and we use the
package version when building the packages, we end up with a cos system
that can have version X and a recovery that can have version Z. This
results in a cos-reset that doesnt really reset the exact version number
that was before.

Currently this only syncs the versions, the underlying issue is the same

Signed-off-by: Itxaka <igarcia@suse.com>