### PR TITLE
Fixup refactoring leftover

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.9-3
+    version: 0.7.9-7
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -10,12 +10,10 @@ packages:
   - !!merge <<: *cos
     name: "cos-container"
     description: "cOS container image, used to build cOS derivatives from scratch"
-    version: 0.7.9-6
   - !!merge <<: *cos
     category: "recovery"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
-    version: 0.7.9-3
   - !!merge <<: *cos
     name: "cos-img"
     category: "recovery"

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -390,7 +390,7 @@ do_format()
             parted -s ${_DEVICE} mkpart primary fat32 0% 50MB # efi
             parted -s ${_DEVICE} set 1 ${_BOOTFLAG} on
             PREFIX=${_DEVICE}
-            if [ ! -e ${PREFIX}${STATE_NUM} ]; then
+            if [ ! -e ${PREFIX}1 ]; then
                 PREFIX=${_DEVICE}p
             fi
             _BOOT=${PREFIX}1

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,6 +1,6 @@
 name: "installer"
 category: "utils"
-version: "0.24"
+version: "0.25"
 description: "Installer, Upgrade and reset utilities to manage cOS derivatives"
 requires:
 - name: "luet-mtree"


### PR DESCRIPTION
STATE_NUM is not required, what we are targeting here is always the
first partition

Fixes #929

cc @bk201 @johnliu55tw 

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>