### PR TITLE
Bump meta packages

### DIFF
--- a/packages/meta/build.yaml
+++ b/packages/meta/build.yaml
@@ -1,9 +1,0 @@
-requires:
-- name: "base"
-  category: "distro"
-  version: ">=0"
-
-package_dir: "/package"
-steps:
-- mkdir -p /package/var/db/cos
-- touch /package/var/db/cos/{{.Values.category}}_{{.Values.name}}_{{.Values.version}}

--- a/packages/meta/collection.yaml
+++ b/packages/meta/collection.yaml
@@ -3,7 +3,7 @@ packages:
     category: "meta"
     name: "toolchain"
     description: "Meta package for cOS toolchain"
-    version: 0.10-1
+    version: "0.20"
     requires:
       - category: toolchain
         name: elemental-cli
@@ -21,7 +21,6 @@ packages:
       - category: toolchain-fips
         name: luet
         version: ">=0"
-    version: 0.10-1
   - !!merge <<: *metabase
     name: "cos-modules"
     description: "Meta package for cOS core modules. It includes cos-setup, dracut and grub configuration"
@@ -41,7 +40,6 @@ packages:
       - name: "base-dracut-modules"
         category: "system"
         version: ">=0"
-    version: 0.10-1
   - !!merge <<: *metabase
     name: "cos-core"
     description: "cOS core package. It includes toolchain and base grub/dracut configuration"
@@ -55,7 +53,6 @@ packages:
       - name: "suc-integration"
         category: "system"
         version: ">=0"
-    version: 0.10-1
   - !!merge <<: *metabase
     name: "cos-core-fips"
     requires:
@@ -65,7 +62,6 @@ packages:
       - category: meta
         name: cos-modules
         version: ">=0"
-    version: 0.10-1
   - !!merge <<: *metabase
     name: "cos-minimal"
     description: "cOS minimal package. It includes toolchain, grub/dracut configuration and a default cloud-init preset"
@@ -76,7 +72,6 @@ packages:
       - category: system
         name: cloud-config
         version: ">=0"
-    version: 0.10-1
   - !!merge <<: *metabase
     name: "cos-minimal-fips"
     requires:
@@ -86,7 +81,6 @@ packages:
       - category: system
         name: cloud-config
         version: ">=0"
-    version: 0.10-1
   - !!merge <<: *metabase
     name: "cos-verify"
     requires:
@@ -96,7 +90,6 @@ packages:
       - category: toolchain
         name: luet-cosign
         version: ">0.0.10-3"
-    version: 0.10-1
   # Provides backward compatibility
   - !!merge <<: *metabase
     category: "system"
@@ -121,4 +114,3 @@ packages:
         name: "recovery"
       - !!merge <<: *cc
         name: "live"
-    version: 0.10-2


### PR DESCRIPTION
Also empty build.yaml to treat it as an empty package.
This was a workaround to docker limitation for empty images, but now that `luet` supports that directly, no need to touch any db file anymore

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>