### PR TITLE
bump all livecd packages

### DIFF
--- a/packages/livecd/grub2/collection.yaml
+++ b/packages/livecd/grub2/collection.yaml
@@ -1,10 +1,10 @@
 packages:
 - name: "grub2"
   category: "live"
-  version: "0.0.2"
+  version: "0.0.2-1"
   description: "Grub2 booloader for live systems"
 
 - name: "grub2-efi-image"
   category: "live"
-  version: "0.0.1"
+  version: "0.0.1-1"
   description: "Grub2 booloader EFI image for live systems"

--- a/packages/livecd/live-boot/definition.yaml
+++ b/packages/livecd/live-boot/definition.yaml
@@ -1,5 +1,5 @@
 name: "boot"
 category: "live"
-version: "0.2.2"
+version: "0.2.2-1"
 
 hidden: true # No need to make it installable for now

--- a/packages/livecd/syslinux/build.yaml
+++ b/packages/livecd/syslinux/build.yaml
@@ -4,10 +4,10 @@ prelude:
 - apk add wget
 - |
    PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && \
-   wget https://kernel.org/pub/linux/utils/boot/syslinux/syslinux-{{.Values.version}}.tar.xz
-- echo "{{ ( index .Values.labels "package.checksum" ) }}  syslinux-{{.Values.version}}.tar.xz" | sha256sum -c
-- mkdir -p /syslinux
-- tar -xvf syslinux-{{.Values.version}}.tar.xz -C /syslinux
+   wget https://kernel.org/pub/linux/utils/boot/syslinux/syslinux-$PACKAGE_VERSION.tar.xz && \
+   echo "{{ ( index .Values.labels "package.checksum" ) }}  syslinux-$PACKAGE_VERSION.tar.xz" | sha256sum -c && \
+   mkdir -p /syslinux && \
+   tar -xvf syslinux-$PACKAGE_VERSION.tar.xz -C /syslinux
 steps:
 - |
    mkdir -p /output/boot/syslinux && \

--- a/packages/livecd/syslinux/definition.yaml
+++ b/packages/livecd/syslinux/definition.yaml
@@ -1,5 +1,5 @@
 category: "live"
 name: "syslinux"
-version: "6.03"
+version: "6.03-1"
 labels:
   package.checksum: "26d3986d2bea109d5dc0e4f8c4822a459276cf021125e8c9f23c3cca5d8c850e"

--- a/packages/livecd/systemd-boot/definition.yaml
+++ b/packages/livecd/systemd-boot/definition.yaml
@@ -1,6 +1,6 @@
 category: "live"
 name: "systemd-boot"
-version: "26"
+version: "26-1"
 package_version: "26-May-2018"
 labels:
   package.checksum: "371099b6382e787596363eb4a87bd9d59ebb6183e78840c14a9611d01c81cee1"


### PR DESCRIPTION
Unfortunately this packages are not usually bumped, so they are not
signed. If we want to have the full chain signed, we need to bump them
so they are pushed and signed, otherwise they wont be forcepushed, so no
signuture for them.

Signed-off-by: Itxaka <igarcia@suse.com>