### PR TITLE
Adapt installer test to cloud-init output change

### DIFF
--- a/tests/installer/installer_test.go
+++ b/tests/installer/installer_test.go
@@ -204,7 +204,7 @@ var _ = Describe("cOS Installer tests", func() {
 				Expect(out).To(ContainSubstring("Preparing recovery.."))
 				Expect(out).To(ContainSubstring("Preparing passive boot.."))
 				Expect(out).To(ContainSubstring("Formatting drives.."))
-				Expect(out).To(ContainSubstring("fatal error: 1 error occurred:"))
+				Expect(out).To(ContainSubstring("1 error occurred:"))
 				s.Reboot()
 				By("Checking we booted from the installed cOS")
 				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))


### PR DESCRIPTION
This should fix the installer tests https://github.com/rancher-sandbox/cOS-toolkit/runs/4564804131?check_suite_focus=true 

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>