### PR TITLE
Allow to specify an image to cos-installer

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.3-5
+    version: "0.7.4"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -15,12 +15,9 @@ packages:
     category: "recovery"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
-    version: 0.7.3-5
   - !!merge <<: *cos
     name: "cos-img"
     category: "recovery"
-    version: 0.7.3-5
   - !!merge <<: *cos
     name: "cos-squash"
     category: "recovery"
-    version: 0.7.3-5

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,4 +1,4 @@
 name: "installer"
 category: "utils"
-version: "0.21.1"
+version: "0.22"
 description: "Installer, Upgrade and reset utilities to manage cOS derivatives"

--- a/packages/installer/deploy.sh
+++ b/packages/installer/deploy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -e
 
-cos deploy $@
+export INTERACTIVE=true
+
+cos install --no-format $@

--- a/tests/recovery-raw-disk/recovery_raw_disk_test.go
+++ b/tests/recovery-raw-disk/recovery_raw_disk_test.go
@@ -1,10 +1,9 @@
 package cos_test
 
 import (
-	"github.com/rancher-sandbox/cOS/tests/sut"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/cOS/tests/sut"
 )
 
 var _ = Describe("cOS Recovery deploy tests", func() {


### PR DESCRIPTION
By making `cos-installer` capable to take container images in place of the ISO content, we are untying the installer from the ISO. This has two benefit:

1) the installer can be used to deploy cOS (and any derivative) outside of the ISO context, also standalone. For instance, IF in a booting (e.g. a 3rd party) LiveCD we can run docker, we could install cOS by using the installer inside our container image, specifying the partition and the image to deploy (I'll work on instructions later)
2) remove code dups. `cos-deploy` was partially crossing with `cos-installer`. The only difference is that `cos-deploy` doesn't format, and just copy an image during install, which now `cos-installer` is capable of too as well.

This commit drops cos-deploy * logics, but keeps the wrapper by calling `cos-installer` accordingly.

Additionally, cos-installer now accepts: `--docker-image`, `--no-verify` and `--no-cosign`