### PR TITLE
Add service that allows us to control the cdrom eject

### DIFF
--- a/packages/cos-setup/build.yaml
+++ b/packages/cos-setup/build.yaml
@@ -14,3 +14,4 @@ steps:
 - systemctl enable cos-setup-fs.service
 - systemctl enable cos-setup-boot.service
 - systemctl enable cos-setup-network.service
+- systemctl enable cos-setup-ejectcd.service

--- a/packages/cos-setup/cos-setup-ejectcd.service
+++ b/packages/cos-setup/cos-setup-ejectcd.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Eject the DVD
+After=shutdown.target reboot.target
+DefaultDependencies=no
+# check the ejectcd file was created
+ConditionPathExists=/run/cos/ejectcd
+# also check if we booted from CD
+# probably both work, but if we change the cdlabel then the first fails
+#ConditionKernelCommandLine=root=live:CDLABEL=COS_LIVE
+ConditionKernelCommandLine=cdroot
+
+[Service]
+Type=oneshot
+ExecStart=-/usr/bin/eject -r
+StandardInput=tty-force
+StandardOutput=inherit
+StandardError=inherit
+
+[Install]
+WantedBy=shutdown.target

--- a/packages/cos-setup/definition.yaml
+++ b/packages/cos-setup/definition.yaml
@@ -1,6 +1,6 @@
 name: cos-setup
 category: system
-version: 0.6.2
+version: 0.6.3
 requires:
   - name: "elemental-cli"
     category: "toolchain"

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.8.7-6
+    version: 0.8.8
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -10,12 +10,10 @@ packages:
   - !!merge <<: *cos
     name: "cos-container"
     description: "cOS container image, used to build cOS derivatives from scratch"
-    version: 0.8.7-7
   - !!merge <<: *cos
     category: "recovery"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
-    version: 0.8.7-6
   - !!merge <<: *cos
     name: "cos-img"
     category: "recovery"


### PR DESCRIPTION
This creates a service file that we can control by setting
/run/cos/ejectcd and that will also check to see if we booted with the
cdboot stanza in the cmdline in order to trigger.

By default is set to run after shutdown and reboot if those two
conditions met.

This allows us and derivatives to control ejecting the cd at the end of
an install for example

This is part of https://github.com/rancher-sandbox/os2/issues/31 and I consider that it works much better if we support it trougth the base cOS, instead of patching it in the middle, which we can do, but its nice to have also for our testing.

Signed-off-by: Itxaka <igarcia@suse.com>