### PR TITLE
bump yip and dependants

### DIFF
--- a/packages/cos-setup/definition.yaml
+++ b/packages/cos-setup/definition.yaml
@@ -1,7 +1,7 @@
 name: cos-setup
 category: system
-version: 0.4-11
+version: 0.4-12
 requires:
   - name: "yip"
     category: "toolchain"
-    version: ">=0.8.4"
+    version: ">=0.9.24"

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.5
+    version: 0.7.6
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
+++ b/packages/immutable-rootfs/30cos-immutable-rootfs/module-setup.sh
@@ -29,7 +29,7 @@ install() {
     # Include utilities required for cos-setup services,
     # probably a devoted cos-setup dracut module makes sense
     inst_multiple -o \
-        partprobe lsblk sgdisk mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat mkfs.xfs blkid e2fsck resize2fs mount xfs_growfs umount
+        partprobe sync lsblk sgdisk mkfs.ext2 mkfs.ext3 mkfs.ext4 mkfs.vfat mkfs.fat mkfs.xfs blkid e2fsck resize2fs mount xfs_growfs umount
     inst_hook cmdline 30 "${moddir}/parse-cos-cmdline.sh"
     inst_script "${moddir}/cos-generator.sh" \
         "${systemdutildir}/system-generators/dracut-cos-generator"

--- a/packages/immutable-rootfs/build.yaml
+++ b/packages/immutable-rootfs/build.yaml
@@ -13,7 +13,7 @@ copy:
 - package: 
     category: "toolchain"
     name: "yip"
-    version: ">=0"
+    version: ">=0.9.23"
   source: "/usr/bin/yip"
   destination: "/usr/bin/yip"
 

--- a/packages/immutable-rootfs/build.yaml
+++ b/packages/immutable-rootfs/build.yaml
@@ -13,7 +13,7 @@ copy:
 - package: 
     category: "toolchain"
     name: "yip"
-    version: ">=0.9.23"
+    version: ">=0.9.24"
   source: "/usr/bin/yip"
   destination: "/usr/bin/yip"
 

--- a/packages/immutable-rootfs/collection.yaml
+++ b/packages/immutable-rootfs/collection.yaml
@@ -1,8 +1,8 @@
 packages:
   - name: "immutable-rootfs"
     category: "system"
-    version: 0.2.1
+    version: 0.2.2
     requires:
       - category: toolchain
         name: yip
-        version: ">=0.9.23"
+        version: ">=0.9.24"

--- a/packages/immutable-rootfs/collection.yaml
+++ b/packages/immutable-rootfs/collection.yaml
@@ -1,0 +1,8 @@
+packages:
+  - name: "immutable-rootfs"
+    category: "system"
+    version: 0.2.1
+    requires:
+      - category: toolchain
+        name: yip
+        version: ">=0.9.23"

--- a/packages/immutable-rootfs/definition.yaml
+++ b/packages/immutable-rootfs/definition.yaml
@@ -1,3 +1,0 @@
-name: "immutable-rootfs"
-category: "system"
-version: 0.2.0-12

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -340,7 +340,7 @@ part_probe() {
     partprobe ${dev} 2>/dev/null || true
 
     sync
-    sleep 2
+    sleep 5
 
     dmsetup remove_all 2>/dev/null || true
 }
@@ -561,7 +561,6 @@ get_image()
 {
     if [ -n "$_UPGRADE_IMAGE" ]; then
         local temp
-        part_probe
         _DISTRO=$(mktemp --tmpdir -d cos.XXXXXXXX.image)
         temp=$(mktemp --tmpdir -d cos.XXXXXXXX.image)
         create_rootfs "install" $_DISTRO $temp

--- a/packages/toolchain/collection.yaml
+++ b/packages/toolchain/collection.yaml
@@ -43,7 +43,7 @@ packages:
     name: "yip"
     upx: false
     fips: true
-    version: 0.9.21-1
+    version: 0.9.23
     labels:
       github.repo: "yip"
       github.owner: "mudler"
@@ -53,7 +53,7 @@ packages:
     name: "yip"
     upx: false
     fips: false
-    version: 0.9.21-1
+    version: 0.9.23
     labels:
       github.repo: "yip"
       github.owner: "mudler"

--- a/packages/toolchain/collection.yaml
+++ b/packages/toolchain/collection.yaml
@@ -43,7 +43,7 @@ packages:
     name: "yip"
     upx: false
     fips: true
-    version: 0.9.23
+    version: 0.9.24
     labels:
       github.repo: "yip"
       github.owner: "mudler"
@@ -53,7 +53,7 @@ packages:
     name: "yip"
     upx: false
     fips: false
-    version: 0.9.23
+    version: 0.9.24
     labels:
       github.repo: "yip"
       github.owner: "mudler"


### PR DESCRIPTION
New yip version uses  retries for re-reading the partitions so it doesn't fail or skip on the first run.

Also adds sync into the inmutable rootfs

Fixes: https://github.com/rancher-sandbox/cOS-toolkit/issues/887


Signed-off-by: Itxaka <igarcia@suse.com>