### PR TITLE
ci: Drop autobump.revbump_related from specs

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -7,7 +7,6 @@ packages:
     brand_name: "cOS"
     labels:
       autobump.revdeps: "true"
-      autobump.revbump_related: "recovery/cos-img recovery/cos-squash"
   - !!merge <<: *cos
     name: "cos-container"
     description: "cOS container image, used to build cOS derivatives from scratch"

--- a/packages/toolchain/collection.yaml
+++ b/packages/toolchain/collection.yaml
@@ -9,7 +9,6 @@ packages:
       github.repo: "luet"
       github.owner: "mudler"
       autobump.revdeps: "true"
-      autobump.revbump_related: "system/cos recovery/cos recovery/cos-img recovery/cos-squash"
   - category: "toolchain-fips"
     name: "luet"
     version: "0.20.11"
@@ -20,7 +19,6 @@ packages:
       github.repo: "luet"
       github.owner: "mudler"
       autobump.revdeps: "true"
-      autobump.revbump_related: "system/cos recovery/cos recovery/cos-img recovery/cos-squash"
   - name: "luet-makeiso"
     category: "toolchain"
     version: 0.3.8-15
@@ -48,7 +46,6 @@ packages:
       github.repo: "yip"
       github.owner: "mudler"
       autobump.revdeps: "true"
-      autobump.revbump_related: "system/cos recovery/cos recovery/cos-img recovery/cos-squash"
   - category: "toolchain"
     name: "yip"
     upx: false
@@ -58,4 +55,3 @@ packages:
       github.repo: "yip"
       github.owner: "mudler"
       autobump.revdeps: "true"
-      autobump.revbump_related: "system/cos recovery/cos recovery/cos-img recovery/cos-squash"

--- a/packages/toolchain/cosign/definition.yaml
+++ b/packages/toolchain/cosign/definition.yaml
@@ -5,4 +5,3 @@ labels:
   github.repo: "cosign"
   github.owner: "sigstore"
   autobump.revdeps: "true"
-  autobump.revbump_related: "system/cos recovery/cos recovery/cos-img recovery/cos-squash"

--- a/packages/toolchain/luet-cosign/definition.yaml
+++ b/packages/toolchain/luet-cosign/definition.yaml
@@ -5,4 +5,3 @@ labels:
   github.repo: "luet-cosign"
   github.owner: "rancher-sandbox"
   autobump.revdeps: "true"
-  autobump.revbump_related: "system/cos recovery/cos recovery/cos-img recovery/cos-squash"

--- a/packages/toolchain/luet-mtree/definition.yaml
+++ b/packages/toolchain/luet-mtree/definition.yaml
@@ -5,4 +5,3 @@ labels:
   github.repo: "luet-mtree"
   github.owner: "rancher-sandbox"
   autobump.revdeps: "true"
-  autobump.revbump_related: "system/cos recovery/cos recovery/cos-img recovery/cos-squash"

--- a/packages/toolchain/yq/definition.yaml
+++ b/packages/toolchain/yq/definition.yaml
@@ -6,7 +6,6 @@ uri:
 license: "MIT"
 labels:
   autobump.revdeps: "true"
-  autobump.revbump_related: "system/cos recovery/cos recovery/cos-img recovery/cos-squash"
   github.repo: "yq"
   github.owner: "mikefarah"
   autobump.strategy: "release"


### PR DESCRIPTION
This is not required anymore as now revdeps should be clearly displayed
also for specs that requires final packages during build time.

I think this should also fixups revbumps versions from the bot

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>