### PR TITLE
ci: temporarily disable cancel-in-progress in concurrency

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -949,9 +949,12 @@ name: {{{$config.pipeline}}}-{{{ $config.flavor }}}-{{{ $config.arch }}}
 on: 
 {{{$config.on | toYAML | indent 1 }}}
 
-concurrency:
-  group: ci-{{{$config.pipeline}}}-{{{ $config.flavor }}}-{{{ $config.arch }}}-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-{{{$config.pipeline}}}-{{{ $config.flavor }}}-{{{ $config.arch }}}-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-{{{$config.pipeline}}}-{{{ $config.flavor }}}-{{{ $config.arch }}}-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 
 jobs:
 {{{- if (has $config "build_examples_dir") }}}

--- a/.github/workflows/build-examples-green-x86_64.yaml
+++ b/.github/workflows/build-examples-green-x86_64.yaml
@@ -12,9 +12,12 @@ on:
  push:
    branches:
      - master
-concurrency:
-  group: ci-Examples-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-Examples-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-Examples-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-example-cos-official:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-master-blue-arm64.yaml
+++ b/.github/workflows/build-master-blue-arm64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    branches:
      - master
-concurrency:
-  group: ci-master-blue-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-master-blue-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-master-blue-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-blue-arm64:
     runs-on: [self-hosted, arm64]

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    branches:
      - master
-concurrency:
-  group: ci-master-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-master-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-master-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-blue:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    branches:
      - master
-concurrency:
-  group: ci-master-green-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-master-green-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-master-green-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-green-arm64:
     runs-on: [self-hosted, arm64]

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    branches:
      - master
-concurrency:
-  group: ci-master-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-master-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-master-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-green:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-master-orange-arm64.yaml
+++ b/.github/workflows/build-master-orange-arm64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    branches:
      - master
-concurrency:
-  group: ci-master-orange-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-master-orange-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-master-orange-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-orange-arm64:
     runs-on: [self-hosted, arm64]

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    branches:
      - master
-concurrency:
-  group: ci-master-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-master-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-master-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-orange:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-nightly-blue-x86_64.yaml
+++ b/.github/workflows/build-nightly-blue-x86_64.yaml
@@ -2,9 +2,12 @@ name: nightly-blue-x86_64
 on: 
  schedule:
    - cron: 0 20 * * *
-concurrency:
-  group: ci-nightly-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-nightly-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-nightly-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-blue:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-nightly-green-x86_64.yaml
+++ b/.github/workflows/build-nightly-green-x86_64.yaml
@@ -2,9 +2,12 @@ name: nightly-green-x86_64
 on: 
  schedule:
    - cron: 0 20 * * *
-concurrency:
-  group: ci-nightly-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-nightly-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-nightly-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-green:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-nightly-orange-x86_64.yaml
+++ b/.github/workflows/build-nightly-orange-x86_64.yaml
@@ -2,9 +2,12 @@ name: nightly-orange-x86_64
 on: 
  schedule:
    - cron: 0 20 * * *
-concurrency:
-  group: ci-nightly-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-nightly-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-nightly-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-orange:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-pr-blue-arm64.yaml
+++ b/.github/workflows/build-pr-blue-arm64.yaml
@@ -4,9 +4,12 @@ on:
    types:
      - labeled
      - synchronize
-concurrency:
-  group: ci-PR-blue-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-PR-blue-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-PR-blue-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-blue-arm64:
     runs-on: [self-hosted, arm64]

--- a/.github/workflows/build-pr-blue-x86_64.yaml
+++ b/.github/workflows/build-pr-blue-x86_64.yaml
@@ -8,9 +8,12 @@ on:
      - .github/**
      - Makefile
      - tests/**
-concurrency:
-  group: ci-PR-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-PR-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-PR-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-blue-x86_64:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-pr-docker-blue-x86_64.yaml
+++ b/.github/workflows/build-pr-docker-blue-x86_64.yaml
@@ -8,9 +8,12 @@ on:
      - .github/**
      - Makefile
      - tests/**
-concurrency:
-  group: ci-docker-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-docker-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-docker-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-blue:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-pr-docker-green-x86_64.yaml
+++ b/.github/workflows/build-pr-docker-green-x86_64.yaml
@@ -8,9 +8,12 @@ on:
      - .github/**
      - Makefile
      - tests/**
-concurrency:
-  group: ci-docker-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-docker-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-docker-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-green:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-pr-docker-orange-x86_64.yaml
+++ b/.github/workflows/build-pr-docker-orange-x86_64.yaml
@@ -8,9 +8,12 @@ on:
      - .github/**
      - Makefile
      - tests/**
-concurrency:
-  group: ci-docker-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-docker-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-docker-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-orange:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-pr-green-arm64.yaml
+++ b/.github/workflows/build-pr-green-arm64.yaml
@@ -4,9 +4,12 @@ on:
    types:
      - labeled
      - synchronize
-concurrency:
-  group: ci-PR-green-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-PR-green-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-PR-green-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-green-arm64:
     runs-on: [self-hosted, arm64]

--- a/.github/workflows/build-pr-green-x86_64.yaml
+++ b/.github/workflows/build-pr-green-x86_64.yaml
@@ -8,9 +8,12 @@ on:
      - .github/**
      - Makefile
      - tests/**
-concurrency:
-  group: ci-PR-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-PR-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-PR-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-green-x86_64:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-pr-orange-arm64.yaml
+++ b/.github/workflows/build-pr-orange-arm64.yaml
@@ -4,9 +4,12 @@ on:
    types:
      - labeled
      - synchronize
-concurrency:
-  group: ci-PR-orange-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-PR-orange-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-PR-orange-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-orange-arm64:
     runs-on: [self-hosted, arm64]

--- a/.github/workflows/build-pr-orange-x86_64.yaml
+++ b/.github/workflows/build-pr-orange-x86_64.yaml
@@ -8,9 +8,12 @@ on:
      - .github/**
      - Makefile
      - tests/**
-concurrency:
-  group: ci-PR-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-PR-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-PR-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-orange-x86_64:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    tags:
      - v*
-concurrency:
-  group: ci-release-blue-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-release-blue-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-release-blue-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-blue-arm64:
     runs-on: [self-hosted, arm64]

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    tags:
      - v*
-concurrency:
-  group: ci-release-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-release-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-release-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-blue:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    tags:
      - v*
-concurrency:
-  group: ci-release-green-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-release-green-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-release-green-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-green-arm64:
     runs-on: [self-hosted, arm64]

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    tags:
      - v*
-concurrency:
-  group: ci-release-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-release-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-release-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-green:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    tags:
      - v*
-concurrency:
-  group: ci-release-orange-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-release-orange-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-release-orange-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   build-orange-arm64:
     runs-on: [self-hosted, arm64]

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -3,9 +3,12 @@ on:
  push:
    tags:
      - v*
-concurrency:
-  group: ci-release-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
-  cancel-in-progress: true
+# See: https://github.com/actions/runner/issues/1532, https://github.community/t/breaking-change-to-concurrency-group-syntax/
+# Temporary associate concurrency with a string only
+concurrency: ci-release-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#concurrency:
+#  group: ci-release-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+#  cancel-in-progress: true
 jobs:
   docker-build-orange:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workaround for https://github.com/actions/runner/issues/1532
See also https://github.community/t/breaking-change-to-concurrency-group-syntax/

:shrug: 

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>