### PR TITLE
Downgrade cosign to 1.3.1

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -62,9 +62,6 @@
       - name: Run make {{{ $target }}}
         run: |
           sudo -E make {{{ $target }}}
-  {{{- if eq $target "deps" }}}
-          sudo luet install --no-spinner -y toolchain/yq
-  {{{- end }}}
 {{{end}}}
 
 {{{define "runner"}}}

--- a/.github/config/master.yaml
+++ b/.github/config/master.yaml
@@ -8,7 +8,7 @@ flavors:
         local_runner: false
         push_cache: true
         skip_build: false
-        skip_docker_build: false
+        skip_docker_build: true
 
         pipeline: "master"
         publishing_pipeline: true

--- a/.github/config/pr-docker.yaml
+++ b/.github/config/pr-docker.yaml
@@ -12,7 +12,7 @@ flavors:
         publish_toolchain: false
         publish_cloud: false
         skip_build: true
-        skip_docker_build: false
+        skip_docker_build: true
         repository: "releases" # releases for prod
         cache_repository: "build"
         organization: "quay.io/costoolkit"

--- a/.github/config/releases.yaml
+++ b/.github/config/releases.yaml
@@ -8,7 +8,7 @@ flavors:
         local_runner: false
         push_cache: true
         skip_build: false
-        skip_docker_build: false
+        skip_docker_build: true
 
         pipeline: "release"
         publishing_pipeline: true

--- a/.github/workflows/build-examples-green-x86_64.yaml
+++ b/.github/workflows/build-examples-green-x86_64.yaml
@@ -36,7 +36,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Build cos-official 🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
@@ -71,7 +70,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Build scratch 🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |
@@ -106,7 +104,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Build standard 🔧
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/build-master-blue-arm64.yaml
+++ b/.github/workflows/build-master-blue-arm64.yaml
@@ -48,7 +48,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -92,7 +91,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for blue
         run: |
             source .github/helpers.sh
