### PR TITLE
Arm images (odroidC2)

### DIFF
--- a/.github/workflows/examples_publish.yaml
+++ b/.github/workflows/examples_publish.yaml
@@ -1,0 +1,71 @@
+---
+name: 'build multi-arch example files'
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - tag: "odroid-c2-"
+            dockerfile: "examples/odroid-c2"
+            platforms: "linux/arm64"
+          - tag: "odroid-c2-ubuntu-3.x"
+            dockerfile: "examples/odroid-c2-ubuntu"
+            platforms: "linux/arm64"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=quay.io/costoolkit/examples
+          VERSION=latest
+          SHORTREF=${GITHUB_SHA::8}
+          # If this is git tag, use the tag name as a docker tag
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          fi
+          TAGS="${DOCKER_IMAGE}:${{ matrix.tag }}${VERSION},${DOCKER_IMAGE}:${{ matrix.tag }}${SHORTREF}"
+          # If the VERSION looks like a version number, assume that
+          # this is the most recent version of the image and also
+          # tag it 'latest'.
+          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:${{ matrix.tag }}latest"
+          fi
+          # Set output parameters.
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./${{ matrix.dockerfile }}
+          file: ./${{ matrix.dockerfile }}/Dockerfile
+          platforms: ${{ matrix.platforms }}
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}

--- a/examples/odroid-c2-ubuntu/Dockerfile
+++ b/examples/odroid-c2-ubuntu/Dockerfile
@@ -1,0 +1,30 @@
+ARG LUET_VERSION=0.20.10
+FROM quay.io/luet/base:$LUET_VERSION AS luet
+
+FROM quay.io/costoolkit/examples:odroid-c2-ubuntu-base
+
+ENV COSIGN_EXPERIMENTAL=1
+ENV COSIGN_REPOSITORY=raccos/releases-green
+
+RUN apt-get update -y
+RUN apt-get install -y dracut-core curl dracut-network rsync
+
+# Copy the luet config file pointing to the upgrade repository
+COPY conf/luet.yaml /etc/luet/luet.yaml
+
+RUN curl -L https://github.com/mudler/luet/releases/download/0.20.10/luet-0.20.10-linux-arm64 --output /usr/bin/luet
+
+RUN chmod +x /usr/bin/luet
+RUN luet install -y meta/cos-verify
+
+RUN luet install --plugin luet-cosign -y meta/cos-minimal
+
+COPY files/ /
+
+# Handle initrd and vmlinuz symlinks
+RUN kernel=$(ls /lib/modules | head -n1) && \
+    dracut -f "/boot/initrd-${kernel}" "${kernel}" && \
+    ln -sf "initrd-${kernel}" /boot/initrd
+
+RUN kernel=/boot/Image && \
+    ln -sf "${kernel#/boot/}" /boot/vmlinuz

--- a/examples/odroid-c2-ubuntu/conf/luet.yaml
+++ b/examples/odroid-c2-ubuntu/conf/luet.yaml
@@ -1,0 +1,16 @@
+logging:
+  color: false
+  enable_emoji: false
+general:
+   debug: false
+   spinner_charset: 9
+repositories:
+- name: "cos"
+  description: "cOS official"
+  type: "docker"
+  enable: true
+  cached: true
+  priority: 1
+  verify: false
+  urls:
+  - "quay.io/costoolkit/releases-green-arm64"

