### PR TITLE
installer: prepend set label to enhance compatibility

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.7.16
+    version: 0.7.17
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/installer/cos.sh
+++ b/packages/installer/cos.sh
@@ -1104,7 +1104,7 @@ copy_active() {
         _TARGET=$loop_dir
         # TODO: Size should be tweakable
         dd if=/dev/zero of=${_STATEDIR}/cOS/transition.img bs=1M count=$_DEFAULT_IMAGE_SIZE
-        mkfs.ext2 ${_STATEDIR}/cOS/transition.img -L ${PASSIVE_LABEL}
+        mkfs.ext2 -L ${PASSIVE_LABEL} ${_STATEDIR}/cOS/transition.img
         sync
         _LOOP=$(losetup --show -f ${_STATEDIR}/cOS/transition.img)
         mount -t ext2 $_LOOP $_TARGET

--- a/packages/installer/definition.yaml
+++ b/packages/installer/definition.yaml
@@ -1,6 +1,6 @@
 name: "installer"
 category: "utils"
-version: "0.28.1"
+version: "0.28.2"
 description: "Installer, Upgrade and reset utilities to manage cOS derivatives"
 requires:
 - name: "luet-mtree"


### PR DESCRIPTION
when preparing passive passive partition.

This is a follow-up of https://github.com/rancher-sandbox/cOS-toolkit/pull/1107 as went unnoticed at a first pass.

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>