### PR TITLE
Point cosing to the newest fulcio url

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -529,6 +529,7 @@
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-{{{ $flavor }}}
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       {{{ tmpl.Exec "prepare_build" }}}
       {{{ tmpl.Exec "prepare_worker" }}}

--- a/.github/workflows/build-master-blue-arm64.yaml
+++ b/.github/workflows/build-master-blue-arm64.yaml
@@ -118,6 +118,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -108,6 +108,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -425,6 +425,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -649,6 +649,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-master-orange-arm64.yaml
+++ b/.github/workflows/build-master-orange-arm64.yaml
@@ -120,6 +120,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -108,6 +108,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -118,6 +118,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -108,6 +108,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -425,6 +425,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -649,6 +649,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -120,6 +120,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - run: |
           sudo rm -rf build || true

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -108,6 +108,7 @@ jobs:
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--plugin luet-cosign"
+      COSIGN_FULCIO_URL: "https://v1.fulcio.sigstore.dev"
     steps:
       - name: Install Go
         uses: actions/setup-go@v2


### PR DESCRIPTION
Using this means a breaking change:

```
BREAKING: This change means new cosign versions will generate signatures that
do not validate in older versions of cosign. This only applies to "keyless" experimental mode.
To opt out of this behavior, use: --fulcio-url=https://fulcio.sigstore.dev when signing payloads.
```

We should move to this mode asap, and now that we can resign and push everything it should not be a problem.

Signed-off-by: Itxaka <igarcia@suse.com>