### PR TITLE
Set concurrency to 1 for publish artifacts

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -528,7 +528,7 @@
       {{{- end }}}
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-{{{ $flavor }}}
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       {{{ tmpl.Exec "prepare_build" }}}
       {{{ tmpl.Exec "prepare_worker" }}}

--- a/.github/workflows/build-master-blue-arm64.yaml
+++ b/.github/workflows/build-master-blue-arm64.yaml
@@ -117,7 +117,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -107,7 +107,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -424,7 +424,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -648,7 +648,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-master-orange-arm64.yaml
+++ b/.github/workflows/build-master-orange-arm64.yaml
@@ -119,7 +119,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -107,7 +107,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -117,7 +117,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -107,7 +107,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -424,7 +424,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -648,7 +648,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -119,7 +119,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -107,7 +107,7 @@ jobs:
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
-      PUBLISH_ARGS: "--plugin luet-cosign"
+      PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
Temporary set concurrency to one while pushing artifacts to avoid
hitting a concurrency issue on luet-cosign

Signed-off-by: Itxaka <igarcia@suse.com>