### PR TITLE
Quote the variable in case the value has spaces

### DIFF
--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -1006,7 +1006,7 @@ rebrand_grub_menu() {
 	   mount $STATEDIR /run/boot
 	fi
 
-    grub2-editenv /run/boot/grub_oem_env set default_menu_entry=$grub_entry
+    grub2-editenv /run/boot/grub_oem_env set default_menu_entry="$grub_entry"
 
     umount /run/boot
 }


### PR DESCRIPTION
We have a GRUB entry that contains spaces `Harvester 06f7009-dirty`, and it breaks `cos install`:
```
grub2-editenv: error: invalid parameter 06f7009-dirty
```
Add quotes to support values with spaces.