### PR TITLE
Bump luet-cosing to republish

### DIFF
--- a/packages/meta/collection.yaml
+++ b/packages/meta/collection.yaml
@@ -81,10 +81,11 @@ packages:
         version: ">=0"
   - !!merge <<: *metabase
     name: "cos-verify"
+    version: 0.9-3
     requires:
       - category: toolchain
         name: cosign
         version: ">1.3.1" # signatures generated with >1.3.1 are not validated with versions <= 1.3.1
       - category: toolchain
         name: luet-cosign
-        version: ">=0"
+        version: ">0.0.10-3"

--- a/packages/toolchain/luet-cosign/definition.yaml
+++ b/packages/toolchain/luet-cosign/definition.yaml
@@ -1,6 +1,6 @@
 name: "luet-cosign"
 category: "toolchain"
-version: 0.0.10-3
+version: 0.0.10-4
 labels:
   github.repo: "luet-cosign"
   github.owner: "rancher-sandbox"


### PR DESCRIPTION
Package from orange arm64 seems to be the wrong architecture, bumping this should republish it in the proper arch

Reported by ludea in the rancher-users slack

Signed-off-by: Itxaka <igarcia@suse.com>