@@ -156,7 +154,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -7,27 +7,6 @@ concurrency:
   group: ci-master-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  docker-build-blue:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: blue
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Install CI plugins
-        run: |
-            sudo cp -rfv .github/plugins/* /usr/bin/
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR
   build-blue-x86_64:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -59,7 +59,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -103,7 +102,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for blue
         run: |
             source .github/helpers.sh
@@ -160,7 +158,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -48,7 +48,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -110,7 +109,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -263,7 +261,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Tweak manifest and drop squashfs recovery
         run: |
           source .github/helpers.sh
@@ -402,7 +399,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for green
         run: |
             source .github/helpers.sh
@@ -465,7 +461,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -500,7 +495,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -7,27 +7,6 @@ concurrency:
   group: ci-master-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  docker-build-green:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: green
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Install CI plugins
-        run: |
-            sudo cp -rfv .github/plugins/* /usr/bin/
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR
   build-green-x86_64:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -59,7 +59,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -125,7 +124,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -395,7 +393,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Tweak manifest and drop squashfs recovery
         run: |
           source .github/helpers.sh
@@ -647,7 +644,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for green
         run: |
             source .github/helpers.sh
@@ -703,7 +699,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -720,12 +715,6 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cosign-log
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
   raw-images-green:
     runs-on: ubuntu-latest
     needs:
@@ -744,7 +733,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -853,7 +841,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -884,7 +871,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh

--- a/.github/workflows/build-master-orange-arm64.yaml
+++ b/.github/workflows/build-master-orange-arm64.yaml
@@ -50,7 +50,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -94,7 +93,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for orange
         run: |
             source .github/helpers.sh
@@ -158,7 +156,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -59,7 +59,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -103,7 +102,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for orange
         run: |
             source .github/helpers.sh
@@ -160,7 +158,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -7,27 +7,6 @@ concurrency:
   group: ci-master-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  docker-build-orange:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: orange
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Install CI plugins
-        run: |
-            sudo cp -rfv .github/plugins/* /usr/bin/
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR
   build-orange-x86_64:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build-nightly-blue-x86_64.yaml
+++ b/.github/workflows/build-nightly-blue-x86_64.yaml
@@ -56,7 +56,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -97,7 +96,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh

--- a/.github/workflows/build-nightly-green-x86_64.yaml
+++ b/.github/workflows/build-nightly-green-x86_64.yaml
@@ -56,7 +56,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -109,7 +108,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -379,7 +377,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Tweak manifest and drop squashfs recovery
         run: |
           source .github/helpers.sh
@@ -641,7 +638,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh

--- a/.github/workflows/build-nightly-orange-x86_64.yaml
+++ b/.github/workflows/build-nightly-orange-x86_64.yaml
@@ -56,7 +56,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -97,7 +96,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh

--- a/.github/workflows/build-pr-blue-arm64.yaml
+++ b/.github/workflows/build-pr-blue-arm64.yaml
@@ -47,7 +47,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate

--- a/.github/workflows/build-pr-blue-x86_64.yaml
+++ b/.github/workflows/build-pr-blue-x86_64.yaml
@@ -41,7 +41,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate

--- a/.github/workflows/build-pr-docker-blue-x86_64.yaml
+++ b/.github/workflows/build-pr-docker-blue-x86_64.yaml
@@ -12,24 +12,3 @@ concurrency:
   group: ci-docker-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  docker-build-blue:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: blue
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Install CI plugins
-        run: |
-            sudo cp -rfv .github/plugins/* /usr/bin/
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR

--- a/.github/workflows/build-pr-docker-green-x86_64.yaml
+++ b/.github/workflows/build-pr-docker-green-x86_64.yaml
@@ -12,24 +12,3 @@ concurrency:
   group: ci-docker-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  docker-build-green:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: green
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Install CI plugins
-        run: |
-            sudo cp -rfv .github/plugins/* /usr/bin/
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR

--- a/.github/workflows/build-pr-docker-orange-x86_64.yaml
+++ b/.github/workflows/build-pr-docker-orange-x86_64.yaml
@@ -12,24 +12,3 @@ concurrency:
   group: ci-docker-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  docker-build-orange:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: orange
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Install CI plugins
-        run: |
-            sudo cp -rfv .github/plugins/* /usr/bin/
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR

--- a/.github/workflows/build-pr-green-arm64.yaml
+++ b/.github/workflows/build-pr-green-arm64.yaml
@@ -47,7 +47,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -96,7 +95,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -249,7 +247,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Tweak manifest and drop squashfs recovery
         run: |
           source .github/helpers.sh
@@ -398,7 +395,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh

--- a/.github/workflows/build-pr-green-x86_64.yaml
+++ b/.github/workflows/build-pr-green-x86_64.yaml
@@ -41,7 +41,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -94,7 +93,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -364,7 +362,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Tweak manifest and drop squashfs recovery
         run: |
           source .github/helpers.sh
@@ -626,7 +623,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh

--- a/.github/workflows/build-pr-orange-arm64.yaml
+++ b/.github/workflows/build-pr-orange-arm64.yaml
@@ -49,7 +49,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate

--- a/.github/workflows/build-pr-orange-x86_64.yaml
+++ b/.github/workflows/build-pr-orange-x86_64.yaml
@@ -41,7 +41,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -48,7 +48,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -92,7 +91,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for blue
         run: |
             source .github/helpers.sh
@@ -156,7 +154,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -7,27 +7,6 @@ concurrency:
   group: ci-release-blue-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  docker-build-blue:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: blue
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Install CI plugins
-        run: |
-            sudo cp -rfv .github/plugins/* /usr/bin/
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR
   build-blue-x86_64:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -59,7 +59,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -103,7 +102,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for blue
         run: |
             source .github/helpers.sh
@@ -160,7 +158,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -48,7 +48,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -110,7 +109,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -263,7 +261,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Tweak manifest and drop squashfs recovery
         run: |
           source .github/helpers.sh
@@ -402,7 +399,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for green
         run: |
             source .github/helpers.sh
@@ -465,7 +461,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -501,7 +496,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -566,7 +560,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -59,7 +59,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -125,7 +124,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -395,7 +393,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Tweak manifest and drop squashfs recovery
         run: |
           source .github/helpers.sh
@@ -647,7 +644,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for green
         run: |
             source .github/helpers.sh
@@ -703,7 +699,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:
@@ -720,12 +715,6 @@ jobs:
       - name: Publish to DockerHub 🚀
         run: |
           sudo -E make publish-repo
-      - uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cosign-log
-          path: /tmp/luet-cosign.log
-          if-no-files-found: warn
   github-release-green:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -747,7 +736,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -826,7 +814,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -932,7 +919,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Public IP
         id: ip
         uses: haythem/public-ip@v1.2
@@ -963,7 +949,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -994,7 +979,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh
@@ -1017,7 +1001,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Export cos version
         run: |
              source .github/helpers.sh

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -7,27 +7,6 @@ concurrency:
   group: ci-release-green-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  docker-build-green:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: green
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Install CI plugins
-        run: |
-            sudo cp -rfv .github/plugins/* /usr/bin/
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR
   build-green-x86_64:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -50,7 +50,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -94,7 +93,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for orange
         run: |
             source .github/helpers.sh
@@ -158,7 +156,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -7,27 +7,6 @@ concurrency:
   group: ci-release-orange-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
   cancel-in-progress: true
 jobs:
-  docker-build-orange:
-    runs-on: ubuntu-latest
-    env:
-      FLAVOR: orange
-      ARCH: x86_64
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow
-      - name: Release space from worker
-        run: |
-          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
-          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
-      - name: Install CI plugins
-        run: |
-            sudo cp -rfv .github/plugins/* /usr/bin/
-      - name: Build  🔧
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          source .envrc
-          cos-build $FLAVOR
   build-orange-x86_64:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -59,7 +59,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Run make validate
         run: |
           sudo -E make validate
@@ -103,7 +102,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Generate link for orange
         run: |
             source .github/helpers.sh
@@ -160,7 +158,6 @@ jobs:
       - name: Run make deps
         run: |
           sudo -E make deps
-          sudo luet install --no-spinner -y toolchain/yq
       - name: Download result for build
         uses: actions/download-artifact@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ ifneq ($(shell id -u), 0)
 	@echo "'$@' is missing and you must be root to install it."
 	@exit 1
 else
-	$(LUET) install -y toolchain/yq
+	$(LUET) install -y --relax toolchain/yq
 endif
 
 $(JQ):
@@ -157,7 +157,7 @@ ifneq ($(shell id -u), 0)
 	@echo "'$@' is missing and you must be root to install it."
 	@exit 1
 else
-	$(LUET) install -y utils/jq
+	$(LUET) install -y --relax utils/jq
 endif
 
 $(MAKEISO):
@@ -165,7 +165,7 @@ ifneq ($(shell id -u), 0)
 	@echo "'$@' is missing and you must be root to install it."
 	@exit 1
 else
-	$(LUET) install -y toolchain/luet-makeiso
+	$(LUET) install -y --relax toolchain/luet-makeiso
 endif
 
 $(MTREE):
@@ -173,7 +173,7 @@ ifneq ($(shell id -u), 0)
 	@echo "'$@' is missing and you must be root to install it."
 	@exit 1
 else
-	$(LUET) install -y toolchain/luet-mtree
+	$(LUET) install -y --relax toolchain/luet-mtree
 endif
 
 $(COSIGN):
@@ -181,7 +181,7 @@ ifneq ($(shell id -u), 0)
 	@echo "'$@' is missing and you must be root to install it."
 	@exit 1
 else
-	$(LUET) install -y toolchain/luet-cosign  toolchain/cosign
+	$(LUET) install -y --relax toolchain/luet-cosign  toolchain/cosign@1.3.1
 endif
 
 clean: clean_build clean_iso clean_run clean_test

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ ifneq ($(shell id -u), 0)
 	@echo "'$@' is missing and you must be root to install it."
 	@exit 1
 else
-	$(LUET) install -y --relax toolchain/luet-cosign  toolchain/cosign@1.3.1
+	$(LUET) install -y --relax meta/cos-verify  toolchain/cosign@1.3.1
 endif
 
 clean: clean_build clean_iso clean_run clean_test

--- a/packages/cos/build.yaml
+++ b/packages/cos/build.yaml
@@ -52,7 +52,7 @@ requires:
   version: ">=0"
 - name: "cosign"
   category: "toolchain"
-  version: ">=0"
+  version: "<1.4"
 - name: "luet-cosign"
   category: "toolchain"
   version: ">=0"

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.9-18
+    version: 0.7.9-19
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/meta/collection.yaml
+++ b/packages/meta/collection.yaml
@@ -85,11 +85,11 @@ packages:
         version: ">=0"
   - category: "meta"
     name: "cos-verify"
-    version: 0.7.0-3
+    version: 0.7.0-4
     requires:
       - category: toolchain
         name: cosign
-        version: ">=0"
+        version: "<1.4"
       - category: toolchain
         name: luet-cosign
         version: ">=0"

--- a/packages/toolchain/cosign/definition.yaml
+++ b/packages/toolchain/cosign/definition.yaml
@@ -1,6 +1,6 @@
 name: "cosign"
 category: "toolchain"
-version: "1.4.1"
+version: "1.3.1"
 labels:
   github.repo: "cosign"
   github.owner: "sigstore"


### PR DESCRIPTION
Also disables the docker build step in pipelines, until #939 is delivered

See: https://github.com/rancher-sandbox/cOS-toolkit/issues/975