### PR TITLE
ci: stabilize flaky test and unify grub menu test

### DIFF
--- a/tests/upgrades-images-signed/upgrade_test.go
+++ b/tests/upgrades-images-signed/upgrade_test.go
@@ -52,9 +52,14 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 				By(fmt.Sprintf("upgrading to an old image: %s:cos-system-%s", s.GreenRepo, s.TestVersion))
 				out, err = s.Command(fmt.Sprintf("cos-upgrade --docker-image %s:cos-system-%s", s.GreenRepo, s.TestVersion))
 				Expect(err).ToNot(HaveOccurred())
-				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
-				Expect(out).Should(ContainSubstring("to /usr/local/.cos-upgrade/tmp/rootfs"))
-				Expect(out).Should(ContainSubstring("Upgrade target: active.img"))
+				Expect(out).Should(
+					And(
+						ContainSubstring("Upgrade done, now you might want to reboot"),
+						ContainSubstring("/usr/local/.cos-upgrade/tmp/rootfs"),
+						ContainSubstring("Upgrade target: active.img"),
+						ContainSubstring("Pulled"),
+					),
+				)
 
 				By("rebooting and checking out the version")
 				s.Reboot()

--- a/tests/upgrades-images-unsigned/upgrade_test.go
+++ b/tests/upgrades-images-unsigned/upgrade_test.go
@@ -30,6 +30,9 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 					s.GreenRepo = "quay.io/costoolkit/releases-green-arm64"
 				}
 
+				grubEntry, err := s.Command("grub2-editenv /run/initramfs/cos-state/grub_oem_env list | grep default_menu_entry= | sed 's/default_menu_entry=//'")
+				Expect(err).ToNot(HaveOccurred())
+
 				out, err := s.Command("source /etc/os-release && echo $VERSION")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
@@ -52,41 +55,6 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 				Expect(out).ToNot(Equal(version))
 				Expect(out).To(Equal(fmt.Sprintf("%s\n", s.TestVersion)))
 
-				By("rollbacking state")
-				s.Reset()
-
-				out, err = s.Command("source /etc/os-release && echo $VERSION")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).ToNot(Equal(""))
-				Expect(out).ToNot(Equal(fmt.Sprintf("%s\n", s.TestVersion)))
-				Expect(out).To(Equal(version))
-			})
-
-			// NOTE: once https://github.com/rancher-sandbox/cOS-toolkit/pull/959 is merged,
-			// the image used in the test below here is not relevant anymore and this test
-			// can be run aside of the upgrade-images-signed (which upgrades against master)
-			// What we are checking here is that the grub menu file is getting updated after
-			// running a cos-upgrade from the content of the target image.
-			It("changes grub menu entry during upgrades", func() {
-
-				if s.GetArch() == "aarch64" {
-					Skip("test valid only on amd64, until https://github.com/rancher-sandbox/cOS-toolkit/pull/959 is merged")
-				}
-
-				grubEntry, err := s.Command("grub2-editenv /run/initramfs/cos-state/grub_oem_env list | grep default_menu_entry= | sed 's/default_menu_entry=//'")
-				Expect(err).ToNot(HaveOccurred())
-
-				out, err := s.Command("cos-upgrade --no-cosign --no-verify --docker-image quay.io/costoolkit/test-images:grub_menu")
-				if err != nil {
-					fmt.Fprintf(GinkgoWriter, "Error from cos-upgrade: %v\n", err)
-				}
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).Should(ContainSubstring("Upgrade done, now you might want to reboot"))
-				Expect(out).Should(ContainSubstring("Upgrade target: active.img"))
-				By("rebooting")
-				s.Reboot()
-				Expect(s.BootFrom()).To(Equal(sut.Active))
-
 				By("checking grub menu entry changes", func() {
 					newGrubEntry, err := s.Command("grub2-editenv /run/initramfs/cos-state/grub_oem_env list | grep default_menu_entry= | sed 's/default_menu_entry=//'")
 					Expect(err).ToNot(HaveOccurred())
@@ -95,6 +63,12 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 
 				By("rollbacking state")
 				s.Reset()
+
+				out, err = s.Command("source /etc/os-release && echo $VERSION")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).ToNot(Equal(""))
+				Expect(out).ToNot(Equal(fmt.Sprintf("%s\n", s.TestVersion)))
+				Expect(out).To(Equal(version))
 			})
 		})
 	})


### PR DESCRIPTION
This commit stabilize a flaky test that got recently broken due to output changes in luet (see test failures here, for example https://github.com/rancher-sandbox/cOS-toolkit/runs/4643762803?check_suite_focus=true ) and also reworks the grub menu test globbing into one to save CI time.

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>