### PR TITLE
Add manual workflows for force pushing/publishing the latest artifacts

### DIFF
--- a/.github/workflows/publish_arm64.yaml
+++ b/.github/workflows/publish_arm64.yaml
@@ -1,0 +1,148 @@
+name: publish
+on:
+  workflow_dispatch:
+    inputs:
+      flavor:
+        required: false
+        default: green
+        type: choice
+        description: flavor to build and push
+        options:
+          - green
+          - blue
+          - orange
+      publish-args:
+        required: false
+        default: "--plugin luet-cosign"
+        type: string
+        description: Publish args to pass to publish-repo
+concurrency:
+  group: ci-publish-${{ github.event.inputs.flavor }}-arm64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      LUET_ARCH: arm64
+      FLAVOR: ${{ github.event.inputs.flavor }}
+      ARCH: arm64
+      PLUGINS: cleanup-images
+      FINAL_REPO: quay.io/costoolkit/releases-${{ github.event.inputs.flavor }}
+      DOWNLOAD_METADATA: false
+      PUSH_CACHE: true
+      REPO_CACHE: quay.io/costoolkit/build-${{ github.event.inputs.flavor }}-cache
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+      - name: Install CI plugins
+        run: |
+          sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Login to Quay Registry
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+      - name: Run make validate
+        run: |
+          sudo -E make validate
+      - name: Build packages 🔧
+        run: |
+          export PATH=$PATH:/usr/local/go/bin
+          mkdir build || true
+          pushd ./.github
+          go build -o build
+          popd
+          sudo -E ./.github/build
+          ls -liah $PWD/build
+          sudo chmod -R 777 $PWD/build
+      - name: Generate manifests
+        run: |
+          for f in build/*tar*; do
+            [ -e "$f" ] || continue
+            sudo -E luet mtree -- generate $f -o "$f.mtree"
+          done
+      - name: Append manifests to metadata
+        run: |
+          for f in build/*mtree; do
+            [ -e "$f" ] || continue
+            BASE_NAME=`basename -s .package.tar.zst.mtree $f`
+            sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
+          done
+      - name: Run make create-repo
+        run: |
+          sudo -E make create-repo
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-${{ github.event.inputs.flavor }}-arm64
+          path: build
+          if-no-files-found: error
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write  # undocumented OIDC support.
+    env:
+      FLAVOR: ${{ github.event.inputs.flavor }}
+      ARCH: arm64
+      FINAL_REPO: quay.io/costoolkit/releases-${{ github.event.inputs.flavor }}
+      DOWNLOAD_METADATA: true
+      DOWNLOAD_ALL: false
+      DOWNLOAD_ONLY: true
+      COSIGN_EXPERIMENTAL: 1 # use keyless signing
+      COSIGN_REPOSITORY: raccos/releases-${{ github.event.inputs.flavor }}
+      PUBLISH_ARGS: ${{ github.event.inputs.publish-args }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+      - name: Install CI plugins
+        run: |
+          sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-${{ github.event.inputs.flavor }}-arm64
+          path: build
+      - name: Grab metadata from remotes
+        run: |
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o build
+          popd
+          sudo -E ./.github/build
+          ls -liah $PWD/build
+      - name: Publish to DockerHub 🚀
+        run: |
+          sudo -E make publish-repo

--- a/.github/workflows/publish_x86_64.yaml
+++ b/.github/workflows/publish_x86_64.yaml
@@ -1,0 +1,148 @@
+name: publish
+on:
+  workflow_dispatch:
+    inputs:
+      flavor:
+        required: false
+        default: green
+        type: choice
+        description: flavor to build and push
+        options:
+          - green
+          - blue
+          - orange
+      publish-args:
+        required: false
+        default: "--plugin luet-cosign"
+        type: string
+        description: Publish args to pass to publish-repo
+concurrency:
+  group: ci-publish-${{ github.event.inputs.flavor }}-x86_64-${{ github.head_ref || github.ref }}-${{ github.repository }}
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      LUET_ARCH: x86_64
+      FLAVOR: ${{ github.event.inputs.flavor }}
+      ARCH: x86_64
+      PLUGINS: cleanup-images
+      FINAL_REPO: quay.io/costoolkit/releases-${{ github.event.inputs.flavor }}
+      DOWNLOAD_METADATA: false
+      PUSH_CACHE: true
+      REPO_CACHE: quay.io/costoolkit/build-${{ github.event.inputs.flavor }}-cache
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+      - name: Install CI plugins
+        run: |
+          sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Login to Quay Registry
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+      - name: Run make validate
+        run: |
+          sudo -E make validate
+      - name: Build packages 🔧
+        run: |
+          export PATH=$PATH:/usr/local/go/bin
+          mkdir build || true
+          pushd ./.github
+          go build -o build
+          popd
+          sudo -E ./.github/build
+          ls -liah $PWD/build
+          sudo chmod -R 777 $PWD/build
+      - name: Generate manifests
+        run: |
+          for f in build/*tar*; do
+            [ -e "$f" ] || continue
+            sudo -E luet mtree -- generate $f -o "$f.mtree"
+          done
+      - name: Append manifests to metadata
+        run: |
+          for f in build/*mtree; do
+            [ -e "$f" ] || continue
+            BASE_NAME=`basename -s .package.tar.zst.mtree $f`
+            sudo -E .github/append_manifests.py build/$BASE_NAME.metadata.yaml $f mtree
+          done
+      - name: Run make create-repo
+        run: |
+          sudo -E make create-repo
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-${{ github.event.inputs.flavor }}
+          path: build
+          if-no-files-found: error
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write  # undocumented OIDC support.
+    env:
+      FLAVOR: ${{ github.event.inputs.flavor }}
+      ARCH: x86_64
+      FINAL_REPO: quay.io/costoolkit/releases-${{ github.event.inputs.flavor }}
+      DOWNLOAD_METADATA: true
+      DOWNLOAD_ALL: false
+      DOWNLOAD_ONLY: true
+      COSIGN_EXPERIMENTAL: 1 # use keyless signing
+      COSIGN_REPOSITORY: raccos/releases-${{ github.event.inputs.flavor }}
+      PUBLISH_ARGS: ${{ github.event.inputs.publish-args }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Release space from worker
+        run: |
+          sudo rm -rf /usr/local/lib/android # will release about 10 GB if you don't need Android
+          sudo rm -rf /usr/share/dotnet # will release about 20GB if you don't need .NET
+      - name: Install CI plugins
+        run: |
+          sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+      - name: Download result for build
+        uses: actions/download-artifact@v2
+        with:
+          name: build-${{ github.event.inputs.flavor }}
+          path: build
+      - name: Grab metadata from remotes
+        run: |
+          export PATH=$PATH:/usr/local/go/bin
+          pushd ./.github
+          go build -o build
+          popd
+          sudo -E ./.github/build
+          ls -liah $PWD/build
+      - name: Publish to DockerHub 🚀
+        run: |
+          sudo -E make publish-repo


### PR DESCRIPTION
Adds 2 new workflows which are exclusively manually triggered, that can build and publish the latest artifacts, without running thorough the full pipeline, so they should be faster and allow us to retrigger the publish in case something happened during the final steps (quay failure, net issues, jobs cancelled, signatures failed, etc...)

It also allows to set the --force-push flag so artifacts can be republished and resigned.

Not sure about the current switches thougth, I think currently it should just push the packages under the packages dir? Im not clear on that part, should probably need a couple of manual runs to verify :D

Signed-off-by: Itxaka <igarcia@suse.com>