### PR TITLE
Disable floppy when grub searchs for files/labels

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -56,7 +56,7 @@
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
   {{{- end }}}
   {{{- if $config.local_runner }}}
       - name: Install make
@@ -386,7 +386,7 @@
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -477,7 +477,7 @@
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -776,7 +776,7 @@
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools

--- a/.github/workflows/build-examples-green-x86_64.yaml
+++ b/.github/workflows/build-examples-green-x86_64.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - name: Run make deps
         run: |
           export DOCKER_INSTALL=true
@@ -79,7 +79,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - name: Run make deps
         run: |
           export DOCKER_INSTALL=true
@@ -120,7 +120,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - name: Run make deps
         run: |
           export DOCKER_INSTALL=true

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -228,7 +228,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -398,7 +398,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -176,7 +176,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -220,7 +220,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -350,7 +350,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -459,7 +459,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -503,7 +503,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -633,7 +633,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -858,7 +858,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools

--- a/.github/workflows/build-nightly-blue-x86_64.yaml
+++ b/.github/workflows/build-nightly-blue-x86_64.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - run: |
           git fetch --prune --unshallow
@@ -162,7 +162,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools

--- a/.github/workflows/build-nightly-green-x86_64.yaml
+++ b/.github/workflows/build-nightly-green-x86_64.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - run: |
           git fetch --prune --unshallow
@@ -153,7 +153,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -197,7 +197,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -327,7 +327,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -430,7 +430,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -474,7 +474,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -604,7 +604,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -712,7 +712,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools

--- a/.github/workflows/build-nightly-orange-x86_64.yaml
+++ b/.github/workflows/build-nightly-orange-x86_64.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - run: |
           git fetch --prune --unshallow
@@ -162,7 +162,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools

--- a/.github/workflows/build-pr-green-arm64.yaml
+++ b/.github/workflows/build-pr-green-arm64.yaml
@@ -214,7 +214,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -384,7 +384,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-pr-green-x86_64.yaml
+++ b/.github/workflows/build-pr-green-x86_64.yaml
@@ -167,7 +167,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -211,7 +211,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -341,7 +341,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -450,7 +450,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -494,7 +494,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -624,7 +624,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -738,7 +738,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -228,7 +228,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -398,7 +398,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -176,7 +176,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -220,7 +220,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -350,7 +350,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -459,7 +459,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -503,7 +503,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download iso
         uses: actions/download-artifact@v2
@@ -633,7 +633,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Download vagrant box
         uses: actions/download-artifact@v2
@@ -946,7 +946,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-            go-version: '^1.16'
+            go-version: '1.17'
       - uses: actions/checkout@v2
       - name: Install deps
         run: brew install yq cdrtools
@@ -1015,9 +1015,7 @@ jobs:
       - name: Build AMI for green
         run: |
             source .github/helpers.sh
-            PACKAGE_VERSION=$(cos_package_version)
-            export COS_VERSION="${PACKAGE_VERSION/+/-}"
-            export PKR_VAR_cos_version="${COS_VERSION}"
+            export PKR_VAR_cos_version=$(cos_package_version)
             export PKR_VAR_aws_temporary_security_group_source_cidr="${{ steps.ip.outputs.ipv4 }}/32"
             export PKR_VAR_cos_deploy_args="cos-deploy --docker-image quay.io/costoolkit/releases-green:cos-system-${COS_VERSION}"
             make packer

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.8.8
+    version: 0.8.9
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/packages/grub2/collection.yaml
+++ b/packages/grub2/collection.yaml
@@ -7,13 +7,13 @@ packages:
         version: ">0.0.2"
   - name: "grub2-config"
     category: "system"
-    version: 0.0.14-1
+    version: 0.0.15
     provides:
       - name: "grub-config"
         version: ">0.0.12"
   - name: "grub2-efi-image"
     category: "system"
-    version: 0.0.1-10
+    version: 0.0.2
     # TODO: Modules list could be refined
     efi_modules: ext2 iso9660 linux echo configfile search_label search_fs_file search search_fs_uuid ls normal gzio png fat gettext font minicmd gfxterm gfxmenu all_video xfs gcry_rijndael gcry_sha256 gcry_sha512 test true loadenv part_gpt part_msdos efi_gop efi_uga
     efi_modules_arm64: ext2 iso9660 linux echo configfile search_label search_fs_file search search_fs_uuid ls normal gzio png fat gettext font minicmd gfxterm gfxmenu all_video xfs gcry_rijndael gcry_sha256 gcry_sha512 test true loadenv part_gpt part_msdos efi_gop

--- a/packages/grub2/config/grub.cfg.tmpl
+++ b/packages/grub2/config/grub.cfg.tmpl
@@ -2,15 +2,15 @@ set timeout=10
 
 # Load custom env file
 set env_file="/grubenv"
-search --file --set=env_blk "${env_file}"
+search --no-floppy --file --set=env_blk "${env_file}"
 
 # Load custom env file
 set oem_env_file="/grub_oem_env"
-search --file --set=oem_blk "${oem_env_file}"
+search --no-floppy --file --set=oem_blk "${oem_env_file}"
 
 # Load custom config file
 set custom_menu="/grubmenu"
-search --file --set=menu_blk "${custom_menu}"
+search --no-floppy --file --set=menu_blk "${custom_menu}"
 
 if [ "${oem_blk}" ] ; then
   load_env -f "(${oem_blk})${oem_env_file}"
