### PR TITLE
Add packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/leap
 
 ENV LUET_NOLOCK=true
 
-RUN zypper in -y docker curl squashfs xorriso make which mtools dosfstools jq gptfdisk
+RUN zypper in -y docker curl squashfs xorriso make which mtools dosfstools jq gptfdisk git parted kpartx
 
 COPY . /cOS
 WORKDIR /cOS

--- a/examples/odroid-c2/Dockerfile
+++ b/examples/odroid-c2/Dockerfile
@@ -6,6 +6,8 @@ FROM opensuse/leap:15.3
 ENV COSIGN_EXPERIMENTAL=1
 ENV COSIGN_REPOSITORY=raccos/releases-green
 
+RUN zypper ar -G https://download.opensuse.org/repositories/devel:/ARM:/Factory:/Contrib:/OdroidC2/standard/devel:ARM:Factory:Contrib:OdroidC2.repo
+RUN zypper ref
 RUN zypper in -y \
     # Odroid
     kernel-default-extra \
@@ -39,14 +41,18 @@ RUN zypper in -y \
     open-vm-tools \
     python-azure-agent \
     qemu-guest-agent \
-    kernel-firmware-bnx2 \
-    kernel-firmware-i915 \
-    kernel-firmware-intel \
-    kernel-firmware-iwlwifi \
-    kernel-firmware-mellanox \
-    kernel-firmware-network \
-    kernel-firmware-platform \
-    kernel-firmware-realtek \
+    wireless-tools \
+    wpa_supplicant \
+    iw \
+    iproute2 \
+    dtb-amlogic \
+    aaa_base-extras \
+    odroidc2-firmware \
+    iputils \
+    kmod \
+    libudev1 \
+    vim-small \
+    kernel-firmware-all \
     nano \
     gawk \
     haveged \


### PR DESCRIPTION
Adding packages while I tried to get OdroidC2 working locally. Sadly I don't get eth0 after boot (altought, I can see u-boot trying to get an IP )  so I cannot test upgrades, resets and the full cOS featureset. I'm suspecting kernel, but requires quite some time to experiment.  This change adds firmware packages, firmware and dtbs to the example image

Another approach would be to test with the u-boot and old kernel, but would be suboptimal to release with those ( for the records, here is a spec that build the Odroid kernel https://github.com/rancher-sandbox/cOS-toolkit/commit/c31ebbd1ac151883b49a74fbf90955c38841eb3f).

Also, this PR adds packages to the toolchain image in order to run the arm image script successfully. For reference, that's where I was experimenting with : https://github.com/mudler/cos-embedded-images/