### PR TITLE
Unflaky ci tests

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -72,6 +72,7 @@
   {{{ $target := . }}}
       - name: Run make {{{ $target }}}
         run: |
+          {{{ if eq $target "deps" }}}export DOCKER_INSTALL=true{{{end}}}
           sudo -E make {{{ $target }}}
   {{{ if eq $target "deps" }}}
   {{{- if ne $config.luet_override "" }}}

--- a/.github/config/pr.yaml
+++ b/.github/config/pr.yaml
@@ -34,6 +34,7 @@ flavors:
             paths:
               - 'conf/**'
               - 'packages/**'
+              - 'tests/**'
               - 'make/**'
               - '.github/**'
               - 'Makefile'

--- a/.github/workflows/build-examples-green-x86_64.yaml
+++ b/.github/workflows/build-examples-green-x86_64.yaml
@@ -41,6 +41,7 @@ jobs:
             go-version: '^1.16'
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Build cos-official 🔧
         shell: 'script -q -e -c "bash {0}"'
@@ -81,6 +82,7 @@ jobs:
             go-version: '^1.16'
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Build scratch 🔧
         shell: 'script -q -e -c "bash {0}"'
@@ -121,6 +123,7 @@ jobs:
             go-version: '^1.16'
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Build standard 🔧
         shell: 'script -q -e -c "bash {0}"'

--- a/.github/workflows/build-master-blue-arm64.yaml
+++ b/.github/workflows/build-master-blue-arm64.yaml
@@ -61,6 +61,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -115,6 +116,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for blue
         run: |
@@ -194,6 +196,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -59,6 +59,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -113,6 +114,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for blue
         run: |
@@ -192,6 +194,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -61,6 +61,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -144,6 +145,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -309,6 +311,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -449,6 +452,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for green
         run: |
@@ -527,6 +531,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -581,6 +586,7 @@ jobs:
           path: build
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -59,6 +59,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -142,6 +143,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -420,6 +422,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -673,6 +676,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for green
         run: |
@@ -751,6 +755,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -805,6 +810,7 @@ jobs:
           path: build
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -923,6 +929,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -960,6 +967,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -997,6 +1005,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -1051,6 +1060,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |

--- a/.github/workflows/build-master-orange-arm64.yaml
+++ b/.github/workflows/build-master-orange-arm64.yaml
@@ -63,6 +63,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -117,6 +118,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for orange
         run: |
@@ -196,6 +198,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -59,6 +59,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -113,6 +114,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for orange
         run: |
@@ -192,6 +194,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-nightly-blue-x86_64.yaml
+++ b/.github/workflows/build-nightly-blue-x86_64.yaml
@@ -61,6 +61,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -113,6 +114,7 @@ jobs:
           path: build
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |

--- a/.github/workflows/build-nightly-green-x86_64.yaml
+++ b/.github/workflows/build-nightly-green-x86_64.yaml
@@ -61,6 +61,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -119,6 +120,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -391,6 +393,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -661,6 +664,7 @@ jobs:
           path: build
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |

--- a/.github/workflows/build-nightly-orange-x86_64.yaml
+++ b/.github/workflows/build-nightly-orange-x86_64.yaml
@@ -61,6 +61,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -113,6 +114,7 @@ jobs:
           path: build
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |

--- a/.github/workflows/build-pr-blue-arm64.yaml
+++ b/.github/workflows/build-pr-blue-arm64.yaml
@@ -60,6 +60,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |

