### PR TITLE
Use latest luet from script in the publish job

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -529,6 +529,7 @@
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-{{{ $flavor }}}
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       {{{ tmpl.Exec "prepare_build" }}}
       {{{ tmpl.Exec "prepare_worker" }}}

--- a/.github/workflows/build-master-blue-arm64.yaml
+++ b/.github/workflows/build-master-blue-arm64.yaml
@@ -118,6 +118,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -108,6 +108,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -425,6 +425,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -649,6 +649,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-master-orange-arm64.yaml
+++ b/.github/workflows/build-master-orange-arm64.yaml
@@ -120,6 +120,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -108,6 +108,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -118,6 +118,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -108,6 +108,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -425,6 +425,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -649,6 +649,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -120,6 +120,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -108,6 +108,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
+      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
github workers are symlinking /bin to /usr/bin/ which results in luet
identifying the luet-cosign plugin twice and calling it twice which
results in failure to sign the artifacts due both plugins accessing the
same files at the same time.

This makes it so luet is installed from the get_luet.sh script directly,
which would install the latest version, which has a fix to have unique
plugin names in the go-pluggable lib[0]

This commit is safe to revert once the luet and luet-cosign packages
have been published as there contain fixes for this issue.

[0] https://github.com/mudler/go-pluggable/commit/9263b05c562e6207999fd74bebf2cf36fa013e02

Signed-off-by: Itxaka <igarcia@suse.com>