### PR TITLE
installer: prepend set label to enhance compatibility

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.15
+    version: 0.7.16
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -526,7 +526,7 @@ do_mount()
     fi
 
     dd if=/dev/zero of=${_STATEDIR}/cOS/active.img bs=1M count=$_DEFAULT_IMAGE_SIZE
-    mkfs.ext2 ${_STATEDIR}/cOS/active.img -L ${ACTIVE_LABEL}
+    mkfs.ext2 -L ${ACTIVE_LABEL} ${_STATEDIR}/cOS/active.img
 
     if [ -z "$_${ACTIVE_LABEL}" ]; then
         sync

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,6 +1,6 @@
 name: "installer"
 category: "utils"
-version: "0.28.0"
+version: "0.28.1"
 description: "Installer, Upgrade and reset utilities to manage cOS derivatives"
 requires:
 - name: "luet-mtree"


### PR DESCRIPTION
Setting the option at the bottom prevents some versions of mkfs to work
correctly (e.g. alpine).

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>