### PR TITLE
Build cos package by stacking packages rather than build envs

### DIFF
--- a/packages/base/build.yaml
+++ b/packages/base/build.yaml
@@ -27,3 +27,6 @@ steps:
     rm -f /var/lib/dbus/machine-id && \
     mkdir -p /var/lib/dbus && \
     ln -sf /etc/machine-id /var/lib/dbus/machine-id
+
+# See https://luet-lab.github.io/docs/docs/concepts/packages/specfile/#package-by-container-content
+unpack: true

--- a/packages/base/definition.yaml
+++ b/packages/base/definition.yaml
@@ -1,6 +1,5 @@
 name: "base"
 category: "distro"
 version: "0.20211101"
-hidden: true # No need to make it installable for now
 labels:
   autobump.strategy: "snapshot"

--- a/packages/cos/build.yaml
+++ b/packages/cos/build.yaml
@@ -1,6 +1,11 @@
 #### system/cos system/cos-container and recovery/cos start here
 {{ if or (eq .Values.name "cos-container") (eq .Values.name "cos" ) }}
 requires:
+# Base distro is not required by other packages to facilitate their usage
+# as stand alone packages (e.g. in Dockerfiles), so that it is included here.
+- name: "base"
+  category: "distro"
+  version: ">=0"
 - name: "cos-setup"
   category: "system"
   version: ">=0"
@@ -77,6 +82,8 @@ steps:
 
 # See https://luet-lab.github.io/docs/docs/concepts/packages/specfile/#package-by-container-content
 unpack: true
+# See https://luet-lab.github.io/docs/docs/concepts/packages/specfile/#requires_final_images
+requires_final_images: true
 
 # Files to exclude from the final 
 # artifact 

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.7
+    version: 0.7.8
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:


### PR DESCRIPTION
This commit changes the build approach for cos package. Instead of
stacking build environments for the build it stacks all dependency
packages. This allows control over the distinction of build time
requirements and run time requirements.

Signed-off-by: David Cassany <dcassany@suse.com>