### PR TITLE
Split cloud config files

### DIFF
--- a/packages/cloud-config/build.yaml
+++ b/packages/cloud-config/build.yaml
@@ -7,23 +7,23 @@ requires:
   version: ">=0"
 
 steps:
-- mkdir -p /system/oem
-- cp -rfv oem/{{.Values.oem_file}} /system/oem
-- chmod -R 600 /system/oem
+- mkdir -p {{.Values.oem_dir}}
+- cp -rfv oem/{{.Values.oem_file}} {{.Values.oem_dir}}
+- chmod -R 600 {{.Values.oem_dir}}
 {{ if .Values.templated }}
-- cos-tmpl-render /system/oem/{{.Values.oem_file}}
+- cos-tmpl-render {{.Values.oem_dir}}/{{.Values.oem_file}}
 {{ end }}
 
 {{ if eq .Values.oem_file "02_upgrades.yaml" }}
 {{ if .Values.codename }}
-- sed -i 's/:FLAVOR:/{{.Values.codename}}/g' /system/oem/02_upgrades.yaml
+- sed -i 's/:FLAVOR:/{{.Values.codename}}/g' {{.Values.oem_dir}}/02_upgrades.yaml
 {{end}}
 {{ if .Values.arch }}
   {{if eq .Values.arch "x86_64"}}
-- sed -i 's/:ARCH://g' /system/oem/02_upgrades.yaml
+- sed -i 's/:ARCH://g' {{.Values.oem_dir}}/02_upgrades.yaml
   {{end}}
   {{if eq .Values.arch "aarch64"}}
-- sed -i 's/:ARCH:/-arm64/g' /system/oem/02_upgrades.yaml
+- sed -i 's/:ARCH:/-arm64/g' {{.Values.oem_dir}}/02_upgrades.yaml
   {{end}}
 {{end}}
 {{ end }}

--- a/packages/cloud-config/build.yaml
+++ b/packages/cloud-config/build.yaml
@@ -7,11 +7,14 @@ requires:
   version: ">=0"
 
 steps:
-- mkdir -p /system /oem
-- cp -rfv oem /system
+- mkdir -p /system/oem
+- cp -rfv oem/{{.Values.oem_file}} /system/oem
 - chmod -R 600 /system/oem
-- cos-tmpl-render /system/oem/00_rootfs.yaml.tmpl
-- cos-tmpl-render /system/oem/06_recovery.yaml.tmpl
+{{ if .Values.templated }}
+- cos-tmpl-render /system/oem/{{.Values.oem_file}}
+{{ end }}
+
+{{ if eq .Values.oem_file "02_upgrades.yaml" }}
 {{ if .Values.codename }}
 - sed -i 's/:FLAVOR:/{{.Values.codename}}/g' /system/oem/02_upgrades.yaml
 {{end}}
@@ -23,3 +26,4 @@ steps:
 - sed -i 's/:ARCH:/-arm64/g' /system/oem/02_upgrades.yaml
   {{end}}
 {{end}}
+{{ end }}

--- a/packages/cloud-config/collection.yaml
+++ b/packages/cloud-config/collection.yaml
@@ -1,0 +1,39 @@
+packages:
+- &base
+  name: defaults
+  category: cloud-config
+  version: "0.1"
+  oem_file: "01_defaults.yaml"
+  templated: false
+  requires:
+  - name: "cos-setup"
+    category: "system"
+    version: ">=0"
+- <<: *base
+  name: "rootfs"
+  oem_file: "00_rootfs.yaml.tmpl"
+  templated: true
+- <<: *base
+  name: "upgrades"
+  oem_file: "02_upgrades.yaml"
+  templated: false
+- <<: *base
+  name: "branding"
+  oem_file: "03_branding.yaml"
+  templated: false
+- <<: *base
+  name: "accounting"
+  oem_file: "04_accounting.yaml"
+  templated: false
+- <<: *base
+  name: "network"
+  oem_file: "05_network.yaml"
+  templated: false
+- <<: *base
+  name: "recovery"
+  oem_file: "06_recovery.yaml.tmpl"
+  templated: true
+- <<: *base
+  name: "live"
+  oem_file: "07_live.yaml"
+  templated: false

