### PR TITLE
Move elemental to git based tracking for versions

### DIFF
--- a/packages/toolchain/elemental-cli/build.yaml
+++ b/packages/toolchain/elemental-cli/build.yaml
@@ -13,7 +13,7 @@ env:
 
 prelude:
   {{ template "golang_deps" .}}
-  {{ $opts:= dict "version" (printf "v%s" .Values.version) "org" ( index .Values.labels "github.owner" ) "repo" ( index .Values.labels "github.repo" ) }}
+  {{ $opts:= dict "version" ( index .Values.labels "git.hash" ) "org" ( index .Values.labels "github.owner" ) "repo" ( index .Values.labels "github.repo" ) }}
   {{ template "golang_download_package" $opts}}
 steps:
   - |

--- a/packages/toolchain/elemental-cli/collection.yaml
+++ b/packages/toolchain/elemental-cli/collection.yaml
@@ -3,12 +3,14 @@ packages:
     name: "elemental-cli"
     category: "toolchain"
     bin_name: "elemental"
-    version: 0.0.11
+    version: 0.0.13-0
     fips: false
     labels:
       github.repo: "elemental-cli"
       github.owner: "rancher-sandbox"
       autobump.revdeps: "true"
+      git.hash: "d1d11006f556aacaddf82a403894a4445b7b696c"
+      autobump.strategy: "git_hash"
 # - !!merge <<: *elemental
 #   category: "toolchain-fips"
 #   fips: true


### PR DESCRIPTION
Instead of having to bump the version on elemental each time we need a
change, we can move to using a git_sha and keep our versions separated
from the elemental ones for now as we may need pathes and commits from
elemental and we dont want to keep generating releases.

Once elemental is stable we can change back to using the package version
as the elemental version again, thus for now we should only bump the
revision and keep the version number at 0.0.12 until then.

Signed-off-by: Itxaka <igarcia@suse.com>