### PR TITLE
Add experimental package with openrc services

### DIFF
--- a/packages/openrc/cos-setup/build.yaml
+++ b/packages/openrc/cos-setup/build.yaml
@@ -1,0 +1,9 @@
+requires:
+- name: "base"
+  category: "distro"
+  version: ">=0"
+output_dir: "/package"
+steps:
+- mkdir /package
+- cp -rfv files/* /package
+- chmod +x /package/usr/bin/cos-setup-reconcile

--- a/packages/openrc/cos-setup/definition.yaml
+++ b/packages/openrc/cos-setup/definition.yaml
@@ -1,0 +1,8 @@
+name: cos-setup
+category: system-openrc
+version: "0.1"
+description: "Experimental package for openrc support"
+requires:
+  - name: "elemental-cli"
+    category: "toolchain"
+    version: ">=0"

--- a/packages/openrc/cos-setup/files/etc/init.d/cos-setup-boot
+++ b/packages/openrc/cos-setup/files/etc/init.d/cos-setup-boot
@@ -1,0 +1,10 @@
+#!/sbin/openrc-run
+
+depend() {
+  provide cos-setup-boot
+}
+
+start() {
+  elemental run-stage boot
+  eend 0
+}

--- a/packages/openrc/cos-setup/files/etc/init.d/cos-setup-network
+++ b/packages/openrc/cos-setup/files/etc/init.d/cos-setup-network
@@ -1,0 +1,11 @@
+#!/sbin/openrc-run
+
+depend() {
+  after net
+  provide cos-setup-network
+}
+
+start() {
+  elemental run-stage network
+  eend 0
+}

--- a/packages/openrc/cos-setup/files/etc/init.d/cos-setup-reconcile
+++ b/packages/openrc/cos-setup/files/etc/init.d/cos-setup-reconcile
@@ -1,0 +1,15 @@
+#!/sbin/openrc-run
+
+depend() {
+  provide cos-setup-reconcile
+}
+
+supervisor=supervise-daemon
+name="cos-setup-reconcile"
+command="cos-setup-reconcile"
+supervise_daemon_args="--stdout /var/log/cos-setup-reconcile.log --stderr /var/log/cos-setup-reconcile.log"
+pidfile="/run/cos-setup-reconcile.pid"
+respawn_delay=5
+set -o allexport
+if [ -f /etc/environment ]; then source /etc/environment; fi
+set +o allexport

--- a/packages/openrc/cos-setup/files/usr/bin/cos-setup-reconcile
+++ b/packages/openrc/cos-setup/files/usr/bin/cos-setup-reconcile
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+SLEEP_TIME=${SLEEP_TIME:-360}
+
+while :
+do
+    elemental run-stage "reconcile"
+    sleep "$SLEEP_TIME"
+done


### PR DESCRIPTION
Those are taken from
https://github.com/c3os-io/c3os/tree/94e6d6fa67a6ff25be8f146f892ebeaaf865ebc1/overlay/files-alpine and seems to be working, providing minimum functionality for alpine(and openrc based) support. I'd like to upstream them here so to avoid re-implementation spreading across.

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>