### PR TITLE
Add helm

### DIFF
--- a/packages/utils/helm/build.yaml
+++ b/packages/utils/helm/build.yaml
@@ -1,0 +1,29 @@
+requires:
+  - name: "golang{{- if .Values.fips -}}-fips{{- end -}}"
+    category: "build"
+    version: ">=0"
+env:
+{{ template "golang_env" }}
+{{if .Values.fips}}
+- CGO_ENABLED=1
+{{ else }}
+- CGO_ENABLED=0
+- LDFLAGS="-s -w"
+{{ end }}
+
+prelude:
+  {{ template "golang_deps" .}}
+  {{ $opts:= dict "version" (printf "v%s" .Values.version) "org" ( index .Values.labels "github.owner" ) "repo" ( index .Values.labels "github.repo" ) }}
+  {{ template "golang_download_package" $opts}}
+steps:
+- |
+    PACKAGE_VERSION=${PACKAGE_VERSION%\-*} && \
+    cd /luetbuild/go/src/github.com/{{ ( index .Values.labels "github.owner" ) }}/{{.Values.name}} && \
+    make build && mv bin/{{.Values.name}} /usr/bin/{{.Values.name}}
+{{ if .Values.fips }}
+# Check that we build with fips
+- go tool nm /usr/bin/{{.Values.name}} | grep '_Cfunc__goboringcrypto_' 1> /dev/null
+{{ end }}
+
+includes:
+  - /usr/bin/{{.Values.name}}

--- a/packages/utils/helm/collection.yaml
+++ b/packages/utils/helm/collection.yaml
@@ -1,0 +1,15 @@
+packages:
+- &helm
+  name: "helm"
+  fips: false
+  category: "utils"
+  version: 3.7.1
+  description: "The Kubernetes Package Manager"
+  license: "Apache-2.0 License"
+  labels:
+    github.repo: "helm"
+    github.owner: "helm"
+# TODO: fips doesn't work yet
+#- !!merge <<: *helm
+#  category: "utils-fips"
+#  fips: true


### PR DESCRIPTION
As I was having a look over cosign usage in os2, helm is used, and maybe it's better to have it here so we can consume it directly the signed version with along all the other packages.

Update:
Scope is to secure this part of the supply chain https://github.com/rancher/os2/blob/085bc09768be96ee90b07d23cbe653c485d08fc0/Dockerfile#L7

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>