--- a/examples/odroid-c2-ubuntu/files/etc/cos/config
+++ b/examples/odroid-c2-ubuntu/files/etc/cos/config
@@ -1,0 +1,45 @@
+# cOS configuration file
+# This file allows to tweak cOS configuration such as: default upgrade/recovery image and GRUB menu entry
+
+# Disable/enable image verification during upgrades ( default: true )
+VERIFY=false
+
+# Disable/enable upgrades via release channels instead of container images. ( default: true )
+CHANNEL_UPGRADES=false
+
+# Default container image used for upgrades. ( defaults to system/cos with channel CHANNEL_UPGRADES enabled )
+UPGRADE_IMAGE="quay.io/mudler/cos-test:cos-standard"
+
+# Default recovery image to use when upgrading the recovery partition
+# ( defaults to recovery/cos in vanilla cOS images with channel CHANNEL_UPGRADES enabled. Otherwise it defaults to UPGRADE_IMAGE ).
+RECOVERY_IMAGE="quay.io/costoolkit/examples:"
+
+# GRUB entry to display on boot. ( defaults: cOS )
+GRUB_ENTRY_NAME="example"
+
+# Space separated list of additional paths that are used to
+# source cloud-config from. ( defaults paths are: /system/oem /oem/ /usr/local/cloud-config/ )
+CLOUD_INIT_PATHS=""
+
+# This is the directory that can be used to store cloud-init files that can be enabled/disabled in runtime
+# by cos-features. ( defaults to /system/features )
+COS_FEATURESDIR="/system/features"
+
+# This is the repository that hosts the signature files used by cosign and luet-cosign plugin during upgrade/deploy to
+# check the artifact signatures
+COSIGN_REPOSITORY="raccos/releases-green"
+
+# This sets keyless verify on building packages with luet and the luet-cosign plugin.
+# 1  = enabled keyless, 0 = disabled, uses normal public key verification
+COSIGN_EXPERIMENTAL=1
+
+# This sets the location of the public key to use to verify the packages installed by luet during upgrade/deploy
+# This can be set to file, URL, KMS URI or Kubernetes Secret
+# This is only used if COSIGN_EXPERIMENTAL is set to 0
+COSIGN_PUBLIC_KEY_LOCATION=""
+
+# Default size (in MB) of disk image files (.img) created during upgrades
+DEFAULT_IMAGE_SIZE=3240
+
+# Path to default configuration grub file
+GRUBCONF="/etc/cos/grub.cfg"

--- a/examples/odroid-c2-ubuntu/files/etc/os-release
+++ b/examples/odroid-c2-ubuntu/files/etc/os-release
@@ -1,0 +1,2 @@
+VERSION="15.3"
+PRETTY_NAME="openSUSE"

--- a/examples/odroid-c2-ubuntu/files/system/oem/04_accounting.yaml
+++ b/examples/odroid-c2-ubuntu/files/system/oem/04_accounting.yaml
@@ -1,0 +1,17 @@
+# Default cOS OEM configuration file
+#
+# This file is part of cOS and will get reset during upgrades.
+#
+# Before you change this file manually,
+# consider copying this file to /usr/local/cloud-config or
+# copy the file with a prefix starting by 90, e.g. /oem/91_custom.yaml
+name: "Default user"
+stages:
+   initramfs:
+     - name: "Setup users"
+       ensure_entities:
+       - path: /etc/shadow
+         entity: |
+            kind: "shadow"
+            username: "root"
+            password: "cos"

--- a/examples/odroid-c2/Dockerfile
+++ b/examples/odroid-c2/Dockerfile
@@ -1,0 +1,69 @@
+ARG LUET_VERSION=0.20.10
+FROM quay.io/luet/base:$LUET_VERSION AS luet
+
+FROM opensuse/leap:15.3
+
+ENV COSIGN_EXPERIMENTAL=1
+ENV COSIGN_REPOSITORY=raccos/releases-green
+
+RUN zypper in -y \
+    # Odroid
+    kernel-default-extra \
+    systemd-sysvinit \
+    grub2-arm64-efi \
+    iproute2 \
+    squashfs \
+    conntrack-tools \
+    findutils \
+    haveged \
+    lsscsi \
+    lvm2 \
+    mdadm \
+    multipath-tools \
+    nfs-utils \
+    open-iscsi \
+    open-vm-tools \
+    python-azure-agent \
+    qemu-guest-agent \
+    rng-tools \
+    systemd \
+    vim \
+    parted \
+    dracut \
+    e2fsprogs \
+    dosfstools \
+    kernel-default \
+    kernel-firmware-bnx2 \
+    kernel-firmware-i915 \
+    kernel-firmware-intel \
+    kernel-firmware-iwlwifi \
+    kernel-firmware-mellanox \
+    kernel-firmware-network \
+    kernel-firmware-platform \
+    kernel-firmware-realtek \
+    coreutils \
+    less \
+    device-mapper \
+    grub2 \
+    which \
+    curl \
+    nano \
+    gawk \
+    haveged \
+    tar \
+    rsync \
+    timezone \
+    jq \
+    gptfdisk
+
+# Copy the luet config file pointing to the upgrade repository
+COPY conf/luet.yaml /etc/luet/luet.yaml
+RUN curl -L https://github.com/mudler/luet/releases/download/0.20.10/luet-0.20.10-linux-arm64 --output /usr/bin/luet
+
+RUN chmod +x /usr/bin/luet
+RUN luet install -y meta/cos-verify
+
+RUN luet install --plugin luet-cosign -y meta/cos-minimal
+
+COPY files/ /
+RUN mkinitrd

