### PR TITLE
Add NetworkManager package to cOS and derivatives

### DIFF
--- a/examples/odroid-c2/Dockerfile
+++ b/examples/odroid-c2/Dockerfile
@@ -40,6 +40,7 @@ RUN zypper in -y \
     mdadm \
     multipath-tools \
     nano \
+    NetworkManager \
     nfs-utils \
     odroidc2-firmware \
     open-iscsi \
@@ -61,6 +62,11 @@ RUN zypper in -y \
     wpa_supplicant
 
 RUN zypper cc
+
+# Configure NetworkManager as default network management service
+RUN zypper remove -y wicked
+RUN systemctl disable wicked \
+    && systemctl enable NetworkManager
 
 # Copy the luet config file pointing to the upgrade repository
 COPY conf/luet.yaml /etc/luet/luet.yaml

--- a/examples/rpi/Dockerfile
+++ b/examples/rpi/Dockerfile
@@ -38,6 +38,7 @@ RUN zypper in -y \
     mdadm \
     multipath-tools \
     nano \
+    NetworkManager \
     nfs-utils \
     open-iscsi \
     open-vm-tools \
@@ -59,6 +60,11 @@ RUN zypper in -y \
     wpa_supplicant
 
 RUN zypper cc
+
+# Configure NetworkManager as default network management service
+RUN zypper remove -y wicked
+RUN systemctl disable wicked \
+    && systemctl enable NetworkManager
 
 # Copy the luet config file pointing to the upgrade repository
 COPY conf/luet.yaml /etc/luet/luet.yaml

--- a/examples/standard/Dockerfile
+++ b/examples/standard/Dockerfile
@@ -43,6 +43,7 @@ RUN zypper in -y \
     mdadm \
     multipath-tools \
     nano \
+    NetworkManager\
     nfs-utils \
     open-iscsi \
     open-vm-tools \
@@ -62,6 +63,13 @@ RUN zypper in -y \
     timezone \
     vim \
     which
+
+RUN zypper cc
+
+# Configure NetworkManager as default network management service
+RUN zypper remove -y wicked
+RUN systemctl disable wicked \
+    && systemctl enable NetworkManager
 
 # Copy the luet config file pointing to the upgrade repository
 COPY conf/luet.yaml /etc/luet/luet.yaml

--- a/packages/base/definition.yaml
+++ b/packages/base/definition.yaml
@@ -1,5 +1,5 @@
 name: "base"
 category: "distro"
-version: "0.20220416"
+version: "0.20220501"
 labels:
   autobump.strategy: "snapshot"

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.8.9-18
+    version: 0.8.9-20
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/values/green-arm64.yaml
+++ b/values/green-arm64.yaml
@@ -44,6 +44,7 @@ packages: >-
     mdadm
     multipath-tools
     nano
+    NetworkManager
     nfs-utils
     open-iscsi
     open-vm-tools

--- a/values/green-x86_64.yaml
+++ b/values/green-x86_64.yaml
@@ -46,6 +46,7 @@ packages: >-
     mdadm
     multipath-tools
     nano
+    NetworkManager
     nfs-utils
     open-iscsi
     open-vm-tools

--- a/values/orange-arm64.yaml
+++ b/values/orange-arm64.yaml
@@ -30,6 +30,7 @@ packages: >-
     iproute2
     multipath-tools
     nano
+    network-manager
     parted
     rsync
     squashfs-tools

--- a/values/orange-x86_64.yaml
+++ b/values/orange-x86_64.yaml
@@ -32,6 +32,7 @@ packages: >-
     iproute2
     multipath-tools
     nano
+    network-manager
     parted
     rsync
     squashfs-tools


### PR DESCRIPTION
Add NetworkManager package to provide automatic networks detection and configuration for systems.

Fixes #1228

Signed-off-by: Michal Jura <mjura@suse.com>