--- a/.github/workflows/build-pr-blue-x86_64.yaml
+++ b/.github/workflows/build-pr-blue-x86_64.yaml
@@ -4,6 +4,7 @@ on:
    paths:
      - conf/**
      - packages/**
+     - tests/**
      - make/**
      - .github/**
      - Makefile

--- a/.github/workflows/build-pr-blue-x86_64.yaml
+++ b/.github/workflows/build-pr-blue-x86_64.yaml
@@ -63,6 +63,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |

--- a/.github/workflows/build-pr-green-arm64.yaml
+++ b/.github/workflows/build-pr-green-arm64.yaml
@@ -60,6 +60,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -130,6 +131,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -295,6 +297,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -458,6 +461,7 @@ jobs:
           path: build
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |

--- a/.github/workflows/build-pr-green-x86_64.yaml
+++ b/.github/workflows/build-pr-green-x86_64.yaml
@@ -4,6 +4,7 @@ on:
    paths:
      - conf/**
      - packages/**
+     - tests/**
      - make/**
      - .github/**
      - Makefile

--- a/.github/workflows/build-pr-green-x86_64.yaml
+++ b/.github/workflows/build-pr-green-x86_64.yaml
@@ -63,6 +63,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -133,6 +134,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -411,6 +413,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -687,6 +690,7 @@ jobs:
           path: build
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |

--- a/.github/workflows/build-pr-orange-arm64.yaml
+++ b/.github/workflows/build-pr-orange-arm64.yaml
@@ -62,6 +62,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |

--- a/.github/workflows/build-pr-orange-x86_64.yaml
+++ b/.github/workflows/build-pr-orange-x86_64.yaml
@@ -4,6 +4,7 @@ on:
    paths:
      - conf/**
      - packages/**
+     - tests/**
      - make/**
      - .github/**
      - Makefile

--- a/.github/workflows/build-pr-orange-x86_64.yaml
+++ b/.github/workflows/build-pr-orange-x86_64.yaml
@@ -63,6 +63,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -61,6 +61,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -115,6 +116,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for blue
         run: |
@@ -194,6 +196,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -59,6 +59,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -113,6 +114,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for blue
         run: |
@@ -192,6 +194,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -61,6 +61,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -144,6 +145,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -309,6 +311,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -449,6 +452,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for green
         run: |
@@ -527,6 +531,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -569,6 +574,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -652,6 +658,7 @@ jobs:
           path: build
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -59,6 +59,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -142,6 +143,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -420,6 +422,7 @@ jobs:
           sudo apt-get install -y xorriso squashfs-tools mtools
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Tweak manifest and drop squashfs recovery
         run: |
@@ -673,6 +676,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for green
         run: |
@@ -751,6 +755,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2
@@ -795,6 +800,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -892,6 +898,7 @@ jobs:
           path: build
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -1000,6 +1007,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Public IP
         id: ip
@@ -1037,6 +1045,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -1074,6 +1083,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -1111,6 +1121,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -1165,6 +1176,7 @@ jobs:
             sudo cp -rfv .github/plugins/* /usr/bin/
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |
@@ -1204,6 +1216,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Export cos version
         run: |

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -63,6 +63,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -117,6 +118,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for orange
         run: |
@@ -196,6 +198,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -59,6 +59,7 @@ jobs:
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Run make validate
         run: |
@@ -113,6 +114,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Generate link for orange
         run: |
@@ -192,6 +194,7 @@ jobs:
             password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run make deps
         run: |
+          export DOCKER_INSTALL=true
           sudo -E make deps
       - name: Download result for build
         uses: actions/download-artifact@v2

--- a/tests/installer/installer_efi_test.go
+++ b/tests/installer/installer_efi_test.go
@@ -1,0 +1,234 @@
+package cos_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/cOS/tests/sut"
+)
+
+var _ = Describe("cOS Installer EFI tests", func() {
+	var s *sut.SUT
+
+	BeforeEach(func() {
+		s = sut.NewSUT()
+		s.EventuallyConnects()
+	})
+
+	Context("Using efi", func() {
+		// EFI variant tests is not able to set the boot order and there is no plan to let the user do so according to virtualbox
+		// So we need to manually eject/insert the cd to force the boot order. CD inserted -> boot from cd, CD empty -> boot from disk
+		BeforeEach(func() {
+			// Assert we are booting from CD before running the tests
+			By("Making sure we booted from CD")
+			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.LiveCD))
+			out, err := s.Command("grep /dev/sr /etc/mtab")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("iso9660"))
+			out, err = s.Command("df -h /")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(ContainSubstring("LiveOS_rootfs"))
+			s.EmptyDisk("/dev/sda")
+			_, _ = s.Command("sync")
+		})
+		AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				s.GatherAllLogs()
+			}
+		})
+		// Commented because there is only a single active test, hence restoring CD before
+		// after rebooting is not needed.
+		/*AfterEach(func() {
+			if CurrentGinkgoTestDescription().Failed {
+				s.GatherAllLogs()
+			}
+			// Store COS iso path
+			s.SetCOSCDLocation()
+			// Set Cos CD in the drive
+			s.RestoreCOSCD()
+			By("Reboot to make sure we boot from CD")
+			s.Reboot()
+		})*/
+		Context("partition layout tests", func() {
+			Context("with partition layout", func() {
+				It("Forcing GPT", func() {
+					err := s.SendFile("../assets/layout.yaml", "/usr/local/layout.yaml", "0770")
+					By("Running the elemental install with a layout file")
+					Expect(err).To(BeNil())
+					out, err := s.Command("elemental install --force-gpt --partition-layout /usr/local/layout.yaml /dev/sda")
+					fmt.Printf(out)
+					Expect(err).To(BeNil())
+					Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
+					Expect(out).To(ContainSubstring("Installing GRUB.."))
+					Expect(out).To(ContainSubstring("Copying COS_PASSIVE image..."))
+					Expect(out).To(ContainSubstring("Mounting disk partitions"))
+					Expect(out).To(ContainSubstring("Partitioning device..."))
+
+					// This section of the test is flaky in our CI w/EFI. Commenting it out for the time being
+					PContext("reboots successfully into installed system", func() {
+						// Remove iso so we boot directly from the disk
+						s.EjectCOSCD()
+						// Reboot so we boot into the just installed cos
+						s.Reboot()
+						By("Checking we booted from the installed cOS")
+						ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
+						// check partition values
+						// Values have to match the yaml under ../assets/layout.yaml
+						// That is the file that the installer uses so partitions should match those values
+						disk := s.GetDiskLayout("/dev/sda")
+
+						for _, part := range []sut.PartitionEntry{
+							{
+								Label:  "COS_STATE",
+								Size:   8192,
+								FsType: sut.Ext4,
+							},
+							{
+								Label:  "COS_OEM",
+								Size:   10,
+								FsType: sut.Ext4,
+							},
+							{
+								Label:  "COS_RECOVERY",
+								Size:   4000,
+								FsType: sut.Ext2,
+							},
+							{
+								Label:  "COS_PERSISTENT",
+								Size:   100,
+								FsType: sut.Ext2,
+							},
+						} {
+							CheckPartitionValues(disk, part)
+						}
+					})
+				})
+				// Marked as pending to reduce the number of efi tests. VBox efi support is
+				// not good enough to run extensive tests
+				PIt("Not forcing GPT", func() {
+					err := s.SendFile("../assets/layout.yaml", "/usr/local/layout.yaml", "0770")
+					By("Running the elemental install with a layout file")
+					Expect(err).To(BeNil())
+					out, err := s.Command("elemental install --partition-layout /usr/local/layout.yaml /dev/sda")
+					Expect(err).To(BeNil())
+					Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
+					Expect(out).To(ContainSubstring("Installing GRUB.."))
+					Expect(out).To(ContainSubstring("Copying COS_PASSIVE image..."))
+					Expect(out).To(ContainSubstring("Mounting disk partitions"))
+					Expect(out).To(ContainSubstring("Partitioning device..."))
+					// Remove iso so we boot directly from the disk
+					s.EjectCOSCD()
+					// Reboot so we boot into the just installed cos
+					s.Reboot()
+					By("Checking we booted from the installed cOS")
+					ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
+					// check partition values
+					// Values have to match the yaml under ../assets/layout.yaml
+					// That is the file that the installer uses so partitions should match those values
+					disk := s.GetDiskLayout("/dev/sda")
+
+					for _, part := range []sut.PartitionEntry{
+						{
+							Label:  "COS_STATE",
+							Size:   8192,
+							FsType: sut.Ext4,
+						},
+						{
+							Label:  "COS_OEM",
+							Size:   10,
+							FsType: sut.Ext4,
+						},
+						{
+							Label:  "COS_RECOVERY",
+							Size:   4000,
+							FsType: sut.Ext2,
+						},
+						{
+							Label:  "COS_PERSISTENT",
+							Size:   100,
+							FsType: sut.Ext2,
+						},
+					} {
+						CheckPartitionValues(disk, part)
+					}
+				})
+			})
+		})
+		// Marked as pending to reduce the number of efi tests. VBox efi support is
+		// not good enough to run extensive tests
+		PContext("install source tests", func() {
+			It("from iso", func() {
+				By("Running the elemental install")
+				out, err := s.Command("elemental install /dev/sda")
+				Expect(err).To(BeNil())
+				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
+				Expect(out).To(ContainSubstring("Installing GRUB.."))
+				Expect(out).To(ContainSubstring("Copying COS_PASSIVE image"))
+				Expect(out).To(ContainSubstring("Copying COS_SYSTEM image"))
+				Expect(out).To(ContainSubstring("Mounting disk partitions"))
+				Expect(out).To(ContainSubstring("Partitioning device..."))
+				// Remove iso so we boot directly from the disk
+				s.EjectCOSCD()
+				// Reboot so we boot into the just installed cos
+				s.Reboot()
+				By("Checking we booted from the installed cOS")
+				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
+			})
+			PIt("from url", func() {})
+			It("from docker image", func() {
+				By("Running the elemental install")
+				out, err := s.Command(fmt.Sprintf("elemental install --docker-image  %s:cos-system-%s /dev/sda", s.GreenRepo, s.TestVersion))
+				Expect(err).To(BeNil())
+				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
+				Expect(out).To(ContainSubstring("Installing GRUB.."))
+				Expect(out).To(ContainSubstring("Copying COS_PASSIVE image..."))
+				Expect(out).To(ContainSubstring("Mounting disk partitions"))
+				Expect(out).To(ContainSubstring("Partitioning device..."))
+				s.EjectCOSCD()
+				// Reboot so we boot into the just installed cos
+				s.Reboot()
+				By("Checking we booted from the installed cOS")
+				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
+				Expect(s.GetOSRelease("VERSION")).To(Equal(s.TestVersion))
+			})
+		})
+		// Marked as pending to reduce the number of efi tests. VBox efi support is
+		// not good enough to run extensive tests
+		PContext("efi/gpt tests", func() {
+			It("forces gpt", func() {
+				By("Running the installer")
+				out, err := s.Command("elemental install --force-gpt /dev/sda")
+				Expect(err).To(BeNil())
+				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
+				Expect(out).To(ContainSubstring("Installing GRUB.."))
+				Expect(out).To(ContainSubstring("Copying COS_PASSIVE image..."))
+				Expect(out).To(ContainSubstring("Mounting disk partitions"))
+				Expect(out).To(ContainSubstring("Partitioning device..."))
+				// Remove iso so we boot directly from the disk
+				s.EjectCOSCD()
+				// Reboot so we boot into the just installed cos
+				s.Reboot()
+				By("Checking we booted from the installed cOS")
+				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
+			})
+			It("forces efi", func() {
+				By("Running the installer")
+				out, err := s.Command("elemental install --force-efi /dev/sda")
+				Expect(err).To(BeNil())
+				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
+				Expect(out).To(ContainSubstring("Installing GRUB.."))
+				Expect(out).To(ContainSubstring("Copying COS_PASSIVE image..."))
+				Expect(out).To(ContainSubstring("Mounting disk partitions"))
+				Expect(out).To(ContainSubstring("Partitioning device..."))
+				// Remove iso so we boot directly from the disk
+				s.EjectCOSCD()
+				// Reboot so we boot into the just installed cos
+				s.Reboot()
+				// We are on an efi system, should boot from active
+				By("Checking we booted from Active partition")
+				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
+			})
+		})
+	})
+})

