### PR TITLE
Change packer args to provide target and args

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -245,6 +245,17 @@
     env:
       FLAVOR: {{{ $flavor }}}
       ARCH: {{{ $config.arch }}}
+      PKR_VAR_arch: {{{ $config.arch }}}
+      PKR_VAR_flavor: {{{ $flavor }}}
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      {{{if eq $config.arch "arm64" }}}
+      PKR_VAR_qemu_binary: qemu-system-aarch64
+      PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
+      PACKER_TARGET: qemu.cos-arm64
+      {{{else}}}
+      PACKER_TARGET: qemu.cos
+      {{{- end}}}
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -260,17 +271,7 @@
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch={{{ $config.arch }}}
-          export PKR_VAR_flavor={{{ $flavor }}}
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          {{{if eq $config.arch "arm64" }}}
-          export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
-          PACKER_ARGS="-only qemu.cos-arm64" make packer
-          {{{else}}}
-          PACKER_ARGS="-only qemu.cos" make packer
-          {{{- end}}}
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-{{{$subset}}}-{{{ $flavor }}}-QEMU-{{{ $config.arch }}}.qcow
@@ -292,17 +293,17 @@
   vbox-{{{$subset}}}-{{{ $flavor }}}:
     runs-on: macos-10.15
     needs: iso-{{{$subset}}}-{{{ $flavor }}}
+    env:
+      PKR_VAR_arch: {{{ $config.arch }}}
+      PKR_VAR_flavor: {{{ $flavor }}}
+      PKR_VAR_feature: vagrant
+      PACKER_TARGET: virtualbox-iso.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
         uses: actions/download-artifact@v2
         with:
           name: cOS-{{{$subset}}}-{{{ $flavor }}}-{{{ $config.arch }}}.iso.zip
-
-      # - name: Install deps
-      #   run: |
-      #     brew tap hashicorp/tap
-      #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
             brew install yq
@@ -310,8 +311,8 @@
         run: |
           export YQ=/usr/local/bin/yq
           source .github/helpers.sh
-          COS_VERSION=$(cos_version)
-          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch={{{ $config.arch }}}' -var='flavor={{{ $flavor }}}' -only virtualbox-iso.cos" make packer
+          export PKR_VAR_build=$(cos_version)
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-{{{$subset}}}-{{{ $flavor }}}-vbox-{{{ $config.arch }}}.ova
@@ -793,6 +794,9 @@
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      PKR_VAR_flavor: {{{ $flavor }}}
+      PKR_VAR_git_sha: "${GITHUB_SHA}"
+      PACKER_TARGET: amazon-ebs.cos
     steps:
       - uses: actions/checkout@v2
       {{{ tmpl.Exec "make" "deps" }}}
@@ -805,11 +809,9 @@
             PACKAGE_VERSION=$(cos_package_version)
             export COS_VERSION="${PACKAGE_VERSION/+/-}"
             export PKR_VAR_cos_version="${COS_VERSION}"
-            export PKR_VAR_cos_deploy_args="cos-deploy {{{ if (ne $flavor "green") }}}--no-verify {{{ end }}}--docker-image {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}:cos-system-${COS_VERSION}"
-            export PKR_VAR_flavor={{{ $flavor }}}
-            export PKR_VAR_git_sha="${GITHUB_SHA}"
             export PKR_VAR_aws_temporary_security_group_source_cidr="${{ steps.ip.outputs.ipv4 }}/32"
-            make packer-aws
+            export PKR_VAR_cos_deploy_args="cos-deploy {{{ if (ne $flavor "green") }}}--no-verify {{{ end }}}--docker-image {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}:cos-system-${COS_VERSION}"
+            make packer
 {{{ end }}}
 
 {{{define "image_link"}}}

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -131,6 +131,13 @@ jobs:
     env:
       FLAVOR: green
       ARCH: arm64
