### PR TITLE
Add dasel

### DIFF
--- a/packages/toolchain/dasel/build.yaml
+++ b/packages/toolchain/dasel/build.yaml
@@ -1,0 +1,20 @@
+requires:
+  - name: "golang"
+    category: "build"
+    version: ">=0"
+env:
+  - PATH=$PATH:/usr/local/go/bin
+  - GOPATH=/luetbuild/go
+  - GO111MODULE=on
+  - CGO_ENABLED=0
+  - LDFLAGS="-s -w"
+prelude:
+{{ template "golang_deps" .}}
+{{ $opts:= dict "version" (printf "v%s" .Values.version) "org" ( index .Values.labels "github.owner" ) "repo" ( index .Values.labels "github.repo" ) }}
+{{ template "golang_download_package" $opts}}
+steps:
+  - |
+    PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && \
+    cd /luetbuild/go/src/github.com/TomWright/dasel && go build --ldflags "$LDFLAGS" ./cmd/dasel && mv dasel /usr/bin/dasel
+includes:
+  - /usr/bin/dasel

--- a/packages/toolchain/dasel/build.yaml
+++ b/packages/toolchain/dasel/build.yaml
@@ -17,4 +17,4 @@ steps:
     PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && \
     cd /luetbuild/go/src/github.com/{{ ( index .Values.labels "github.owner" ) }}/{{.Values.name}} && go build --ldflags "$LDFLAGS" ./cmd/{{.Values.name}} && mv {{.Values.name}} /usr/bin/{{.Values.name}}
 includes:
-  - /usr/bin/dasel
+  - /usr/bin/{{.Values.name}}

--- a/packages/toolchain/dasel/build.yaml
+++ b/packages/toolchain/dasel/build.yaml
@@ -15,6 +15,6 @@ prelude:
 steps:
   - |
     PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && \
-    cd /luetbuild/go/src/github.com/TomWright/dasel && go build --ldflags "$LDFLAGS" ./cmd/dasel && mv dasel /usr/bin/dasel
+    cd /luetbuild/go/src/github.com/{{ ( index .Values.labels "github.owner" ) }}/{{.Values.name}} && go build --ldflags "$LDFLAGS" ./cmd/{{.Values.name}} && mv {{.Values.name}} /usr/bin/{{.Values.name}}
 includes:
   - /usr/bin/dasel

--- a/packages/toolchain/dasel/build.yaml
+++ b/packages/toolchain/dasel/build.yaml
@@ -3,11 +3,10 @@ requires:
     category: "build"
     version: ">=0"
 env:
-  - PATH=$PATH:/usr/local/go/bin
-  - GOPATH=/luetbuild/go
-  - GO111MODULE=on
-  - CGO_ENABLED=0
-  - LDFLAGS="-s -w"
+{{ template "golang_env" }}
+- CGO_ENABLED=0
+- LDFLAGS="-s -w"
+
 prelude:
 {{ template "golang_deps" .}}
 {{ $opts:= dict "version" (printf "v%s" .Values.version) "org" ( index .Values.labels "github.owner" ) "repo" ( index .Values.labels "github.repo" ) }}

--- a/packages/toolchain/dasel/definition.yaml
+++ b/packages/toolchain/dasel/definition.yaml
@@ -1,0 +1,10 @@
+name: dasel
+category: toolchain
+version: "1.22.1"
+labels:
+  github.repo: "dasel"
+  github.owner: "TomWright"
+uri:
+  - https://github.com/TomWright/dasel
+license: "MIT License"
+description: "Query, update and convert data structures from the command line. Comparable to jq/yq but supports JSON, TOML, YAML, XML and CSV with zero runtime dependencies."


### PR DESCRIPTION
This utility can be used to parse xml and vice versa. Will be used to
parse xml from openSUSE repository for autobumping packages.

Example:
```yaml
      autobump.hook: |
        curl -s -L https://download.opensuse.org/repositories/hardware:/boot/openSUSE_Factory_ARM/$(curl -s -L https://download.opensuse.org/repositories/hardware:/boot/openSUSE_Factory_ARM/repodata/repomd.xml | dasel select -p xml 'repomd.data.[0].location.-href') | gunzip | dasel -r xml -p json | jq '.metadata.package[] | select(.name=="u-boot-rpiarm64") | select(.arch!="src").version | map(.)[2] + map(.)[1]' -r
      autobump.version_hook: |
        curl -s -L https://download.opensuse.org/repositories/hardware:/boot/openSUSE_Factory_ARM/$(curl -s -L https://download.opensuse.org/repositories/hardware:/boot/openSUSE_Factory_ARM/repodata/repomd.xml | dasel select -p xml 'repomd.data.[0].location.-href') | gunzip | dasel -r xml -p json | jq '.metadata.package[] | select(.name=="u-boot-rpiarm64") | select(.arch!="src").version | map(.)[2] + map(.)[1]' -r

# We do assume that checksum is sha256
      autobump.checksum: |
        curl -s -L https://download.opensuse.org/repositories/hardware:/boot/openSUSE_Factory_ARM/$(curl -s -L https://download.opensuse.org/repositories/hardware:/boot/openSUSE_Factory_ARM/repodata/repomd.xml | dasel select -p xml 'repomd.data.[0].location.-href') | gunzip | dasel -r xml -p json | jq '.metadata.package[] | select(.name=="u-boot-rpiarm64") | select(.arch!="src").checksum."#text"' -r
```
Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>