### PR TITLE
Expand installer tests

### DIFF
--- a/make/Makefile.test
+++ b/make/Makefile.test
@@ -170,7 +170,7 @@ ifneq ("$(ENABLE_VIDEO_CAPTURE)", "")
 	VBoxManage modifyvm "test" --recording on --recordingscreens 0 --recordingfile $(ROOT_DIR)/capture.webm
 endif
 	VBoxManage modifyvm "test" --uart1 0x3f8 4 --uartmode1 file $(ROOT_DIR)/serial_port1.log --nic1 nat --boot1 disk --boot2 dvd --natpf1 "guestssh,tcp,,2222,,22"
-	VBoxManage storagectl "test" --name "sata controller" --add sata --portcount 2
+	VBoxManage storagectl "test" --name "sata controller" --add sata --portcount 2 --hostiocache off
 	VBoxManage storageattach "test" --storagectl "sata controller" --port 0 --device 0 --type hdd --medium $(ROOT_DIR)/sda.vdi
 	VBoxManage storageattach "test" --storagectl "sata controller" --port 1 --device 0 --type dvddrive --medium $(ISO)
 

--- a/tests/assets/broken-config.yaml
+++ b/tests/assets/broken-config.yaml
@@ -1,0 +1,7 @@
+# stolen from https://gist.github.com/kantord/a56ea6c5920847a186d819633d6d6c18
+dashboard "Variables example":
+  - h1 text: Variables Example
+  -       dropdown my_var=pie:
+  - {"value": pie, "text": "Pie chart"}
+  - {"value": bar, "text": "Bar chart"}
+  p text: "Selected chart type: ${my_var}"

--- a/tests/assets/config.yaml
+++ b/tests/assets/config.yaml
@@ -1,0 +1,3 @@
+stages:
+  network:
+    - hostname: "testhostname"

--- a/tests/assets/layout.yaml
+++ b/tests/assets/layout.yaml
@@ -1,0 +1,23 @@
+stages:
+  partitioning:
+    - name: "Repart disk"
+      layout:
+        device:
+          path: /dev/sda
+        add_partitions:
+          - fsLabel: COS_STATE
+            size: 8192
+            pLabel: state
+          - fsLabel: COS_OEM
+            size: 10
+            pLabel: oem
+          - fsLabel: COS_RECOVERY
+            # default filesystem is ext2 if omitted
+            filesystem: ext4
+            size: 4000
+            pLabel: recovery
+          - fsLabel: COS_PERSISTENT
+            pLabel: persistent
+            # default filesystem is ext2 if omitted
+            filesystem: ext4
+            size: 100


### PR DESCRIPTION
Should cover most of the config options.

missing options:
 - –iso (How to serve the iso?)
 - –poweroff (Can probably be only tested on bios)
 - –no-format (Requires a pre-format)
 - –docker-image
 - –debug ( needed?)
 - –no-verify
 - –no-cosign
 
Partial #859 