### PR TITLE
fixup: add missing then in if block

### DIFF
--- a/images/arm-img-builder.sh
+++ b/images/arm-img-builder.sh
@@ -198,7 +198,7 @@ while [ "$#" -gt 0 ]; do
     shift 1
 done
 
-if [ -n "$cos_config"] && [ -e "$cos_config" ];
+if [ -n "$cos_config"] && [ -e "$cos_config" ]; then
   source "$cos_config"
 fi
 


### PR DESCRIPTION
Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>

https://github.com/rancher-sandbox/cOS-toolkit/runs/4392664263?check_suite_focus=true
Otherwise CI fails with:

```
Run mkdir build
./images/arm-img-builder.sh: line 203: syntax error near unexpected token `fi'
Error: Process completed with exit code 2.
```