### PR TITLE
Add framework images

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -959,6 +959,56 @@
 {{{- end}}}
 {{{end}}}
 
+
+{{{define "framework_images_steps"}}}
+{{{ $tag := . }}}
+      {{{ tmpl.Exec "prepare_worker" }}}
+      {{{ tmpl.Exec "make" "deps" }}}
+      {{{ tmpl.Exec "cos_version" }}}
+      - name: Prepare
+        id: prep
+        run: |
+          tag="{{{$tag}}}"
+          P_VERSION="${tag/+/-}"
+          # Set output parameters.
+          echo ::set-output name=tags::quay.io/costoolkit/framework:${P_VERSION}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./images/framework
+          file: ./images/framework/Dockerfile
+          platforms: "linux/arm64,linux/amd64"
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+{{{end}}}
+
+{{{define "framework_images"}}}
+{{{ $config := (datasource "config") }}}
+{{{ $flavor := "green" }}}
+{{{- if and $config.publishing_pipeline $config.publish_toolchain }}}
+  build-framework-tagged:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: publish-{{{$flavor}}}
+    steps:
+      {{{tmpl.Exec "framework_images_steps" "${{ env.COS_VERSION }}"}}}
+  build-framework-latest:
+    if: "!startsWith(github.ref, 'refs/tags/')"
+    runs-on: ubuntu-latest
+    needs: publish-{{{$flavor}}}
+    steps:
+      {{{tmpl.Exec "framework_images_steps" "latest"}}}
+{{{- end}}}
+{{{end}}}
+
 name: {{{$config.pipeline}}}-{{{ $config.flavor }}}-{{{ $config.arch }}}
 
 on: 
@@ -1032,6 +1082,7 @@ jobs:
 {{{- end }}}
 
 {{{tmpl.Exec "toolchain_images"}}}
+{{{tmpl.Exec "framework_images"}}}
 {{{- if $config.publish_cloud }}}
 {{{tmpl.Exec "publish_vanilla"}}}
 {{{- end }}}

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -954,3 +954,105 @@ jobs:
           export P_VERSION="${tag/+/-}"
           docker build -t quay.io/costoolkit/toolchain:$P_VERSION .
           docker push quay.io/costoolkit/toolchain:$P_VERSION
+  build-framework-tagged:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: publish-green
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Release space from worker ♻
+        if: always()
+        run: |
+          sudo rm -rf build || true
+          sudo rm -rf bin || true
+          sudo rm /usr/bin/luet || true
+          sudo rm -Rf /etc/luet/ || true
+          sudo rm -Rf /var/tmp/luet || true
+          sudo rm -Rf /var/luet || true
+          docker system prune -f -a --volumes || true
+      - name: Install CI plugins
+        run: |
+            sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+      - name: Prepare
+        id: prep
+        run: |
+          tag="${{ env.COS_VERSION }}"
+          P_VERSION="${tag/+/-}"
+          # Set output parameters.
+          echo ::set-output name=tags::quay.io/costoolkit/framework:${P_VERSION}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./images/framework
+          file: ./images/framework/Dockerfile
+          platforms: "linux/arm64,linux/amd64"
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+  build-framework-latest:
+    if: "!startsWith(github.ref, 'refs/tags/')"
+    runs-on: ubuntu-latest
+    needs: publish-green
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Release space from worker ♻
+        if: always()
+        run: |
+          sudo rm -rf build || true
+          sudo rm -rf bin || true
+          sudo rm /usr/bin/luet || true
+          sudo rm -Rf /etc/luet/ || true
+          sudo rm -Rf /var/tmp/luet || true
+          sudo rm -Rf /var/luet || true
+          docker system prune -f -a --volumes || true
+      - name: Install CI plugins
+        run: |
+            sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+      - name: Prepare
+        id: prep
+        run: |
+          tag="latest"
+          P_VERSION="${tag/+/-}"
+          # Set output parameters.
+          echo ::set-output name=tags::quay.io/costoolkit/framework:${P_VERSION}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./images/framework
+          file: ./images/framework/Dockerfile
+          platforms: "linux/arm64,linux/amd64"
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -1062,6 +1062,108 @@ jobs:
           export P_VERSION="${tag/+/-}"
           docker build -t quay.io/costoolkit/toolchain:$P_VERSION .
           docker push quay.io/costoolkit/toolchain:$P_VERSION