+      PKR_VAR_arch: arm64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PKR_VAR_qemu_binary: qemu-system-aarch64
+      PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
+      PACKER_TARGET: qemu.cos-arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -146,13 +153,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=arm64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
-          PACKER_ARGS="-only qemu.cos-arm64" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-squashfs-green-QEMU-arm64.qcow
@@ -284,6 +285,13 @@ jobs:
     env:
       FLAVOR: green
       ARCH: arm64
+      PKR_VAR_arch: arm64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PKR_VAR_qemu_binary: qemu-system-aarch64
+      PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
+      PACKER_TARGET: qemu.cos-arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -299,13 +307,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=arm64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
-          PACKER_ARGS="-only qemu.cos-arm64" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-nonsquashfs-green-QEMU-arm64.qcow

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -231,6 +231,11 @@ jobs:
     env:
       FLAVOR: green
       ARCH: x86_64
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -246,11 +251,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=x86_64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          PACKER_ARGS="-only qemu.cos" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-squashfs-green-QEMU-x86_64.qcow
@@ -266,16 +267,17 @@ jobs:
   vbox-squashfs-green:
     runs-on: macos-10.15
     needs: iso-squashfs-green
+    env:
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PACKER_TARGET: virtualbox-iso.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
         uses: actions/download-artifact@v2
         with:
           name: cOS-squashfs-green-x86_64.iso.zip
-      # - name: Install deps
-      #   run: |
-      #     brew tap hashicorp/tap
-      #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
             brew install yq
@@ -283,8 +285,8 @@ jobs:
         run: |
           export YQ=/usr/local/bin/yq
           source .github/helpers.sh
-          COS_VERSION=$(cos_version)
-          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=x86_64' -var='flavor=green' -only virtualbox-iso.cos" make packer
+          export PKR_VAR_build=$(cos_version)
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-squashfs-green-vbox-x86_64.ova
@@ -500,6 +502,11 @@ jobs:
     env:
       FLAVOR: green
       ARCH: x86_64
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -515,11 +522,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=x86_64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          PACKER_ARGS="-only qemu.cos" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-nonsquashfs-green-QEMU-x86_64.qcow
@@ -535,16 +538,17 @@ jobs:
   vbox-nonsquashfs-green:
     runs-on: macos-10.15
     needs: iso-nonsquashfs-green
+    env:
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PACKER_TARGET: virtualbox-iso.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
         uses: actions/download-artifact@v2
         with:
           name: cOS-nonsquashfs-green-x86_64.iso.zip
-      # - name: Install deps
-      #   run: |
-      #     brew tap hashicorp/tap
-      #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
             brew install yq
@@ -552,8 +556,8 @@ jobs:
         run: |
           export YQ=/usr/local/bin/yq
           source .github/helpers.sh
-          COS_VERSION=$(cos_version)
-          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=x86_64' -var='flavor=green' -only virtualbox-iso.cos" make packer
+          export PKR_VAR_build=$(cos_version)
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-nonsquashfs-green-vbox-x86_64.ova

--- a/.github/workflows/build-nightly-green-x86_64.yaml
+++ b/.github/workflows/build-nightly-green-x86_64.yaml
@@ -215,6 +215,11 @@ jobs:
     env:
       FLAVOR: green
       ARCH: x86_64
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -230,11 +235,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=x86_64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          PACKER_ARGS="-only qemu.cos" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-squashfs-green-QEMU-x86_64.qcow
@@ -250,16 +251,17 @@ jobs:
   vbox-squashfs-green:
     runs-on: macos-10.15
     needs: iso-squashfs-green
+    env:
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PACKER_TARGET: virtualbox-iso.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
         uses: actions/download-artifact@v2
         with:
           name: cOS-squashfs-green-x86_64.iso.zip
-      # - name: Install deps
-      #   run: |
-      #     brew tap hashicorp/tap
-      #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
             brew install yq
@@ -267,8 +269,8 @@ jobs:
         run: |
           export YQ=/usr/local/bin/yq
           source .github/helpers.sh
