### PR TITLE
simplify AMI publish name

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -847,9 +847,7 @@
       - name: Build AMI for {{{ $flavor }}}
         run: |
             source .github/helpers.sh
-            PACKAGE_VERSION=$(cos_package_version)
-            export COS_VERSION="${PACKAGE_VERSION/+/-}"
-            export PKR_VAR_cos_version="${COS_VERSION}"
+            export PKR_VAR_cos_version=$(cos_package_version)
             export PKR_VAR_aws_temporary_security_group_source_cidr="${{ steps.ip.outputs.ipv4 }}/32"
             export PKR_VAR_cos_deploy_args="cos-deploy {{{ if (ne $flavor "green") }}}--no-verify {{{ end }}}--docker-image {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}:cos-system-${COS_VERSION}"
             make packer

--- a/.github/helpers.sh
+++ b/.github/helpers.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 YQ="${YQ:-/usr/bin/yq}"
 

--- a/packer/images.json.pkr.hcl
+++ b/packer/images.json.pkr.hcl
@@ -1,7 +1,7 @@
 source "amazon-ebs" "cos" {
   access_key      = var.aws_access_key
-  ami_name        = "${var.name}-${replace(var.cos_version, "+", "-")}-${formatdate("DDMMYYYY", timestamp())}-${substr(var.git_sha, 0, 7)}-${var.flavor}-${var.arch}"
-  ami_description = "${var.name}-${replace(var.cos_version, "+", "-")}-${formatdate("DDMMYYYY", timestamp())}-${substr(var.git_sha, 0, 7)}-${var.flavor}-${var.arch}"
+  ami_name        = "${var.name}-${var.cos_version}-${var.flavor}"
+  ami_description = "${var.name}-${var.cos_version}-${var.flavor}"
   ami_groups      = var.aws_ami_groups
   instance_type   = var.aws_instance_type
   region          = var.aws_region


### PR DESCRIPTION
 - No need for github sha, is part of the tags
 - No need for arch its already in there as part of ec2
 - No need for character substitution, we no longer use + signs in
versions

Signed-off-by: Itxaka <igarcia@suse.com>