+  build-framework-tagged:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: publish-green
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Release space from worker ♻
+        if: always()
+        run: |
+          sudo rm -rf build || true
+          sudo rm -rf bin || true
+          sudo rm /usr/bin/luet || true
+          sudo rm -Rf /etc/luet/ || true
+          sudo rm -Rf /var/tmp/luet || true
+          sudo rm -Rf /var/luet || true
+          docker system prune -f -a --volumes || true
+      - name: Install CI plugins
+        run: |
+            sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+      - name: Prepare
+        id: prep
+        run: |
+          tag="${{ env.COS_VERSION }}"
+          P_VERSION="${tag/+/-}"
+          # Set output parameters.
+          echo ::set-output name=tags::quay.io/costoolkit/framework:${P_VERSION}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./images/framework
+          file: ./images/framework/Dockerfile
+          platforms: "linux/arm64,linux/amd64"
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+  build-framework-latest:
+    if: "!startsWith(github.ref, 'refs/tags/')"
+    runs-on: ubuntu-latest
+    needs: publish-green
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          git fetch --prune --unshallow
+      - name: Release space from worker ♻
+        if: always()
+        run: |
+          sudo rm -rf build || true
+          sudo rm -rf bin || true
+          sudo rm /usr/bin/luet || true
+          sudo rm -Rf /etc/luet/ || true
+          sudo rm -Rf /var/tmp/luet || true
+          sudo rm -Rf /var/luet || true
+          docker system prune -f -a --volumes || true
+      - name: Install CI plugins
+        run: |
+            sudo cp -rfv .github/plugins/* /usr/bin/
+      - name: Run make deps
+        run: |
+          sudo -E make deps
+      - name: Export cos version
+        run: |
+             source .github/helpers.sh
+             echo "COS_VERSION=$(cos_version)" >> $GITHUB_ENV
+      - name: Prepare
+        id: prep
+        run: |
+          tag="latest"
+          P_VERSION="${tag/+/-}"
+          # Set output parameters.
+          echo ::set-output name=tags::quay.io/costoolkit/framework:${P_VERSION}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./images/framework
+          file: ./images/framework/Dockerfile
+          platforms: "linux/arm64,linux/amd64"
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
   # We need only a single vanilla image for any OS
   # Vanilla image is always based on openSUSE
   publish-vanilla-ami:

--- a/images/framework/Dockerfile
+++ b/images/framework/Dockerfile
@@ -1,0 +1,16 @@
+FROM quay.io/luet/base:latest as builder
+
+COPY cos.yaml /etc/luet/luet.yaml
+
+ENV USER=root
+
+# We set the shell to /usr/bin/luet, as the base image doesn't have busybox, just luet
+# and certificates to be able to correctly handle TLS requests.
+SHELL ["/usr/bin/luet", "install", "-y", "--system-target", "/framework"]
+
+# Each package we want to install needs a new line here
+RUN meta/cos-core
+RUN meta/cos-verify
+
+FROM scratch
+COPY --from=builder /framework /

--- a/images/framework/cos.yaml
+++ b/images/framework/cos.yaml
@@ -1,0 +1,21 @@
+repositories:
+- &cos
+  name: "cos"
+  description: "cOS official"
+  # Repository type
+  type: "docker"
+  # Repository cache
+  cached: true
+  # Repository priority
+  priority: 1
+  # Repository architecture
+  arch: "amd64"
+  # Enable/disable Docker notary checks
+  # 
+  verify: false
+  urls:
+  - "quay.io/costoolkit/releases-green"
+- <<: *cos
+  arch: "arm64"
+  urls:
+  - "quay.io/costoolkit/releases-green-arm64"


### PR DESCRIPTION
Adds multiplatform framework images that can be directly consumed downstream in Dockerfiles with `COPY --from=<image> / /` to apply the framework without any `luet` setup/interaction.

Context: os2 create its own framework images, but that was already along the lines for the #108 features to bring static binaries for airgap. 

By shipping our own tagged framework images we relief machinery while building Dockerfiles, and offer also a way to get signed images with all the tools (cosign,etc included)

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>