-          COS_VERSION=$(cos_version)
-          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=x86_64' -var='flavor=green' -only virtualbox-iso.cos" make packer
+          export PKR_VAR_build=$(cos_version)
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-squashfs-green-vbox-x86_64.ova
@@ -484,6 +486,11 @@ jobs:
     env:
       FLAVOR: green
       ARCH: x86_64
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -499,11 +506,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=x86_64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          PACKER_ARGS="-only qemu.cos" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-nonsquashfs-green-QEMU-x86_64.qcow
@@ -519,16 +522,17 @@ jobs:
   vbox-nonsquashfs-green:
     runs-on: macos-10.15
     needs: iso-nonsquashfs-green
+    env:
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PACKER_TARGET: virtualbox-iso.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
         uses: actions/download-artifact@v2
         with:
           name: cOS-nonsquashfs-green-x86_64.iso.zip
-      # - name: Install deps
-      #   run: |
-      #     brew tap hashicorp/tap
-      #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
             brew install yq
@@ -536,8 +540,8 @@ jobs:
         run: |
           export YQ=/usr/local/bin/yq
           source .github/helpers.sh
-          COS_VERSION=$(cos_version)
-          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=x86_64' -var='flavor=green' -only virtualbox-iso.cos" make packer
+          export PKR_VAR_build=$(cos_version)
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-nonsquashfs-green-vbox-x86_64.ova

--- a/.github/workflows/build-pr-green-arm64.yaml
+++ b/.github/workflows/build-pr-green-arm64.yaml
@@ -117,6 +117,13 @@ jobs:
     env:
       FLAVOR: green
       ARCH: arm64
+      PKR_VAR_arch: arm64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PKR_VAR_qemu_binary: qemu-system-aarch64
+      PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
+      PACKER_TARGET: qemu.cos-arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -132,13 +139,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=arm64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
-          PACKER_ARGS="-only qemu.cos-arm64" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-squashfs-green-QEMU-arm64.qcow
@@ -270,6 +271,13 @@ jobs:
     env:
       FLAVOR: green
       ARCH: arm64
+      PKR_VAR_arch: arm64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PKR_VAR_qemu_binary: qemu-system-aarch64
+      PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
+      PACKER_TARGET: qemu.cos-arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -285,13 +293,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=arm64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
-          PACKER_ARGS="-only qemu.cos-arm64" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-nonsquashfs-green-QEMU-arm64.qcow

--- a/.github/workflows/build-pr-green-x86_64.yaml
+++ b/.github/workflows/build-pr-green-x86_64.yaml
@@ -203,6 +203,11 @@ jobs:
     env:
       FLAVOR: green
       ARCH: x86_64
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -218,11 +223,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=x86_64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          PACKER_ARGS="-only qemu.cos" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-squashfs-green-QEMU-x86_64.qcow
@@ -238,16 +239,17 @@ jobs:
   vbox-squashfs-green:
     runs-on: macos-10.15
     needs: iso-squashfs-green
+    env:
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PACKER_TARGET: virtualbox-iso.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
         uses: actions/download-artifact@v2
         with:
           name: cOS-squashfs-green-x86_64.iso.zip
-      # - name: Install deps
-      #   run: |
-      #     brew tap hashicorp/tap
-      #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
             brew install yq
@@ -255,8 +257,8 @@ jobs:
         run: |
           export YQ=/usr/local/bin/yq
           source .github/helpers.sh
-          COS_VERSION=$(cos_version)
-          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=x86_64' -var='flavor=green' -only virtualbox-iso.cos" make packer
+          export PKR_VAR_build=$(cos_version)
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-squashfs-green-vbox-x86_64.ova
@@ -472,6 +474,11 @@ jobs:
     env:
       FLAVOR: green
       ARCH: x86_64
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -487,11 +494,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=x86_64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          PACKER_ARGS="-only qemu.cos" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-nonsquashfs-green-QEMU-x86_64.qcow
@@ -507,16 +510,17 @@ jobs:
   vbox-nonsquashfs-green:
     runs-on: macos-10.15
     needs: iso-nonsquashfs-green