--- a/tests/installer/installer_test.go
+++ b/tests/installer/installer_test.go
@@ -8,13 +8,6 @@ import (
 	"github.com/rancher-sandbox/cOS/tests/sut"
 )
 
-func CheckPartitionValues(diskLayout sut.DiskLayout, entry sut.PartitionEntry) {
-	part, err := diskLayout.GetPartition(entry.Label)
-	Expect(err).To(BeNil())
-	Expect((part.Size / 1024) / 1024).To(Equal(entry.Size))
-	Expect(part.FsType).To(Equal(entry.FsType))
-}
-
 var _ = Describe("cOS Installer tests", func() {
 	var s *sut.SUT
 
@@ -43,11 +36,13 @@ var _ = Describe("cOS Installer tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(ContainSubstring("LiveOS_rootfs"))
 		})
+
 		AfterEach(func() {
 			if CurrentGinkgoTestDescription().Failed {
 				s.GatherAllLogs()
 			}
 		})
+
 		Context("install source tests", func() {
 			It("from iso", func() {
 				By("Running the elemental install")
@@ -82,6 +77,7 @@ var _ = Describe("cOS Installer tests", func() {
 				Expect(s.GetOSRelease("VERSION")).To(Equal(s.TestVersion))
 			})
 		})
+
 		Context("partition layout tests", func() {
 			Context("with partition layout", func() {
 				It("Forcing GPT", func() {
@@ -130,6 +126,7 @@ var _ = Describe("cOS Installer tests", func() {
 						CheckPartitionValues(disk, part)
 					}
 				})
+
 				It("No GPT", func() {
 					err := s.SendFile("../assets/layout.yaml", "/usr/local/layout.yaml", "0770")
 					By("Running the elemental install with a layout file")
@@ -178,6 +175,7 @@ var _ = Describe("cOS Installer tests", func() {
 				})
 			})
 		})
+
 		Context("efi/gpt tests", func() {
 			It("forces gpt", func() {
 				By("Running the installer")
@@ -193,6 +191,7 @@ var _ = Describe("cOS Installer tests", func() {
 				By("Checking we booted from the installed cOS")
 				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
 			})
+
 			It("forces efi", func() {
 				By("Running the installer")
 				out, err := s.Command("elemental install --force-efi /dev/sda")
@@ -232,222 +231,6 @@ var _ = Describe("cOS Installer tests", func() {
 				out, err = s.Command("hostname")
 				Expect(err).To(BeNil())
 				Expect(out).To(ContainSubstring("testhostname"))
-
-			})
-		})
-	})
-	Context("Using efi", func() {
-		// EFI variant tests is not able to set the boot order and there is no plan to let the user do so according to virtualbox
-		// So we need to manually eject/insert the cd to force the boot order. CD inserted -> boot from cd, CD empty -> boot from disk
-		BeforeEach(func() {
-			// Assert we are booting from CD before running the tests
-			By("Making sure we booted from CD")
-			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.LiveCD))
-			out, err := s.Command("grep /dev/sr /etc/mtab")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring("iso9660"))
-			out, err = s.Command("df -h /")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(out).To(ContainSubstring("LiveOS_rootfs"))
-			s.EmptyDisk("/dev/sda")
-			_, _ = s.Command("sync")
-		})
-		AfterEach(func() {
-			if CurrentGinkgoTestDescription().Failed {
-				s.GatherAllLogs()
-			}
-		})
-		// Commented because there is only a single active test, hence restoring CD before
-		// after rebooting is not needed.
-		/*AfterEach(func() {
-			if CurrentGinkgoTestDescription().Failed {
-				s.GatherAllLogs()
-			}
-			// Store COS iso path
-			s.SetCOSCDLocation()
-			// Set Cos CD in the drive
-			s.RestoreCOSCD()
-			By("Reboot to make sure we boot from CD")
-			s.Reboot()
-		})*/
-		Context("partition layout tests", func() {
-			Context("with partition layout", func() {
-				It("Forcing GPT", func() {
-					err := s.SendFile("../assets/layout.yaml", "/usr/local/layout.yaml", "0770")
-					By("Running the elemental install with a layout file")
-					Expect(err).To(BeNil())
-					out, err := s.Command("elemental install --force-gpt --partition-layout /usr/local/layout.yaml /dev/sda")
-					fmt.Printf(out)
-					Expect(err).To(BeNil())
-					Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
-					Expect(out).To(ContainSubstring("Installing GRUB.."))
-					Expect(out).To(ContainSubstring("Copying COS_PASSIVE image..."))
-					Expect(out).To(ContainSubstring("Mounting disk partitions"))
-					Expect(out).To(ContainSubstring("Partitioning device..."))
-
-					// This section of the test is flaky in our CI w/EFI. Commenting it out for the time being
-					PIt("reboots successfully into installed system", func() {
-						// Remove iso so we boot directly from the disk
-						s.EjectCOSCD()
-						// Reboot so we boot into the just installed cos
-						s.Reboot()
-						By("Checking we booted from the installed cOS")
-						ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
-						// check partition values
-						// Values have to match the yaml under ../assets/layout.yaml
-						// That is the file that the installer uses so partitions should match those values
-						disk := s.GetDiskLayout("/dev/sda")
-
-						for _, part := range []sut.PartitionEntry{
-							{
-								Label:  "COS_STATE",
-								Size:   8192,
-								FsType: sut.Ext4,
-							},
-							{
-								Label:  "COS_OEM",
-								Size:   10,
-								FsType: sut.Ext4,
-							},
-							{
-								Label:  "COS_RECOVERY",
-								Size:   4000,
-								FsType: sut.Ext2,
-							},
-							{
-								Label:  "COS_PERSISTENT",
-								Size:   100,
-								FsType: sut.Ext2,
-							},
-						} {
-							CheckPartitionValues(disk, part)
-						}
-					})
-				})
-				// Marked as pending to reduce the number of efi tests. VBox efi support is
-				// not good enough to run extensive tests
-				PIt("Not forcing GPT", func() {
-					err := s.SendFile("../assets/layout.yaml", "/usr/local/layout.yaml", "0770")
-					By("Running the elemental install with a layout file")
-					Expect(err).To(BeNil())
-					out, err := s.Command("elemental install --partition-layout /usr/local/layout.yaml /dev/sda")
-					Expect(err).To(BeNil())
-					Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
-					Expect(out).To(ContainSubstring("Installing GRUB.."))
-					Expect(out).To(ContainSubstring("Copying COS_PASSIVE image..."))
-					Expect(out).To(ContainSubstring("Mounting disk partitions"))
-					Expect(out).To(ContainSubstring("Partitioning device..."))
-					// Remove iso so we boot directly from the disk
-					s.EjectCOSCD()
-					// Reboot so we boot into the just installed cos
-					s.Reboot()
-					By("Checking we booted from the installed cOS")
-					ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
-					// check partition values
-					// Values have to match the yaml under ../assets/layout.yaml
-					// That is the file that the installer uses so partitions should match those values
-					disk := s.GetDiskLayout("/dev/sda")
-
-					for _, part := range []sut.PartitionEntry{
-						{
-							Label:  "COS_STATE",
-							Size:   8192,
-							FsType: sut.Ext4,
-						},
-						{
-							Label:  "COS_OEM",
-							Size:   10,
-							FsType: sut.Ext4,
-						},
-						{
-							Label:  "COS_RECOVERY",
-							Size:   4000,
-							FsType: sut.Ext2,
-						},
-						{
-							Label:  "COS_PERSISTENT",
-							Size:   100,
-							FsType: sut.Ext2,
-						},
-					} {
-						CheckPartitionValues(disk, part)
-					}
-				})
-			})
-		})
-		// Marked as pending to reduce the number of efi tests. VBox efi support is
-		// not good enough to run extensive tests
-		PContext("install source tests", func() {
-			It("from iso", func() {
-				By("Running the elemental install")
-				out, err := s.Command("elemental install /dev/sda")
-				Expect(err).To(BeNil())
-				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
-				Expect(out).To(ContainSubstring("Installing GRUB.."))
-				Expect(out).To(ContainSubstring("Copying COS_PASSIVE image"))
-				Expect(out).To(ContainSubstring("Copying COS_SYSTEM image"))
-				Expect(out).To(ContainSubstring("Mounting disk partitions"))
-				Expect(out).To(ContainSubstring("Partitioning device..."))
-				// Remove iso so we boot directly from the disk
-				s.EjectCOSCD()
-				// Reboot so we boot into the just installed cos
-				s.Reboot()
-				By("Checking we booted from the installed cOS")
-				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
-			})
-			PIt("from url", func() {})
-			It("from docker image", func() {
-				By("Running the elemental install")
-				out, err := s.Command(fmt.Sprintf("elemental install --docker-image  %s:cos-system-%s /dev/sda", s.GreenRepo, s.TestVersion))
-				Expect(err).To(BeNil())
-				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
-				Expect(out).To(ContainSubstring("Installing GRUB.."))
-				Expect(out).To(ContainSubstring("Copying COS_PASSIVE image..."))
-				Expect(out).To(ContainSubstring("Mounting disk partitions"))
-				Expect(out).To(ContainSubstring("Partitioning device..."))
-				s.EjectCOSCD()
-				// Reboot so we boot into the just installed cos
-				s.Reboot()
-				By("Checking we booted from the installed cOS")
-				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
-				Expect(s.GetOSRelease("VERSION")).To(Equal(s.TestVersion))
-			})
-		})
-		// Marked as pending to reduce the number of efi tests. VBox efi support is
-		// not good enough to run extensive tests
-		PContext("efi/gpt tests", func() {
-			It("forces gpt", func() {
-				By("Running the installer")
-				out, err := s.Command("elemental install --force-gpt /dev/sda")
-				Expect(err).To(BeNil())
-				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
-				Expect(out).To(ContainSubstring("Installing GRUB.."))
-				Expect(out).To(ContainSubstring("Copying COS_PASSIVE image..."))
-				Expect(out).To(ContainSubstring("Mounting disk partitions"))
-				Expect(out).To(ContainSubstring("Partitioning device..."))
-				// Remove iso so we boot directly from the disk
-				s.EjectCOSCD()
-				// Reboot so we boot into the just installed cos
-				s.Reboot()
-				By("Checking we booted from the installed cOS")
-				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
-			})
-			It("forces efi", func() {
-				By("Running the installer")
-				out, err := s.Command("elemental install --force-efi /dev/sda")
-				Expect(err).To(BeNil())
-				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
-				Expect(out).To(ContainSubstring("Installing GRUB.."))
-				Expect(out).To(ContainSubstring("Copying COS_PASSIVE image..."))
-				Expect(out).To(ContainSubstring("Mounting disk partitions"))
-				Expect(out).To(ContainSubstring("Partitioning device..."))
-				// Remove iso so we boot directly from the disk
-				s.EjectCOSCD()
-				// Reboot so we boot into the just installed cos
-				s.Reboot()
-				// We are on an efi system, should boot from active
-				By("Checking we booted from Active partition")
-				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
 			})
 		})
 	})

--- a/tests/installer/installer_test.go
+++ b/tests/installer/installer_test.go
@@ -284,41 +284,45 @@ var _ = Describe("cOS Installer tests", func() {
 					Expect(out).To(ContainSubstring("Copying COS_PASSIVE image..."))
 					Expect(out).To(ContainSubstring("Mounting disk partitions"))
 					Expect(out).To(ContainSubstring("Partitioning device..."))
-					// Remove iso so we boot directly from the disk
-					s.EjectCOSCD()
-					// Reboot so we boot into the just installed cos
-					s.Reboot()
-					By("Checking we booted from the installed cOS")
-					ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
-					// check partition values
-					// Values have to match the yaml under ../assets/layout.yaml
-					// That is the file that the installer uses so partitions should match those values
-					disk := s.GetDiskLayout("/dev/sda")
 
-					for _, part := range []sut.PartitionEntry{
-						{
-							Label:  "COS_STATE",
-							Size:   8192,
-							FsType: sut.Ext4,
-						},
-						{
-							Label:  "COS_OEM",
-							Size:   10,
-							FsType: sut.Ext4,
-						},
-						{
-							Label:  "COS_RECOVERY",
-							Size:   4000,
-							FsType: sut.Ext2,
-						},
-						{
-							Label:  "COS_PERSISTENT",
-							Size:   100,
-							FsType: sut.Ext2,
-						},
-					} {
-						CheckPartitionValues(disk, part)
-					}
+					// This section of the test is flaky in our CI w/EFI. Commenting it out for the time being
+					PIt("reboots successfully into installed system", func() {
+						// Remove iso so we boot directly from the disk
+						s.EjectCOSCD()
+						// Reboot so we boot into the just installed cos
+						s.Reboot()
+						By("Checking we booted from the installed cOS")
+						ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))
+						// check partition values
+						// Values have to match the yaml under ../assets/layout.yaml
+						// That is the file that the installer uses so partitions should match those values
+						disk := s.GetDiskLayout("/dev/sda")
+
+						for _, part := range []sut.PartitionEntry{
+							{
+								Label:  "COS_STATE",
+								Size:   8192,
+								FsType: sut.Ext4,
+							},
+							{
+								Label:  "COS_OEM",
+								Size:   10,
+								FsType: sut.Ext4,
+							},
+							{
+								Label:  "COS_RECOVERY",
+								Size:   4000,
+								FsType: sut.Ext2,
+							},
+							{
+								Label:  "COS_PERSISTENT",
+								Size:   100,
+								FsType: sut.Ext2,
+							},
+						} {
+							CheckPartitionValues(disk, part)
+						}
+					})
 				})
 				// Marked as pending to reduce the number of efi tests. VBox efi support is
 				// not good enough to run extensive tests

--- a/tests/installer/tests_suite_test.go
+++ b/tests/installer/tests_suite_test.go
@@ -5,9 +5,17 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/cOS/tests/sut"
 )
 
 func TestTests(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "cOS Installer test Suite")
+}
+
+func CheckPartitionValues(diskLayout sut.DiskLayout, entry sut.PartitionEntry) {
+	part, err := diskLayout.GetPartition(entry.Label)
+	Expect(err).To(BeNil())
+	Expect((part.Size / 1024) / 1024).To(Equal(entry.Size))
+	Expect(part.FsType).To(Equal(entry.FsType))
 }


### PR DESCRIPTION
- Disable part of the EFI installer tests which makes it flaky. Keeps one portion for sanity check (that it boots and can install, without performing a reboot)
- Split up installer tests
- Tighten up the bootstrap script used in ci to install `luet`. Adds checksum verification and also installation via docker from our repositories which is then forced to be used in our pipelines.

Fixes #1202 