@@ -51,7 +51,7 @@ insmod loopback
 insmod squash4
 
 menuentry "${display_name}" --id cos {
-  search.fs_label @STATE_LABEL@ root
+  search --no-floppy --label @STATE_LABEL@ root
   set img=/cOS/active.img
   set label=@ACTIVE_LABEL@
   loopback loop0 /$img
@@ -62,7 +62,7 @@ menuentry "${display_name}" --id cos {
 }
 
 menuentry "${display_name} (fallback)" --id fallback {
-  search.fs_label @STATE_LABEL@ root
+  search --no-floppy --label  @STATE_LABEL@ root
   set img=/cOS/passive.img
   set label=@PASSIVE_LABEL@
   loopback loop0 /$img
@@ -73,13 +73,13 @@ menuentry "${display_name} (fallback)" --id fallback {
 }
 
 menuentry "${display_name} recovery" --id recovery {
-  if search.file /cOS/recovery.squashfs ; then
+  if search --no-floppy --file /cOS/recovery.squashfs ; then
     set img=/cOS/recovery.squashfs
     set recoverylabel=@RECOVERY_LABEL@
   else
     set img=/cOS/recovery.img
   fi
-  search.fs_label @RECOVERY_LABEL@ root
+  search --no-floppy --label @RECOVERY_LABEL@ root
   set label=@SYSTEM_LABEL@
   loopback loop0 /$img
   set root=($root)

--- a/packages/grub2/config/grub.cfg.tmpl
+++ b/packages/grub2/config/grub.cfg.tmpl
@@ -51,7 +51,7 @@ insmod loopback
 insmod squash4
 
 menuentry "${display_name}" --id cos {
-  search --no-floppy --label @STATE_LABEL@ root
+  search --no-floppy --label --set=root @STATE_LABEL@
   set img=/cOS/active.img
   set label=@ACTIVE_LABEL@
   loopback loop0 /$img
@@ -62,7 +62,7 @@ menuentry "${display_name}" --id cos {
 }
 
 menuentry "${display_name} (fallback)" --id fallback {
-  search --no-floppy --label  @STATE_LABEL@ root
+  search --no-floppy --label --set=root @STATE_LABEL@
   set img=/cOS/passive.img
   set label=@PASSIVE_LABEL@
   loopback loop0 /$img
@@ -79,7 +79,7 @@ menuentry "${display_name} recovery" --id recovery {
   else
     set img=/cOS/recovery.img
   fi
-  search --no-floppy --label @RECOVERY_LABEL@ root
+  search --no-floppy --label --set=root @RECOVERY_LABEL@
   set label=@SYSTEM_LABEL@
   loopback loop0 /$img
   set root=($root)

--- a/packages/grub2/config/grub_efi.cfg.tmpl
+++ b/packages/grub2/config/grub_efi.cfg.tmpl
@@ -1,4 +1,4 @@
-search --no-floppy --label @RECOVERY_LABEL@ root
+search --no-floppy --label --set=root @RECOVERY_LABEL@
 set root=($root)
 set prefix=($root)/grub2
 configfile ($root)/etc/cos/grub.cfg

--- a/packages/grub2/config/grub_efi.cfg.tmpl
+++ b/packages/grub2/config/grub_efi.cfg.tmpl
@@ -1,4 +1,4 @@
-search.fs_label @RECOVERY_LABEL@ root
+search --no-floppy --label @RECOVERY_LABEL@ root
 set root=($root)
 set prefix=($root)/grub2
 configfile ($root)/etc/cos/grub.cfg

--- a/packages/livecd/grub2/collection.yaml
+++ b/packages/livecd/grub2/collection.yaml
@@ -1,10 +1,10 @@
 packages:
 - name: "grub2"
   category: "live"
-  version: "0.0.2-1"
+  version: "0.0.3"
   description: "Grub2 booloader for live systems"
 
 - name: "grub2-efi-image"
   category: "live"
-  version: "0.0.1-1"
+  version: "0.0.2"
   description: "Grub2 booloader EFI image for live systems"

--- a/packages/livecd/grub2/config/grub_live.cfg
+++ b/packages/livecd/grub2/config/grub_live.cfg
@@ -1,4 +1,4 @@
-search --file --set=root /boot/kernel.xz
+search --no-floppy --file --set=root /boot/kernel.xz
 set default=0
 set timeout=10
 set timeout_style=menu

--- a/packages/livecd/grub2/config/grub_live_efi.cfg
+++ b/packages/livecd/grub2/config/grub_live_efi.cfg
@@ -1,3 +1,3 @@
-search --file --set=root /boot/kernel.xz
+search --no-floppy --file --set=root /boot/kernel.xz
 set prefix=($root)/boot/grub2
 configfile $prefix/grub.cfg

--- a/packages/meta/collection.yaml
+++ b/packages/meta/collection.yaml
@@ -3,7 +3,7 @@ packages:
     category: "meta"
     name: "toolchain"
     description: "Meta package for cOS toolchain"
-    version: 0.9-5
+    version: 0.10-0
     requires:
       - category: toolchain
         name: elemental-cli


### PR DESCRIPTION
It was reported that searching includes floppy search by default and
that could lead to grub hanging while checking non-existant floppy
drives.

This patch fully disables floppy search

Partial: https://github.com/harvester/harvester/issues/2115

Signed-off-by: Itxaka <igarcia@suse.com>