### PR TITLE
cos.sh: Add _COS_BOOTING_FROM_LIVE environment variable

### DIFF
--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -241,11 +241,15 @@ is_booting_from_squashfs() {
 }
 
 is_booting_from_live() {
+    if [ -n "$_COS_BOOTING_FROM_LIVE" ]; then
+        return 0
+    fi
+
     if cat /proc/cmdline | grep -q "CDLABEL"; then
         return 0
-    else
-        return 1
     fi
+
+    return 1
 }
 
 prepare_target() {


### PR DESCRIPTION
In the PXE boot scenario, there is no `CDLABEL` kernel parameter.
Adding a variable to indicate we are booting from live.

**More context**

- I'm trying to bump cOS packages in Harvester side to catch up. This ensure we have all new features and fixes, and prevent backports in the future.
- In Harvester, we handle the ISO download outside of the `cos` script, the variable `_COS_INSTALL_ISO_URL` is not set when invoking `cos` script and the script tries to find a channel and download OS images. We can only count on the `is_booting_from_live ` detection here. 
https://github.com/rancher-sandbox/cOS-toolkit/blob/86743bcb9eaeeafd99edec97315547886478b63f/packages/installer/cos.sh#L1410-L1411
- In situations like PXE boot, the `CDLABEL` parameter is not set, my proposal is to add a new environment variable `_COS_BOOTING_FROM_LIVE` to indicate a live boot. https://github.com/rancher-sandbox/cOS-toolkit/blob/86743bcb9eaeeafd99edec97315547886478b63f/packages/installer/cos.sh#L243-L249