### PR TITLE
ci: Drop cosign action

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -525,8 +525,6 @@
             password: ${{ secrets.QUAY_PASSWORD }}
       {{{- end }}}
       {{{ tmpl.Exec "make" "deps" }}}
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-master-blue-arm64.yaml
+++ b/.github/workflows/build-master-blue-arm64.yaml
@@ -150,8 +150,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -151,8 +151,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -451,8 +451,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -636,8 +636,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-master-orange-arm64.yaml
+++ b/.github/workflows/build-master-orange-arm64.yaml
@@ -152,8 +152,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -151,8 +151,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -150,8 +150,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -151,8 +151,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -451,8 +451,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -636,8 +636,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -152,8 +152,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -151,8 +151,6 @@ jobs:
         run: |
           sudo -E make deps
           sudo luet install --no-spinner -y toolchain/yq
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@f700e6fbbab82f6897758a3af7a8dede4e308656 # v1.2.1
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
We are using our luet package as the source of truth so we should not
install cosign twice.

Signed-off-by: Itxaka <igarcia@suse.com>