+    env:
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PACKER_TARGET: virtualbox-iso.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
         uses: actions/download-artifact@v2
         with:
           name: cOS-nonsquashfs-green-x86_64.iso.zip
-      # - name: Install deps
-      #   run: |
-      #     brew tap hashicorp/tap
-      #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
             brew install yq
@@ -524,8 +528,8 @@ jobs:
         run: |
           export YQ=/usr/local/bin/yq
           source .github/helpers.sh
-          COS_VERSION=$(cos_version)
-          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=x86_64' -var='flavor=green' -only virtualbox-iso.cos" make packer
+          export PKR_VAR_build=$(cos_version)
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-nonsquashfs-green-vbox-x86_64.ova

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -131,6 +131,13 @@ jobs:
     env:
       FLAVOR: green
       ARCH: arm64
+      PKR_VAR_arch: arm64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PKR_VAR_qemu_binary: qemu-system-aarch64
+      PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
+      PACKER_TARGET: qemu.cos-arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -146,13 +153,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=arm64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
-          PACKER_ARGS="-only qemu.cos-arm64" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-squashfs-green-QEMU-arm64.qcow
@@ -284,6 +285,13 @@ jobs:
     env:
       FLAVOR: green
       ARCH: arm64
+      PKR_VAR_arch: arm64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PKR_VAR_qemu_binary: qemu-system-aarch64
+      PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
+      PACKER_TARGET: qemu.cos-arm64
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -299,13 +307,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=arm64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          export PKR_VAR_qemu_binary="qemu-system-aarch64"
-          export PKR_VAR_firmware=/usr/share/qemu-efi-aarch64/QEMU_EFI.fd
-          PACKER_ARGS="-only qemu.cos-arm64" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-nonsquashfs-green-QEMU-arm64.qcow

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -231,6 +231,11 @@ jobs:
     env:
       FLAVOR: green
       ARCH: x86_64
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -246,11 +251,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=x86_64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          PACKER_ARGS="-only qemu.cos" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-squashfs-green-QEMU-x86_64.qcow
@@ -266,16 +267,17 @@ jobs:
   vbox-squashfs-green:
     runs-on: macos-10.15
     needs: iso-squashfs-green
+    env:
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PACKER_TARGET: virtualbox-iso.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
         uses: actions/download-artifact@v2
         with:
           name: cOS-squashfs-green-x86_64.iso.zip
-      # - name: Install deps
-      #   run: |
-      #     brew tap hashicorp/tap
-      #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
             brew install yq
@@ -283,8 +285,8 @@ jobs:
         run: |
           export YQ=/usr/local/bin/yq
           source .github/helpers.sh
-          COS_VERSION=$(cos_version)
-          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=x86_64' -var='flavor=green' -only virtualbox-iso.cos" make packer
+          export PKR_VAR_build=$(cos_version)
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-squashfs-green-vbox-x86_64.ova
@@ -500,6 +502,11 @@ jobs:
     env:
       FLAVOR: green
       ARCH: x86_64
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PKR_VAR_accelerator: none
+      PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
@@ -515,11 +522,7 @@ jobs:
         run: |
           source .github/helpers.sh
           export PKR_VAR_build=$(cos_version)
-          export PKR_VAR_arch=x86_64
-          export PKR_VAR_flavor=green
-          export PKR_VAR_feature=vagrant
-          export PKR_VAR_accelerator=none
-          PACKER_ARGS="-only qemu.cos" make packer
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-nonsquashfs-green-QEMU-x86_64.qcow
@@ -535,16 +538,17 @@ jobs:
   vbox-nonsquashfs-green:
     runs-on: macos-10.15
     needs: iso-nonsquashfs-green
