### PR TITLE
Default RPi serial console to 115200 bps

### DIFF
--- a/examples/rpi/files/etc/cos/bootargs.cfg
+++ b/examples/rpi/files/etc/cos/bootargs.cfg
@@ -11,9 +11,9 @@ set kernel=/boot/vmlinuz
 # https://bugzilla.opensuse.org/show_bug.cgi?id=1181683 and https://github.com/raspberrypi/linux/issues/4020
 if [ -n "$recoverylabel" ]; then
 
-    set kernelcmd="console=tty1 console=ttyS0 root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5 modprobe.blacklist=vc4"
+    set kernelcmd="console=tty1 console=ttyS0,115200 root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5 modprobe.blacklist=vc4"
 else
-    set kernelcmd="console=tty1 console=ttyS0 root=LABEL=$label cos-img/filename=$img panic=5 security=selinux selinux=1 modprobe.blacklist=vc4"
+    set kernelcmd="console=tty1 console=ttyS0,115200 root=LABEL=$label cos-img/filename=$img panic=5 security=selinux selinux=1 modprobe.blacklist=vc4"
 fi
 
 set initramfs=/boot/initrd


### PR DESCRIPTION
This is the [default baudrate](https://www.raspberrypi.com/documentation/computers/configuration.html#enabling-early-console-for-linux) on Raspberry Pi and also used by its bootloader.

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>