### PR TITLE
Bind mount initrd's tmpfs /tmp at initramfs stage

### DIFF
--- a/packages/cos-setup/cos-setup-initramfs.service
+++ b/packages/cos-setup/cos-setup-initramfs.service
@@ -7,7 +7,7 @@ Before=initrd.target
 
 [Service]
 RootDirectory=/sysroot
-BindPaths=/proc /sys /dev /run
+BindPaths=/proc /sys /dev /run /tmp
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/cos-setup initramfs

--- a/packages/cos-setup/definition.yaml
+++ b/packages/cos-setup/definition.yaml
@@ -1,6 +1,6 @@
 name: cos-setup
 category: system
-version: "0.6"
+version: "0.6.1"
 requires:
   - name: "elemental-cli"
     category: "toolchain"


### PR DESCRIPTION
This commit bind mounts /tmp from initrd environment to initramfs stage
environment (chroot on /sysroot). This enables the use of tools or
utilites in initramfs stage that relay on a writable /tmp.

Note this is an ephemeral filesystem that gets lost at switching root
stage, so right after initramfs stage.

Signed-off-by: David Cassany <dcassany@suse.com>