--- a/packages/cloud-config/collection.yaml
+++ b/packages/cloud-config/collection.yaml
@@ -1,18 +1,19 @@
 packages:
 - &base
-  name: defaults
+  name: "rootfs"
+  oem_file: "00_rootfs.yaml.tmpl"
+  oem_dir: "/system/oem"
+  templated: true
   category: cloud-config
   version: "0.1"
-  oem_file: "01_defaults.yaml"
-  templated: false
   requires:
   - name: "cos-setup"
     category: "system"
     version: ">=0"
 - <<: *base
-  name: "rootfs"
-  oem_file: "00_rootfs.yaml.tmpl"
-  templated: true
+  name: "defaults"
+  oem_file: "01_defaults.yaml"
+  templated: false
 - <<: *base
   name: "upgrades"
   oem_file: "02_upgrades.yaml"

--- a/packages/cloud-config/definition.yaml
+++ b/packages/cloud-config/definition.yaml
@@ -1,7 +1,0 @@
-name: cloud-config
-category: system
-version: 0.11-2
-requires:
-  - name: "cos-setup"
-    category: "system"
-    version: ">=0"

--- a/packages/cloud-config/oem/05_network.yaml
+++ b/packages/cloud-config/oem/05_network.yaml
@@ -9,11 +9,6 @@ name: "Default network configuration"
 stages:
    initramfs:
      - name: "Setup network"
-       dns:
-         path: /etc/resolv.conf
-         nameservers:
-         - 8.8.8.8
-         - 1.1.1.1
        files:
        - path: /etc/sysconfig/network/ifcfg-eth0
          content: |

--- a/packages/cos/build.yaml
+++ b/packages/cos/build.yaml
@@ -9,9 +9,6 @@ requires:
 - name: "installer"
   category: "utils"
   version: ">0.28.0"
-- name: "cloud-config"
-  category: "system"
-  version: ">=0"
 - name: "immutable-rootfs"
   category: "system"
   version: ">0.3-1"
@@ -56,6 +53,24 @@ requires:
 - name: "luet-cosign"
   category: "toolchain"
   version: ">=0"
+- &cc
+  name: "rootfs"
+  category: cloud-config
+  version: ">=0"
+- <<: *cc
+  name: "defaults"
+- <<: *cc
+  name: "upgrades"
+- <<: *cc
+  name: "branding"
+- <<: *cc
+  name: "accounting"
+- <<: *cc
+  name: "network"
+- <<: *cc
+  name: "recovery"
+- <<: *cc
+  name: "live"
 
 # Templated package https://luet-lab.github.io/docs/docs/concepts/packages/templates/
 steps:

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.8.2-10
+    version: "0.8.3"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -10,12 +10,10 @@ packages:
   - !!merge <<: *cos
     name: "cos-container"
     description: "cOS container image, used to build cOS derivatives from scratch"
-    version: 0.8.2-10
   - !!merge <<: *cos
     category: "recovery"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
-    version: 0.8.2-10
   - !!merge <<: *cos
     name: "cos-img"
     category: "recovery"

--- a/packages/meta/collection.yaml
+++ b/packages/meta/collection.yaml
@@ -87,3 +87,27 @@ packages:
       - category: toolchain
         name: luet-cosign
         version: ">0.0.10-3"
+  # Provides backward compatibility
+  - !!merge <<: *metabase
+    category: "system"
+    name: "cloud-config"
+    description: "Meta package for pulling all cloud configs"
+    requires:
+    - &cc
+      name: defaults
+      category: cloud-config
+      version: ">=0"
+    - <<: *cc
+      name: "rootfs"
+    - <<: *cc
+      name: "upgrades"
+    - <<: *cc
+      name: "branding"
+    - <<: *cc
+      name: "accounting"
+    - <<: *cc
+      name: "network"
+    - <<: *cc
+      name: "recovery"
+    - <<: *cc
+      name: "live"


### PR DESCRIPTION
This PR creates single packages for each cloud config file so they can be installed singularly. It also moves the current `system/cloud-config` as a meta package, that pulls down all the cloud config files