+    env:
+      PKR_VAR_arch: x86_64
+      PKR_VAR_flavor: green
+      PKR_VAR_feature: vagrant
+      PACKER_TARGET: virtualbox-iso.cos
     steps:
       - uses: actions/checkout@v2
       - name: Download ISO
         uses: actions/download-artifact@v2
         with:
           name: cOS-nonsquashfs-green-x86_64.iso.zip
-      # - name: Install deps
-      #   run: |
-      #     brew tap hashicorp/tap
-      #     brew install hashicorp/tap/packer
       - name: Install deps
         run: |
             brew install yq
@@ -552,8 +556,8 @@ jobs:
         run: |
           export YQ=/usr/local/bin/yq
           source .github/helpers.sh
-          COS_VERSION=$(cos_version)
-          PACKER_ARGS="-var='feature=vagrant' -var='build=$COS_VERSION' -var='arch=x86_64' -var='flavor=green' -only virtualbox-iso.cos" make packer
+          export PKR_VAR_build=$(cos_version)
+          make packer
       - uses: actions/upload-artifact@v2
         with:
           name: cOS-Packer-nonsquashfs-green-vbox-x86_64.ova
@@ -898,6 +902,9 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      PKR_VAR_flavor: green
+      PKR_VAR_git_sha: "${GITHUB_SHA}"
+      PACKER_TARGET: amazon-ebs.cos
     steps:
       - uses: actions/checkout@v2
       - name: Run make deps
@@ -913,11 +920,9 @@ jobs:
             PACKAGE_VERSION=$(cos_package_version)
             export COS_VERSION="${PACKAGE_VERSION/+/-}"
             export PKR_VAR_cos_version="${COS_VERSION}"
-            export PKR_VAR_cos_deploy_args="cos-deploy --docker-image quay.io/costoolkit/releases-green:cos-system-${COS_VERSION}"
-            export PKR_VAR_flavor=green
-            export PKR_VAR_git_sha="${GITHUB_SHA}"
             export PKR_VAR_aws_temporary_security_group_source_cidr="${{ steps.ip.outputs.ipv4 }}/32"
-            make packer-aws
+            export PKR_VAR_cos_deploy_args="cos-deploy --docker-image quay.io/costoolkit/releases-green:cos-system-${COS_VERSION}"
+            make packer
   build-toolchain-tagged:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -95,9 +95,9 @@ DESTINATION?=$(ROOT_DIR)/build
 export MANIFEST?=$(ROOT_DIR)/manifest.yaml
 
 #
-# Arguments to packer for creating the ISO
+# Packer target to build
 #
-PACKER_ARGS?=-only virtualbox-iso.cos
+PACKER_TARGET?=virtualbox-iso.cos
 
 #
 # Used by .iso, .test, and .run

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -124,12 +124,4 @@ ifeq ("$(PACKER)","/usr/sbin/packer")
 	@echo "Please set PACKER to the correct binary before calling make"
 	@exit 1
 endif
-ifeq ("$(ISO)","")
-	@echo "Please run 'make iso' or 'make local-iso' first"
-	@exit 1
-endif
-	cd $(ROOT_DIR)/packer && $(PACKER) build -var "iso=$(ISO)" $(PACKER_ARGS) .
-
-
-packer-aws:
-	cd $(ROOT_DIR)/packer && $(PACKER) build $(PACKER_ARGS) -only amazon-ebs.cos .
+	export PKR_VAR_iso=$(ISO) && cd $(ROOT_DIR)/packer && $(PACKER) build -only $(PACKER_TARGET) .


### PR DESCRIPTION
Drop packer-aws
Change PACKER_ARGS to PACKER_TARGET, now we only need to set the target
to build
Use PKR_VAR_ env vars to pass whatever args packer needs. This allows
more flexibility and better visibility on CI
Drop ISO check on packer makefile. Packer will complain if the iso value
is empty so we dont need to check that. Plus also allows us to add more
targets to the packer config and use the same makefile target

Signed-off-by: Itxaka <igarcia@suse.com>