### PR TITLE
Rebrand on upgrade

### DIFF
--- a/packages/backports/installer/cos.sh
+++ b/packages/backports/installer/cos.sh
@@ -1209,6 +1209,8 @@ upgrade() {
     echo "Flush changes to disk"
     sync
 
+    rebrand
+
     if [ -n "$INTERACTIVE" ] && [ $INTERACTIVE == false ]; then
         if grep -q 'cos.upgrade.power_off=true' /proc/cmdline; then
             poweroff -f

--- a/packages/backports/installer/cos.sh
+++ b/packages/backports/installer/cos.sh
@@ -78,7 +78,7 @@ run_hook() {
 
     prepare_chroot $dir
     chroot $dir /usr/bin/cos-setup $hook
-    chroot $dir /usr/bin/cos-rebrand
+    chroot $dir /usr/sbin/cos-rebrand
     cleanup_chroot $dir
 }
 

--- a/packages/backports/installer/cos.sh
+++ b/packages/backports/installer/cos.sh
@@ -78,6 +78,7 @@ run_hook() {
 
     prepare_chroot $dir
     chroot $dir /usr/bin/cos-setup $hook
+    chroot $dir /usr/bin/cos-rebrand
     cleanup_chroot $dir
 }
 
@@ -1129,8 +1130,6 @@ deploy() {
 
     set_active_passive
 
-    rebrand
-
     echo "Flush changes to disk"
     sync
 
@@ -1208,8 +1207,6 @@ upgrade() {
 
     echo "Flush changes to disk"
     sync
-
-    rebrand
 
     if [ -n "$INTERACTIVE" ] && [ $INTERACTIVE == false ]; then
         if grep -q 'cos.upgrade.power_off=true' /proc/cmdline; then
@@ -1317,8 +1314,6 @@ install() {
 
     prepare_recovery
     prepare_passive
-
-    rebrand
 
     if [ "$STRICT_MODE" = "true" ]; then
     cos-setup after-install

--- a/packages/backports/installer/definition.yaml
+++ b/packages/backports/installer/definition.yaml
@@ -1,4 +1,4 @@
 name: "installer"
 category: "utils"
-version: "0.21.2"
+version: "0.21.3"
 description: "Installer, Upgrade and reset utilities to manage cOS derivatives"

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.9-14
+    version: 0.7.9-18
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -10,12 +10,10 @@ packages:
   - !!merge <<: *cos
     name: "cos-container"
     description: "cOS container image, used to build cOS derivatives from scratch"
-    version: 0.7.9-17
   - !!merge <<: *cos
     category: "recovery"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
-    version: 0.7.9-14
   - !!merge <<: *cos
     name: "cos-img"
     category: "recovery"

--- a/packages/cos/setup.yaml
+++ b/packages/cos/setup.yaml
@@ -25,3 +25,4 @@ stages:
         DOCUMENTATION_URL: "https://github.com/mudler/cOS"
         VERSION: ":VERSION:"
         PRETTY_NAME: ":PRETTY_NAME:"
+        GRUB_ENTRY_NAME: "cOS :VERSION:"

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -1209,6 +1209,8 @@ rebrand_cleanup()
 # END COS_REBRAND
 
 rebrand() {
+    load_full_config
+    
     rebrand_grub_menu "${_GRUB_ENTRY_NAME}"
 }
 

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -224,7 +224,7 @@ run_chroot_hook() {
 
     prepare_chroot $dir
     chroot $dir /usr/bin/cos-setup $hook
-    chroot $dir /usr/bin/cos-rebrand
+    chroot $dir /usr/sbin/cos-rebrand
     cleanup_chroot $dir
 }
 

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -218,12 +218,13 @@ cleanup_chroot() {
     done
 }
 
-run_hook() {
+run_chroot_hook() {
     local hook=$1
     local dir=$2
 
     prepare_chroot $dir
     chroot $dir /usr/bin/cos-setup $hook
+    chroot $dir /usr/bin/cos-rebrand
     cleanup_chroot $dir
 }
 
@@ -965,9 +966,9 @@ create_rootfs() {
         mount $_OEM $target/oem
     fi
     if [ "$_STRICT_MODE" = "true" ]; then
-        run_hook after-$hook_name-chroot $target
+        run_chroot_hook after-$hook_name-chroot $target
     else 
-        run_hook after-$hook_name-chroot $target || true
+        run_chroot_hook after-$hook_name-chroot $target || true
     fi
     if [ -n "$_OEM" ]; then
      umount $target/oem
@@ -1052,7 +1053,7 @@ run_reset_hook() {
     mount $_PERSISTENT $loop_dir/usr/local
     mount $_OEM $loop_dir/oem
 
-    run_hook after-reset-chroot $loop_dir
+    run_chroot_hook after-reset-chroot $loop_dir
 
     umount $loop_dir/oem
     umount $loop_dir/usr/local
@@ -1316,8 +1317,6 @@ upgrade() {
     echo "Flush changes to disk"
     sync
 
-    rebrand
-
     if [ -n "$INTERACTIVE" ] && [ $INTERACTIVE == false ]; then
         if grep -q 'cos.upgrade.power_off=true' /proc/cmdline; then
             poweroff -f
@@ -1444,9 +1443,9 @@ install() {
     # Otherwise, hooks are executed in get_image
     if [ -z "$_UPGRADE_IMAGE" ]; then
         if [ "$_STRICT_MODE" = "true" ]; then
-            run_hook after-install-chroot $_TARGET
+            run_chroot_hook after-install-chroot $_TARGET
         else
-            run_hook after-install-chroot $_TARGET || true
+            run_chroot_hook after-install-chroot $_TARGET || true
         fi
     fi
 
@@ -1456,8 +1455,6 @@ install() {
         prepare_recovery
     fi
     prepare_passive
-
-    rebrand
 
     if [ -z "$_UPGRADE_IMAGE" ]; then
         if [ "$_STRICT_MODE" = "true" ]; then

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -1316,6 +1316,8 @@ upgrade() {
     echo "Flush changes to disk"
     sync
 
+    rebrand
+
     if [ -n "$INTERACTIVE" ] && [ $INTERACTIVE == false ]; then
         if grep -q 'cos.upgrade.power_off=true' /proc/cmdline; then
             poweroff -f

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,6 +1,6 @@
 name: "installer"
 category: "utils"
-version: "0.25.1"
+version: "0.25.2"
 description: "Installer, Upgrade and reset utilities to manage cOS derivatives"
 requires:
 - name: "luet-mtree"

--- a/tests/upgrades-images-signed/upgrade_test.go
+++ b/tests/upgrades-images-signed/upgrade_test.go
@@ -28,9 +28,6 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 	Context("After install", func() {
 		When("upgrading", func() {
 			It("upgrades to latest available (master) and reset", func() {
-				grubEntry, err := s.Command("grub2-editenv /run/boot/grub_oem_env list | grep default_menu_entry= | sed 's/default_menu_entry=//'")
-				Expect(err).ToNot(HaveOccurred())
-
 				out, err := s.Command("cos-upgrade")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
@@ -38,11 +35,6 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 				By("rebooting")
 				s.Reboot()
 				Expect(s.BootFrom()).To(Equal(sut.Active))
-				By("checking grub menu entry changes", func() {
-					newGrubEntry, err := s.Command("grub2-editenv /run/boot/grub_oem_env list | grep default_menu_entry= | sed 's/default_menu_entry=//'")
-					Expect(err).ToNot(HaveOccurred())
-					Expect(grubEntry).ToNot(Equal(newGrubEntry))
-				})
 			})
 
 			It("upgrades to a specific image and reset back to the installed version", func() {

--- a/tests/upgrades-images-unsigned/upgrade_test.go
+++ b/tests/upgrades-images-unsigned/upgrade_test.go
@@ -76,7 +76,7 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 				grubEntry, err := s.Command("grub2-editenv /run/initramfs/cos-state/grub_oem_env list | grep default_menu_entry= | sed 's/default_menu_entry=//'")
 				Expect(err).ToNot(HaveOccurred())
 
-				out, err := s.Command("cos-upgrade --no-verify --docker-image quay.io/costoolkit/test-images:grub_menu")
+				out, err := s.Command("cos-upgrade --no-cosign --no-verify --docker-image quay.io/costoolkit/test-images:grub_menu")
 				if err != nil {
 					fmt.Fprintf(GinkgoWriter, "Error from cos-upgrade: %v\n", err)
 				}

--- a/tests/upgrades-images-unsigned/upgrade_test.go
+++ b/tests/upgrades-images-unsigned/upgrade_test.go
@@ -61,6 +61,41 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 				Expect(out).ToNot(Equal(fmt.Sprintf("%s\n", s.TestVersion)))
 				Expect(out).To(Equal(version))
 			})
+
+			// NOTE: once https://github.com/rancher-sandbox/cOS-toolkit/pull/959 is merged,
+			// the image used in the test below here is not relevant anymore and this test
+			// can be run aside of the upgrade-images-signed (which upgrades against master)
+			// What we are checking here is that the grub menu file is getting updated after
+			// running a cos-upgrade from the content of the target image.
+			It("changes grub menu entry during upgrades", func() {
+
+				if s.GetArch() == "aarch64" {
+					Skip("test valid only on amd64, until https://github.com/rancher-sandbox/cOS-toolkit/pull/959 is merged")
+				}
+
+				grubEntry, err := s.Command("grub2-editenv /run/initramfs/cos-state/grub_oem_env list | grep default_menu_entry= | sed 's/default_menu_entry=//'")
+				Expect(err).ToNot(HaveOccurred())
+
+				out, err := s.Command("cos-upgrade --no-verify --docker-image quay.io/costoolkit/test-images:grub_menu")
+				if err != nil {
+					fmt.Fprintf(GinkgoWriter, "Error from cos-upgrade: %v\n", err)
+				}
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
+				Expect(out).Should(ContainSubstring("Upgrade target: active.img"))
+				By("rebooting")
+				s.Reboot()
+				Expect(s.BootFrom()).To(Equal(sut.Active))
+
+				By("checking grub menu entry changes", func() {
+					newGrubEntry, err := s.Command("grub2-editenv /run/initramfs/cos-state/grub_oem_env list | grep default_menu_entry= | sed 's/default_menu_entry=//'")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(grubEntry).ToNot(Equal(newGrubEntry))
+				})
+
+				By("rollbacking state")
+				s.Reset()
+			})
 		})
 	})
 })


### PR DESCRIPTION
This PR calls `cos-rebrand` among the chroot hooks in order to apply branding from the system which is being upgraded.
The chroot hooks are called after the target is set up so this ensures we have the target ready, while probably this isn't the best place for it, we can keep this in mind while working on the new cli. Aside, as we have to backport this, I wanted to keep the changes minimal.

It adds a simple test inside the upgrade one instead of a separate one in order to not overload the CI

Fixes #928 