### PR TITLE
Add --silence-hooks to installer to set yip loglevel to error

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.12
+    version: 0.7.13
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -302,6 +302,9 @@ installer_cleanup2()
     umount ${_STATEDIR}
     umount ${_RECOVERYDIR}
     [ -n "$_COS_INSTALL_ISO_URL" ] && umount ${_ISOMNT} || true
+    if [ "$_COS_SILENCE_HOOKS" = "true" ]; then
+        unset LOGLEVEL
+    fi
 }
 
 installer_cleanup()
@@ -1403,6 +1406,8 @@ install() {
             --help)
                 usage
                 ;;
+            --silence-hooks)
+                _COS_SILENCE_HOOKS=true
             *)
                 if [ "$#" -gt 2 ]; then
                     usage
@@ -1436,6 +1441,9 @@ install() {
     validate_device
 
     trap installer_cleanup exit
+    if [ "$_COS_SILENCE_HOOKS" = "true" ]; then
+        export LOGLEVEL=error
+    fi
 
     if [ "$_STRICT_MODE" = "true" ]; then
         cos-setup before-install

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -1408,6 +1408,7 @@ install() {
                 ;;
             --silence-hooks)
                 _COS_SILENCE_HOOKS=true
+                ;;
             *)
                 if [ "$#" -gt 2 ]; then
                     usage

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,6 +1,6 @@
 name: "installer"
 category: "utils"
-version: "0.26.1"
+version: "0.26.2"
 description: "Installer, Upgrade and reset utilities to manage cOS derivatives"
 requires:
 - name: "luet-mtree"


### PR DESCRIPTION
This should remove all the info messages we get and instead report only
errors

Fixes #1053 

Signed-off-by: Itxaka <igarcia@suse.com>