### PR TITLE
Revert "Use latest luet from script in the publish job"

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -529,7 +529,6 @@
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-{{{ $flavor }}}
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       {{{ tmpl.Exec "prepare_build" }}}
       {{{ tmpl.Exec "prepare_worker" }}}

--- a/.github/workflows/build-master-blue-arm64.yaml
+++ b/.github/workflows/build-master-blue-arm64.yaml
@@ -118,7 +118,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -108,7 +108,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -425,7 +425,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -649,7 +649,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-master-orange-arm64.yaml
+++ b/.github/workflows/build-master-orange-arm64.yaml
@@ -120,7 +120,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -108,7 +108,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -118,7 +118,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -108,7 +108,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -425,7 +425,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -649,7 +649,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -120,7 +120,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -108,7 +108,6 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--concurrency 1 --plugin luet-cosign"
-      LUET_INSTALL_FROM_COS_REPO: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
Reverts rancher-sandbox/cOS-toolkit#1004

Revert once we have pushed the latest luet (0.21.2) to our repos