### PR TITLE
Workaround to build selinux packages

### DIFF
--- a/packages/selinux/build.yaml
+++ b/packages/selinux/build.yaml
@@ -1,7 +1,4 @@
-requires:
-- name: "base"
-  category: "distro"
-  version: ">=0"
+image: centos:7
 env:
 - GITHUB_ORG={{ ( index .Values.labels "github.owner" ) }}
 - GITHUB_REPO={{ ( index .Values.labels "github.repo" ) }}
@@ -9,8 +6,7 @@ env:
 {{ if .Values.distribution }}
 {{if eq .Values.distribution "opensuse" }}
 prelude:
-- zypper ar https://download.opensuse.org/repositories/security:/SELinux/openSUSE_Leap_15.3/security:SELinux.repo
-- zypper --gpg-auto-import-keys in -y --allow-vendor-change --allow-downgrade container-selinux -libsemanage1
+- yum -y install container-selinux curl
 
 steps:
 - |

--- a/packages/selinux/collection.yaml
+++ b/packages/selinux/collection.yaml
@@ -1,7 +1,7 @@
 packages:
   - name: "k3s"
     category: "selinux"
-    version: "0.5.1"
+    version: "0.5.1-1"
     labels:
       github.repo: "k3s-selinux"
       github.owner: "k3s-io"
@@ -14,7 +14,7 @@ packages:
         curl -s -L "https://github.com/{{.Values.labels.github.owner}}/{{.Values.labels.github.repo}}/releases/download/{{.Values.labels.github.tag}}/sha256sum-centos7-noarch.txt" | grep "noarch" | cut -d" " -f 1
   - name: "rancher"
     category: "selinux"
-    version: 0.2.1-4
+    version: 0.2.1-5
     labels:
       github.repo: "rancher-selinux"
       github.owner: "rancher"


### PR DESCRIPTION
Use centos as base in order to avoid the current issue with building selinux
policies in leap 15.3

Workaround for #960 

Signed-off-by: Itxaka <igarcia@suse.com>