### PR TITLE
Fix a duplicated key in the luet config

### DIFF
--- a/scripts/get_luet.sh
+++ b/scripts/get_luet.sh
@@ -66,14 +66,12 @@ cat > /etc/luet/luet.yaml <<EOF
 general:
   debug: false
   enable_emoji: false
+  spinner_charset: 9
 system:
   rootfs: ${LUET_ROOTFS}
   database_path: "${LUET_DATABASE_PATH}"
   database_engine: "${LUET_DATABASE_ENGINE}"
   tmpdir_base: "/var/tmp/luet"
-general:
-   debug: false
-   spinner_charset: 9
 repositories:
 - name: "cos"
   description: "cOS official"


### PR DESCRIPTION
We had a duplicated key in the generated luet config by
scripts/get_luet.sh

Fixes https://github.com/rancher-sandbox/cOS-toolkit/issues/1214

Signed-off-by: Itxaka <igarcia@suse.com>