--- a/examples/odroid-c2/conf/luet.yaml
+++ b/examples/odroid-c2/conf/luet.yaml
@@ -1,0 +1,16 @@
+logging:
+  color: false
+  enable_emoji: false
+general:
+   debug: false
+   spinner_charset: 9
+repositories:
+- name: "cos"
+  description: "cOS official"
+  type: "docker"
+  enable: true
+  cached: true
+  priority: 1
+  verify: false
+  urls:
+  - "quay.io/costoolkit/releases-green-arm64"

--- a/examples/odroid-c2/files/etc/cos/config
+++ b/examples/odroid-c2/files/etc/cos/config
@@ -1,0 +1,45 @@
+# cOS configuration file
+# This file allows to tweak cOS configuration such as: default upgrade/recovery image and GRUB menu entry
+
+# Disable/enable image verification during upgrades ( default: true )
+VERIFY=false
+
+# Disable/enable upgrades via release channels instead of container images. ( default: true )
+CHANNEL_UPGRADES=false
+
+# Default container image used for upgrades. ( defaults to system/cos with channel CHANNEL_UPGRADES enabled )
+UPGRADE_IMAGE="quay.io/mudler/cos-test:cos-standard"
+
+# Default recovery image to use when upgrading the recovery partition
+# ( defaults to recovery/cos in vanilla cOS images with channel CHANNEL_UPGRADES enabled. Otherwise it defaults to UPGRADE_IMAGE ).
+RECOVERY_IMAGE="quay.io/mudler/cos-test:cos-standard"
+
+# GRUB entry to display on boot. ( defaults: cOS )
+GRUB_ENTRY_NAME="example"
+
+# Space separated list of additional paths that are used to
+# source cloud-config from. ( defaults paths are: /system/oem /oem/ /usr/local/cloud-config/ )
+CLOUD_INIT_PATHS=""
+
+# This is the directory that can be used to store cloud-init files that can be enabled/disabled in runtime
+# by cos-features. ( defaults to /system/features )
+COS_FEATURESDIR="/system/features"
+
+# This is the repository that hosts the signature files used by cosign and luet-cosign plugin during upgrade/deploy to
+# check the artifact signatures
+COSIGN_REPOSITORY="raccos/releases-green"
+
+# This sets keyless verify on building packages with luet and the luet-cosign plugin.
+# 1  = enabled keyless, 0 = disabled, uses normal public key verification
+COSIGN_EXPERIMENTAL=1
+
+# This sets the location of the public key to use to verify the packages installed by luet during upgrade/deploy
+# This can be set to file, URL, KMS URI or Kubernetes Secret
+# This is only used if COSIGN_EXPERIMENTAL is set to 0
+COSIGN_PUBLIC_KEY_LOCATION=""
+
+# Default size (in MB) of disk image files (.img) created during upgrades
+DEFAULT_IMAGE_SIZE=3240
+
+# Path to default configuration grub file
+GRUBCONF="/etc/cos/grub.cfg"

--- a/examples/odroid-c2/files/etc/os-release
+++ b/examples/odroid-c2/files/etc/os-release
@@ -1,0 +1,2 @@
+VERSION="15.3"
+PRETTY_NAME="openSUSE"

--- a/examples/odroid-c2/files/system/oem/04_accounting.yaml
+++ b/examples/odroid-c2/files/system/oem/04_accounting.yaml
@@ -1,0 +1,17 @@
+# Default cOS OEM configuration file
+#
+# This file is part of cOS and will get reset during upgrades.
+#
+# Before you change this file manually,
+# consider copying this file to /usr/local/cloud-config or
+# copy the file with a prefix starting by 90, e.g. /oem/91_custom.yaml
+name: "Default user"
+stages:
+   initramfs:
+     - name: "Setup users"
+       ensure_entities:
+       - path: /etc/shadow
+         entity: |
+            kind: "shadow"
+            username: "root"
+            password: "cos"

--- a/images/arm-img-builder.sh
+++ b/images/arm-img-builder.sh
@@ -1,0 +1,426 @@
+#!/bin/bash
+
+set -e
+
+load_vars() {
+
+  container_image=${CONTAINER_IMAGE:-quay.io/costoolkit/examples:odroid-c2-latest}
+  directory=${DIRECTORY:-}
+  output_image="${OUTPUT_IMAGE:-arm.img}"
+  model=${MODEL:-odroid_c2}
+
+  # Img creation options. Size is in MB for all of the vars below
+  size="${SIZE:-7544}"
+  state_size="${STATE_SIZE:-4992}"
+  recovery_size="${RECOVERY_SIZE:-2192}"
+  default_active_size="${DEFAULT_ACTIVE_SIZE:-2400}"
+
+  ## Repositories
+  final_repo="${FINAL_REPO:-quay.io/costoolkit/releases-green-arm64}"
+  repo_type="${REPO_TYPE:-docker}"
+}
+
+cleanup() {
+	sync
+	sync
+	sleep 5
+	sync
+  if [ -n "$EFI" ]; then
+    rm -rf $EFI
+  fi
+  if [ -n "$RECOVERY" ]; then
+    rm -rf $RECOVERY
+  fi
+  if [ -n "$STATEDIR" ]; then
+    rm -rf $STATEDIR
+  fi
+  if [ -n "$TARGET" ]; then
+    umount $TARGET || true
+    umount $LOOP || true
+    rm -rf $TARGET
+  fi
+  if [ -n "$WORKDIR" ]; then
+    rm -rf $WORKDIR
+  fi
+  if [ -n "$DRIVE" ]; then
+    umount $DRIVE || true
+  fi
+  if [ -n "$recovery" ]; then
+    umount $recovery || true
+  fi
+  if [ -n "$state" ]; then
+    umount $state || true
+  fi
+  if [ -n "$efi" ]; then
+    umount $efi || true
+  fi
+  if [ -n "$oem" ]; then
+    umount $oem || true
+  fi
+  losetup -D || true
+}
+
+ensure_dir_structure() {
+    local target=$1
+    for mnt in /sys /proc /dev /tmp /boot /usr/local /oem
+    do
+        if [ ! -d "${target}${mnt}" ]; then
+          mkdir -p ${target}${mnt}
+        fi
+    done
+}
+
+usage()
+{
+    echo "Usage: $0 [options] image.img"
+    echo ""
+    echo "Example: $0 --model odroid-c2 --docker-image <image> output.img"
+    echo ""
+    echo "Flags:"
+    echo " --config: (optional) Specify a cloud-init config file to embed into the final image"
+    echo " --manifest: (optional) Specify a manifest file to customize efi/grub packages installed into the image"
+    echo " --size: (optional) Image size (MB)"
+    echo " --state-partition-size: (optional) Size of the state partition (MB)"
+    echo " --recovery-partition-size: (optional) Size of the recovery partition (MB)"
+    echo " --images-size: (optional) Size of the active/passive/recovery images (MB)"
+    echo " --docker-image: (optional) A container image which will be used for active/passive/recovery system"
+    echo " --local: (optional) Use local repository when building"
+    echo " --directory: (optional) A directory which will be used for active/passive/recovery system"
+    echo " --model: (optional) The board model"
+    echo " --final-repo: (optional) The luet repository used to download bits required for building"
+    echo " --repo-type: (optional) The luet repository type used to download bits required for building"
+    exit 1
+}
+
+get_url()
+{
+    FROM=$1
+    TO=$2
+    case $FROM in
+        ftp*|http*|tftp*)
+            n=0
+            attempts=5
+            until [ "$n" -ge "$attempts" ]
+            do
+                curl -o $TO -fL ${FROM} && break
+                n=$((n+1))
+                echo "Failed to download, retry attempt ${n} out of ${attempts}"
+                sleep 2
+            done
+            ;;
+        *)
+            cp -f $FROM $TO
+            ;;
+    esac
+}
+
+trap "cleanup" 1 2 3 6 9 14 15 EXIT
+
+load_vars
+while [ "$#" -gt 0 ]; do
+    case $1 in
+        --config)
+            shift 1
+            config=$1
+            ;;
+        --manifest)
+            shift 1
+            manifest=$1
+            ;;
+        --size)
+            shift 1
+            size=$1
+            ;;
+        --local)
+            local_build=true
+            ;;
+        --state-partition-size)
+            shift 1
+            state_size=$1
+            ;;
+        --recovery-partition-size)
+            shift 1
+            recovery_size=$1
+            ;;
+        --images-size)
+            shift 1
+            default_active_size=$1
+            ;;
+        --docker-image)
+            shift 1
+            container_image=$1
+            ;;
+        --directory)
+            shift 1
+            directory=$1
+            ;;
+        --model)
+            shift 1
+            model=$1
+            ;;
+        --final-repo)
+            shift 1
+            final_repo=$1
+            ;;
+        --repo-type)
+            shift 1
+            repo_type=$1
+            ;;
+        -h)
+            usage
+            ;;
+        --help)
+            usage
+            ;;
+        *)
+            if [ "$#" -gt 2 ]; then
+                usage
+            fi
+            output_image=$1
+            break
+            ;;
+    esac
+    shift 1
+done
+
+if [ -z "$output_image" ]; then
+  echo "No image file specified"
+  exit 1
+fi
+
+if [ -n "$manifest" ]; then
+  YQ_VERSION=$( yq -V | cut -d " " -f 3 | cut -d "." -f 1)
+
+  if [[ "${YQ_VERSION}" == "3" ]]; then
+    YQ_REPO_COMMAND=(yq r "${manifest}" "raw_disk.$model.repo")
+    YQ_PACKAGES_COMMAND=(yq r -j "${manifest}")
+  else
+    YQ_REPO_COMMAND=(yq e ".raw_disk.$model.repo" "${manifest}")
+    YQ_PACKAGES_COMMAND=(yq e -o=json "$manifest")
+  fi
+
+  final_repo=${final_repo:-$("${YQ_REPO_COMMAND[@]}")}
+fi
+
+echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
+echo "Image Size: $size MB."
+echo "Recovery Partition: $recovery_size."
+echo "State Partition: $state_size MB."
+echo "Images size (active/passive/recovery.img): $default_active_size MB."
+echo "Model: $model"
+if [ -n "$container_image" ] && [ -z "$directory" ]; then
+  echo "Container image: $container_image"
+fi
+if [ -n "$directory" ]; then
+  echo "Root from directory: $directory"
+fi
+echo "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"
+
+# Temp dir used during build
+WORKDIR=$(mktemp -d --tmpdir arm-builder.XXXXXXXXXX)
+ROOT_DIR=$(git rev-parse --show-toplevel)
+TARGET=$(mktemp -d --tmpdir arm-builder.XXXXXXXXXX)
+STATEDIR=$(mktemp -d --tmpdir arm-builder.XXXXXXXXXX)
+
+# Create a luet config for grabbing packages from local and remote repositories (local with high prio)
+cat << EOF > $WORKDIR/luet.yaml
+repositories:
+  - name: cOS
+    enable: true
+    urls:
+      - $final_repo
+    type: $repo_type
+    priority: 90
+EOF
+
+if [ "$local_build" == "true" ]; then
+cat << EOF >> $WORKDIR/luet.yaml
+  - name: local
+    enable: true
+    urls:
+      - $ROOT_DIR/build
+    type: disk
+    priority: 0
+EOF
+fi
+
+export WORKDIR
+
+# Prepare active.img
+
+echo ">> Preparing active.img"
+mkdir -p ${STATEDIR}/cOS
+
+dd if=/dev/zero of=${STATEDIR}/cOS/active.img bs=1M count=$default_active_size
+
+mkfs.ext2 ${STATEDIR}/cOS/active.img -L COS_ACTIVE
+
+sync
+
+LOOP=$(losetup --show -f ${STATEDIR}/cOS/active.img)
+if [ -z "$LOOP" ]; then
+echo "No device"
+exit 1
+fi
+
+mount -t ext2 $LOOP $TARGET
+
+ensure_dir_structure $TARGET
+
+# Download the container image
+if [ -z "$directory" ]; then
+  echo ">>> Downloading container image"
+  luet util unpack $container_image $TARGET
+else
+  echo ">>> Copying files from $directory"
+  rsync -axq --exclude='host' --exclude='mnt' --exclude='proc' --exclude='sys' --exclude='dev' --exclude='tmp' ${directory}/ $TARGET
+fi
+
+umount $TARGET
+sync
+
+if [ -n "$LOOP" ]; then
+    losetup -d $LOOP
+fi
+
+echo ">> Preparing passive.img"
+cp -rfv ${STATEDIR}/cOS/active.img ${STATEDIR}/cOS/passive.img
+tune2fs -L COS_PASSIVE ${STATEDIR}/cOS/passive.img
+
+# Preparing recovery
+echo ">> Preparing recovery.img"
+RECOVERY=$(mktemp -d --tmpdir arm-builder.XXXXXXXXXX)
+if [ -z "$RECOVERY" ]; then
+  echo "No recovery directory"
+  exit 1
+fi
+
+mkdir -p ${RECOVERY}/cOS
+cp -rfv ${STATEDIR}/cOS/active.img ${RECOVERY}/cOS/recovery.img
+
+tune2fs -L COS_SYSTEM ${RECOVERY}/cOS/recovery.img
+
+# Install real grub config to recovery
+if [ -z "$manifest" ]; then
+  luet install --config $WORKDIR/luet.yaml -y --system-target $RECOVERY system/grub2-config 
+  luet install --config $WORKDIR/luet.yaml -y --system-target $RECOVERY/grub2 system/grub2-artifacts
+else
+  while IFS=$'\t' read -r name target ; do
+    if [ "$target" == "root/grub2" ]; then
+      luet install --no-spinner --system-target $RECOVERY/grub2 -y "$name"
+    fi
+    if [ "$target" == "root" ]; then
+      luet install --no-spinner --system-target $RECOVERY -y "$name"
+    fi
+  done < <("${YQ_PACKAGES_COMMAND[@]}" | jq -r ".raw_disk.$model.packages[] | [.name, .target] | @tsv")
+fi
+
+ # Remove luet cache
+rm -rf $RECOVERY/var $RECOVERY/grub2/var
+
+sync
+
+# Prepare efi files
+echo ">> Preparing EFI partition"
+EFI=$(mktemp -d --tmpdir arm-builder.XXXXXXXXXX)
+if [ -z "$EFI" ]; then
+  echo "No EFI directory"
+  exit 1
+fi
+
+if [ -z "$manifest" ]; then
+  luet install --config $WORKDIR/luet.yaml -y --system-target $EFI system/grub2-efi-image
+else
+  while IFS=$'\t' read -r name target ; do
+    if [ "$target" == "efi" ]; then
+      luet install --no-spinner --system-target $EFI -y "$name"
+    fi
+  done < <("${YQ_PACKAGES_COMMAND[@]}" | jq -r ".raw_disk.$model.packages[] | [.name, .target] | @tsv")
+fi
+
+ # Remove luet cache
+rm -rf $EFI/var
+
+echo ">> Writing image and partition table"
+dd if=/dev/zero of="${output_image}" bs=1024000 count="${size}" || exit 1
+sgdisk -n 1:8192:+16M -c 1:EFI -t 1:0700 ${output_image}
+sgdisk -n 2:0:+64M -c 2:oem -t 2:8300 ${output_image}
+sgdisk -n 3:0:+${state_size}M -c 3:state -t 3:8300 ${output_image}
+sgdisk -n 4:0:+${recovery_size}M -c 4:recovery -t 4:8300 ${output_image}
+
+sgdisk -m 1:2:3:4 ${output_image}
+
+# Prepare the image and copy over the files
+
+DRIVE=$(losetup -f "${output_image}" --show)
+if [ -z "${DRIVE}" ]; then
+	echo "Cannot execute losetup for $output_image"
+	exit 1
+fi
+
+device=${DRIVE/\/dev\//}
+
+if [ -z "$device" ]; then
+  echo "No device"
+  exit 1
+fi
+
+device="/dev/mapper/${device}"
+
+partprobe
+
+kpartx -va $DRIVE
+
+echo ">> Populating partitions"
+efi=${device}p1
+oem=${device}p2
+state=${device}p3
+recovery=${device}p4
+
+# Create partitions (COS_RECOVERY, COS_STATE, COS_OEM)
+mkfs.vfat -F 32 ${efi}
+fatlabel ${efi} EFI
+
+mkfs.ext4 -F -L COS_RECOVERY $recovery
+mkfs.ext4 -F -L COS_STATE $state
+mkfs.ext4 -F -L COS_OEM $oem
+
+mkdir $WORKDIR/state
+mkdir $WORKDIR/recovery
+mkdir $WORKDIR/efi
+
+mount $recovery $WORKDIR/recovery
+mount $state $WORKDIR/state
+mount $efi $WORKDIR/efi
+
+# Set a OEM config file if specified
+if [ -n "$config" ]; then
+  echo ">> Copying $config OEM config file"
+  mkdir $WORKDIR/oem
+  mount $oem $WORKDIR/oem
+  get_url $config $WORKDIR/oem/99_custom.yaml
+  umount $WORKDIR/oem
+fi
+
+# Copy over content
+cp -arf $EFI/* $WORKDIR/efi
+cp -arf $RECOVERY/* $WORKDIR/recovery
+cp -arf $STATEDIR/* $WORKDIR/state
+
+umount $WORKDIR/recovery
+umount $WORKDIR/state
+umount $WORKDIR/efi
+
+sync
+
+# Flash uboot and vendor-specific bits
+echo ">> Performing $model specific bits.."
+$ROOT_DIR/images/arm/vendor/$model.sh ${DRIVE}
+
+kpartx -dv $DRIVE
+
+umount $DRIVE || true
+
+echo ">> Done writing $output_image"
+
+cleanup

--- a/images/arm/vendor/odroid_c2.sh
+++ b/images/arm/vendor/odroid_c2.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+image=$1
+
+if [ -z "$image" ]; then
+    echo "No image specified"
+    exit 1
+fi
+
+if [ ! -e "$WORKDIR/luet.yaml" ]; then
+    ls -liah $WORKDIR
+    echo "No valid config file"
+    cat "$WORKDIR/luet.yaml"
+    exit 1
+fi
+
+sudo luet install --config $WORKDIR/luet.yaml -y --system-target $WORKDIR firmware/odroid-c2
+# conv=notrunc ?
+dd if=$WORKDIR/bl1.bin.hardkernel of=$image conv=fsync bs=1 count=442
+dd if=$WORKDIR/bl1.bin.hardkernel of=$image conv=fsync bs=512 skip=1 seek=1
+dd if=$WORKDIR/u-boot.odroidc2 of=$image conv=fsync bs=512 seek=97

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -36,6 +36,16 @@ raw_disk:
         target: root/grub2
       - name: recovery/cos-img
         target: root/cOS
+  odroid_c2:
+    repo: quay.io/costoolkit/releases-green-arm64
+    packages:
+      - name: system/grub2-efi-image
+        target: efi
+      - name: system/grub2-config
+        target: root
+      - name: system/grub2-artifacts
+        target: root/grub2
+
 
 # Raw disk creation values end
 

--- a/packages/firmware/build.yaml
+++ b/packages/firmware/build.yaml
@@ -1,0 +1,16 @@
+requires:
+- name: "base"
+  category: "distro"
+  version: ">=0"
+
+prelude:
+{{ template "distro_install" (dict "Values" .Values "Packages" "wget")}}
+
+steps:
+# TODO: Use zypper
+- wget https://download.opensuse.org/repositories/devel:/ARM:/Factory:/Contrib:/OdroidC2/standard/aarch64/odroidc2-firmware-{{.Values.version}}.aarch64.rpm
+- mkdir -p /data/boot
+- rpm2cpio odroidc2-firmware-{{.Values.version}}.aarch64.rpm | cpio -idmv
+- mv boot/* /data/boot
+
+package_dir: "/data/boot"

--- a/packages/firmware/build.yaml
+++ b/packages/firmware/build.yaml
@@ -1,13 +1,21 @@
-requires:
-- name: "base"
-  category: "distro"
-  version: ">=0"
+{{if .Values.distribution}}
+  {{if eq .Values.distribution "opensuse"}}
+image: {{ .Values.image }}
+  {{else }}
+image: opensuse/leap:15.3
+  {{end}}
+{{end}}
 
 prelude:
-{{ template "distro_install" (dict "Values" .Values "Packages" "wget")}}
+# - zypper addrepo -G https://download.opensuse.org/repositories/devel:/ARM:/Factory:/Contrib:/OdroidC2/standard/devel:ARM:Factory:Contrib:OdroidC2.repo
+# - zypper --gpg-auto-import-keys ref
+- zypper in -y wget
+#{   { template "distro_install" (dict "Values" .Values "Packages" "wget")}}
 
 steps:
-# TODO: Use zypper
+# - mkdir -p /data/boot
+# - zypper --installroot /data  in -yf odroidc2-firmware.aarch64
+# Without zypper:
 - wget https://download.opensuse.org/repositories/devel:/ARM:/Factory:/Contrib:/OdroidC2/standard/aarch64/odroidc2-firmware-{{.Values.version}}.aarch64.rpm
 - mkdir -p /data/boot
 - rpm2cpio odroidc2-firmware-{{.Values.version}}.aarch64.rpm | cpio -idmv

--- a/packages/firmware/collection.yaml
+++ b/packages/firmware/collection.yaml
@@ -1,0 +1,7 @@
+packages:
+- name: "odroid-c2"
+  category: "firmware"
+  version: "20170419-5.177"
+  hidden: true
+  labels:
+    autobump.strategy: "snapshot"

--- a/packages/firmware/collection.yaml
+++ b/packages/firmware/collection.yaml
@@ -2,6 +2,3 @@ packages:
 - name: "odroid-c2"
   category: "firmware"
   version: "20170419-5.177"
-  hidden: true
-  labels:
-    autobump.strategy: "snapshot"

--- a/packages/templates/distro.yaml
+++ b/packages/templates/distro.yaml
@@ -1,0 +1,15 @@
+{{ define "distro_install" }}
+{{ if .Values.distribution }}
+{{if eq .Values.distribution "opensuse" }}
+- zypper in -y --no-recommends {{.Packages}}
+- zypper cc
+{{else if eq .Values.distribution "fedora" }}
+- echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
+- dnf install -y {{.Packages}}
+- dnf clean all
+{{else if eq .Values.distribution "ubuntu" }}
+- apt-get update && apt-get install -y {{.Packages}}
+- apt-get clean
+{{end}}
+{{end}}
+{{end}}


### PR DESCRIPTION
As there is no availability of RPI4 at the moment, I'm attempting to do an arm installation on a arm64 board that I have at hand (OdroidC2, https://en.opensuse.org/HCL:OdroidC2), the HW is old and unsupported at the moment, and kernel support is stop at 3.x, so it might "just not work". Nevertheless, the skeleton and the tooling creates flashable images from container images, with additionally support for vendor specific bits (u-boot, etc) which can be extended in a later moment. 

The PR also adds a CI workflow to create arm64 images for examples. Those can be images that are derivative, and which we can create images from.

ATM testing it on odroid with: `./images/arm-img-builder.sh --model odroid_c2 --docker-image quay.io/costoolkit/examples:odroid-c2-latest`.

This will generate an SD card for odroid-c2 from the image samples. Very PoC state.

**Update**
The kernel doesn't start due to #785 , which doesn't look directly related to this work. Here we provide a basis for supporting other models as well

Todo:

- [x] Cleanup
- [x] Read packages from manifest, have work-out-of-the-box defaults
- [x] CLI, help, docs
- [x] Example Dockerfile should be based on standard image, and not hook into the builder CI images.
- [x] ~Hook ARM images to CI pipelines, publish them~ Odroid images are not booting due to kernel issues, better not publishing them
- [x] ~The firmware package should use zypper to take the required firmware files instead of wgetting them~ Leaving the package as an example
- [x] ~Test basic functionalities are there (upgrade, reset, recovery)~  Cannot test them, as Odroid C2 kernel is not booting
- [x] Take optionally a cloud-init config as input to place into the OEM partition

Seems default kernel for odroidc2 doesn't work. It automatically reboots, I can reproduce the same problem on official JeOS odroidc2 images

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>