### PR TITLE
Set packer qemu plugin to use

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -280,6 +280,7 @@
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       {{{if eq $config.arch "arm64" }}}
       PKR_VAR_qemu_binary: qemu-system-aarch64
       PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd

--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -378,7 +378,7 @@
       ARCH: {{{ $config.arch }}}
       {{{ if eq $config.arch "arm64" }}}
       VAGRANT_CPU: 2
-      VAGRANT_MEMORY: 5120
+      VAGRANT_MEMORY: 4096
       VAGRANT_FIRMWARE: /usr/share/AAVMF/AAVMF_CODE.fd
       COS_HOST: "192.168.122.50:22"
       COS_TIMEOUT: 1800

--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -301,7 +301,7 @@
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh

--- a/.github/config/pr.yaml
+++ b/.github/config/pr.yaml
@@ -56,7 +56,7 @@ flavors:
         cache_repository: "build"
         organization: "quay.io/costoolkit"
         skip_tests: false
-        run_tests: ["test-fallback", "test-smoke", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
+        run_tests: ["test-smoke", "test-upgrades-images-signed", "test-upgrades-images-unsigned", "test-upgrades-local"]
         flavor: "green"
         skip_tests_flavor: [ "blue", "orange", "teal"]
         skip_images_flavor: [ "blue", "orange", "teal" ]

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -199,7 +199,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh
@@ -375,7 +375,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -182,6 +182,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PKR_VAR_qemu_binary: qemu-system-aarch64
       PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
       PACKER_TARGET: qemu.cos-arm64
@@ -358,6 +359,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PKR_VAR_qemu_binary: qemu-system-aarch64
       PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
       PACKER_TARGET: qemu.cos-arm64

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -222,7 +222,7 @@ jobs:
     env:
       ARCH: arm64
       VAGRANT_CPU: 2
-      VAGRANT_MEMORY: 5120
+      VAGRANT_MEMORY: 4096
       VAGRANT_FIRMWARE: /usr/share/AAVMF/AAVMF_CODE.fd
       COS_HOST: "192.168.122.50:22"
       COS_TIMEOUT: 1800
@@ -399,7 +399,7 @@ jobs:
     env:
       ARCH: arm64
       VAGRANT_CPU: 2
-      VAGRANT_MEMORY: 5120
+      VAGRANT_MEMORY: 4096
       VAGRANT_FIRMWARE: /usr/share/AAVMF/AAVMF_CODE.fd
       COS_HOST: "192.168.122.50:22"
       COS_TIMEOUT: 1800

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -268,6 +268,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
@@ -557,6 +558,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -283,7 +283,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh
@@ -572,7 +572,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh

--- a/.github/workflows/build-nightly-green-x86_64.yaml
+++ b/.github/workflows/build-nightly-green-x86_64.yaml
@@ -260,7 +260,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh
@@ -543,7 +543,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh

--- a/.github/workflows/build-nightly-green-x86_64.yaml
+++ b/.github/workflows/build-nightly-green-x86_64.yaml
@@ -245,6 +245,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
@@ -528,6 +529,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-pr-green-arm64.yaml
+++ b/.github/workflows/build-pr-green-arm64.yaml
@@ -185,7 +185,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh
@@ -361,7 +361,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh

--- a/.github/workflows/build-pr-green-arm64.yaml
+++ b/.github/workflows/build-pr-green-arm64.yaml
@@ -208,7 +208,7 @@ jobs:
     env:
       ARCH: arm64
       VAGRANT_CPU: 2
-      VAGRANT_MEMORY: 5120
+      VAGRANT_MEMORY: 4096
       VAGRANT_FIRMWARE: /usr/share/AAVMF/AAVMF_CODE.fd
       COS_HOST: "192.168.122.50:22"
       COS_TIMEOUT: 1800
@@ -385,7 +385,7 @@ jobs:
     env:
       ARCH: arm64
       VAGRANT_CPU: 2
-      VAGRANT_MEMORY: 5120
+      VAGRANT_MEMORY: 4096
       VAGRANT_FIRMWARE: /usr/share/AAVMF/AAVMF_CODE.fd
       COS_HOST: "192.168.122.50:22"
       COS_TIMEOUT: 1800

--- a/.github/workflows/build-pr-green-arm64.yaml
+++ b/.github/workflows/build-pr-green-arm64.yaml
@@ -168,6 +168,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PKR_VAR_qemu_binary: qemu-system-aarch64
       PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
       PACKER_TARGET: qemu.cos-arm64
@@ -215,7 +216,7 @@ jobs:
     needs: qemu-squashfs-green
     strategy:
       matrix:
-        test: [test-fallback, test-smoke, test-upgrades-images-signed, test-upgrades-images-unsigned, test-upgrades-local]
+        test: [test-smoke, test-upgrades-images-signed, test-upgrades-images-unsigned, test-upgrades-local]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
@@ -344,6 +345,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PKR_VAR_qemu_binary: qemu-system-aarch64
       PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
       PACKER_TARGET: qemu.cos-arm64
@@ -391,7 +393,7 @@ jobs:
     needs: qemu-nonsquashfs-green
     strategy:
       matrix:
-        test: [test-fallback, test-smoke, test-upgrades-images-signed, test-upgrades-images-unsigned, test-upgrades-local]
+        test: [test-smoke, test-upgrades-images-signed, test-upgrades-images-unsigned, test-upgrades-local]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/build-pr-green-x86_64.yaml
+++ b/.github/workflows/build-pr-green-x86_64.yaml
@@ -259,6 +259,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
@@ -548,6 +549,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-pr-green-x86_64.yaml
+++ b/.github/workflows/build-pr-green-x86_64.yaml
@@ -274,7 +274,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh
@@ -563,7 +563,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -199,7 +199,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh
@@ -375,7 +375,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -182,6 +182,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PKR_VAR_qemu_binary: qemu-system-aarch64
       PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
       PACKER_TARGET: qemu.cos-arm64
@@ -358,6 +359,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PKR_VAR_qemu_binary: qemu-system-aarch64
       PKR_VAR_firmware: /usr/share/qemu-efi-aarch64/QEMU_EFI.fd
       PACKER_TARGET: qemu.cos-arm64

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -222,7 +222,7 @@ jobs:
     env:
       ARCH: arm64
       VAGRANT_CPU: 2
-      VAGRANT_MEMORY: 5120
+      VAGRANT_MEMORY: 4096
       VAGRANT_FIRMWARE: /usr/share/AAVMF/AAVMF_CODE.fd
       COS_HOST: "192.168.122.50:22"
       COS_TIMEOUT: 1800
@@ -399,7 +399,7 @@ jobs:
     env:
       ARCH: arm64
       VAGRANT_CPU: 2
-      VAGRANT_MEMORY: 5120
+      VAGRANT_MEMORY: 4096
       VAGRANT_FIRMWARE: /usr/share/AAVMF/AAVMF_CODE.fd
       COS_HOST: "192.168.122.50:22"
       COS_TIMEOUT: 1800

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -268,6 +268,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2
@@ -557,6 +558,7 @@ jobs:
       PKR_VAR_accelerator: tcg
       PKR_VAR_cpus: 2
       PKR_VAR_memory: 4096
+      PACKER_GITHUB_API_TOKEN: ${{ github.token }}
       PACKER_TARGET: qemu.cos
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -283,7 +283,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh
@@ -572,7 +572,7 @@ jobs:
       - name: Install Packer
         uses: hashicorp-contrib/setup-packer@v1
         with:
-            packer-version: 1.7.3
+            packer-version: 1.8.0
       - name: Build QEMU Image 🔧
         run: |
           source .github/helpers.sh

--- a/make/Makefile.iso
+++ b/make/Makefile.iso
@@ -118,4 +118,5 @@ ifeq ("$(PACKER)","/usr/sbin/packer")
 	@echo "Please set PACKER to the correct binary before calling make"
 	@exit 1
 endif
+	$(PACKER) init $(ROOT_DIR)/packer
 	export PKR_VAR_iso=$(ISO) && cd $(ROOT_DIR)/packer && $(PACKER) build -only $(PACKER_TARGET) .

--- a/packer/images.json.pkr.hcl
+++ b/packer/images.json.pkr.hcl
@@ -1,3 +1,12 @@
+packer {
+  required_plugins {
+    qemu = {
+      version = ">= 1.0.3"
+      source  = "github.com/hashicorp/qemu"
+    }
+  }
+}
+
 source "amazon-ebs" "cos" {
   access_key      = var.aws_access_key
   ami_name        = "${var.name}-${var.cos_version}-${var.flavor}"

--- a/tests/deploys-images/deploy_test.go
+++ b/tests/deploys-images/deploy_test.go
@@ -39,7 +39,7 @@ var _ = Describe("cOS Deploy tests", func() {
 
 				version := out
 
-				_, err = s.Command(fmt.Sprintf("elemental reset --docker-image %s:cos-system-%s", s.GreenRepo, s.TestVersion))
+				_, err = s.Command(fmt.Sprintf("elemental --debug reset --docker-image %s:cos-system-%s", s.GreenRepo, s.TestVersion))
 				Expect(err).NotTo(HaveOccurred())
 				s.Reboot()
 				ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Active))

--- a/tests/fallback/fallback_test.go
+++ b/tests/fallback/fallback_test.go
@@ -46,7 +46,7 @@ var _ = Describe("cOS booting fallback tests", func() {
 			// Auto assessment was installed
 			bootAssessmentInstalled()
 
-			out, err := s.Command(fmt.Sprintf("elemental upgrade --no-verify --docker-image %s:cos-system-%s", s.GreenRepo, s.TestVersion))
+			out, err := s.Command(fmt.Sprintf("elemental --debug upgrade --no-verify --docker-image %s:cos-system-%s", s.GreenRepo, s.TestVersion))
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).Should(ContainSubstring("Upgrade completed"))
 			Expect(out).Should(ContainSubstring("Upgrading active partition"))

--- a/tests/hooks/chroot_test.go
+++ b/tests/hooks/chroot_test.go
@@ -18,7 +18,7 @@ var _ = Describe("cOS Feature tests", func() {
 			err := s.SendFile("../assets/chroot_hooks.yaml", "/oem/chroot_hooks.yaml", "0770")
 			Expect(err).ToNot(HaveOccurred())
 
-			out, err := s.Command("elemental upgrade")
+			out, err := s.Command("elemental --debug upgrade")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).Should(ContainSubstring("Upgrade completed"))
 			Expect(out).Should(ContainSubstring("Upgrading active partition"))

--- a/tests/installer/installer_test.go
+++ b/tests/installer/installer_test.go
@@ -46,7 +46,7 @@ var _ = Describe("cOS Installer tests", func() {
 		Context("install source tests", func() {
 			It("from iso", func() {
 				By("Running the elemental install")
-				out, err := s.Command("elemental install /dev/sda")
+				out, err := s.Command("elemental --debug install /dev/sda")
 				Expect(err).To(BeNil())
 				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
 				Expect(out).To(ContainSubstring("Installing GRUB.."))
@@ -62,7 +62,7 @@ var _ = Describe("cOS Installer tests", func() {
 			PIt("from url", func() {})
 			It("from docker image", func() {
 				By("Running the elemental install")
-				out, err := s.Command(fmt.Sprintf("elemental install --docker-image  %s:cos-system-%s /dev/sda", s.GreenRepo, s.TestVersion))
+				out, err := s.Command(fmt.Sprintf("elemental --debug install --docker-image  %s:cos-system-%s /dev/sda", s.GreenRepo, s.TestVersion))
 				Expect(err).To(BeNil())
 				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
 				Expect(out).To(ContainSubstring("Installing GRUB.."))
@@ -84,7 +84,7 @@ var _ = Describe("cOS Installer tests", func() {
 					err := s.SendFile("../assets/layout.yaml", "/usr/local/layout.yaml", "0770")
 					By("Running the elemental installer with a layout file")
 					Expect(err).To(BeNil())
-					out, err := s.Command("elemental install --force-gpt --partition-layout /usr/local/layout.yaml /dev/sda")
+					out, err := s.Command("elemental --debug install --force-gpt --partition-layout /usr/local/layout.yaml /dev/sda")
 					Expect(err).To(BeNil())
 					Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
 					Expect(out).To(ContainSubstring("Installing GRUB.."))
@@ -131,7 +131,7 @@ var _ = Describe("cOS Installer tests", func() {
 					err := s.SendFile("../assets/layout.yaml", "/usr/local/layout.yaml", "0770")
 					By("Running the elemental install with a layout file")
 					Expect(err).To(BeNil())
-					out, err := s.Command("elemental install --partition-layout /usr/local/layout.yaml /dev/sda")
+					out, err := s.Command("elemental --debug install --partition-layout /usr/local/layout.yaml /dev/sda")
 					Expect(err).To(BeNil())
 					Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
 					Expect(out).To(ContainSubstring("Installing GRUB.."))
@@ -179,7 +179,7 @@ var _ = Describe("cOS Installer tests", func() {
 		Context("efi/gpt tests", func() {
 			It("forces gpt", func() {
 				By("Running the installer")
-				out, err := s.Command("elemental install --force-gpt /dev/sda")
+				out, err := s.Command("elemental --debug install --force-gpt /dev/sda")
 				Expect(err).To(BeNil())
 				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
 				Expect(out).To(ContainSubstring("Installing GRUB.."))
@@ -194,7 +194,7 @@ var _ = Describe("cOS Installer tests", func() {
 
 			It("forces efi", func() {
 				By("Running the installer")
-				out, err := s.Command("elemental install --force-efi /dev/sda")
+				out, err := s.Command("elemental --debug install --force-efi /dev/sda")
 				Expect(err).To(BeNil())
 				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
 				Expect(out).To(ContainSubstring("Installing GRUB.."))
@@ -214,7 +214,7 @@ var _ = Describe("cOS Installer tests", func() {
 				By("Running the elemental install with a config file")
 				Expect(err).To(BeNil())
 				By("Running the installer")
-				out, err := s.Command("elemental install --cloud-init /tmp/config.yaml /dev/sda")
+				out, err := s.Command("elemental --debug install --cloud-init /tmp/config.yaml /dev/sda")
 				Expect(err).To(BeNil())
 				Expect(out).To(ContainSubstring("Copying COS_ACTIVE image..."))
 				Expect(out).To(ContainSubstring("Installing GRUB.."))

--- a/tests/recovery-raw-disk/recovery_raw_disk_test.go
+++ b/tests/recovery-raw-disk/recovery_raw_disk_test.go
@@ -24,7 +24,7 @@ var _ = Describe("cOS Recovery deploy tests", func() {
 		It("uses cos-deploy to install", func() {
 			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Recovery))
 
-			_, err := s.Command("elemental reset")
+			_, err := s.Command("elemental --debug reset")
 			Expect(err).ToNot(HaveOccurred())
 
 			s.Reboot(sut.TimeoutRawDiskTest)

--- a/tests/recovery/recovery_test.go
+++ b/tests/recovery/recovery_test.go
@@ -50,7 +50,7 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 			}
 
 			By("upgrade active")
-			out, err := s.Command("elemental upgrade")
+			out, err := s.Command("elemental --debug upgrade")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).Should(ContainSubstring("Upgrade completed"))
 			Expect(out).Should(ContainSubstring("Upgrading active partition"))
@@ -75,7 +75,7 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 			s.Reboot()
 			ExpectWithOffset(1, s.BootFrom()).To(Equal(sut.Recovery))
 
-			out, err := s.Command(fmt.Sprintf("elemental upgrade --docker-image %s:cos-system-%s", s.GreenRepo, s.TestVersion))
+			out, err := s.Command(fmt.Sprintf("elemental --debug upgrade --docker-image %s:cos-system-%s", s.GreenRepo, s.TestVersion))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).Should(ContainSubstring("Upgrade completed"))
 			Expect(out).Should(ContainSubstring("Upgrading active partition"))
@@ -97,7 +97,7 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 			It("upgrades to a specific image and reset back to the installed version", func() {
 				version := s.GetOSRelease("VERSION")
 				By(fmt.Sprintf("upgrading to %s:cos-recovery-%s", s.GreenRepo, s.TestVersion))
-				out, err := s.Command(fmt.Sprintf("elemental upgrade --recovery --docker-image %s:cos-recovery-%s", s.GreenRepo, s.TestVersion))
+				out, err := s.Command(fmt.Sprintf("elemental --debug upgrade --recovery --docker-image %s:cos-recovery-%s", s.GreenRepo, s.TestVersion))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).Should(ContainSubstring("Upgrade completed"))
 				Expect(out).Should(ContainSubstring("Upgrading recovery partition"))
@@ -123,7 +123,7 @@ var _ = Describe("cOS Recovery upgrade tests", func() {
 		When("using upgrade channel", func() {
 			It("upgrades to latest image", func() {
 				By("upgrading recovery")
-				out, err := s.Command("elemental upgrade --recovery")
+				out, err := s.Command("elemental --debug upgrade --recovery")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).Should(ContainSubstring("Upgrade completed"))
 				Expect(out).Should(ContainSubstring("Upgrading recovery partition"))

--- a/tests/smoke/smoke_test.go
+++ b/tests/smoke/smoke_test.go
@@ -65,7 +65,7 @@ var _ = Describe("cOS Smoke tests", func() {
 		})
 
 		It("fails running elemental reset from COS_ACTIVE", func() {
-			out, err := s.Command("elemental reset")
+			out, err := s.Command("elemental --debug reset")
 			Expect(err).To(HaveOccurred())
 			Expect(out).Should(ContainSubstring("reset can only be called from the recovery system"))
 		})

--- a/tests/upgrades-images-signed/upgrade_test.go
+++ b/tests/upgrades-images-signed/upgrade_test.go
@@ -28,7 +28,7 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 	Context("After install", func() {
 		When("upgrading", func() {
 			It("upgrades to latest available (master) and reset", func() {
-				out, err := s.Command("elemental upgrade")
+				out, err := s.Command("elemental --debug upgrade")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).Should(ContainSubstring("Upgrade completed"))
 				Expect(out).Should(ContainSubstring("Upgrading active partition"))
@@ -50,7 +50,7 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 
 				version := out
 				By(fmt.Sprintf("upgrading to an old image: %s:cos-system-%s", s.GreenRepo, s.TestVersion))
-				out, err = s.Command(fmt.Sprintf("elemental upgrade --docker-image %s:cos-system-%s", s.GreenRepo, s.TestVersion))
+				out, err = s.Command(fmt.Sprintf("elemental --debug upgrade --docker-image %s:cos-system-%s", s.GreenRepo, s.TestVersion))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).Should(
 					And(

--- a/tests/upgrades-images-unsigned/upgrade_test.go
+++ b/tests/upgrades-images-unsigned/upgrade_test.go
@@ -38,7 +38,7 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 				Expect(out).ToNot(Equal(""))
 
 				version := out
-				out, err = s.Command(fmt.Sprintf("elemental upgrade --no-verify --docker-image %s:cos-system-%s", s.GreenRepo, s.TestVersion))
+				out, err = s.Command(fmt.Sprintf("elemental --debug upgrade --no-verify --docker-image %s:cos-system-%s", s.GreenRepo, s.TestVersion))
 				Expect(err).ToNot(HaveOccurred(), out)
 				Expect(out).Should(ContainSubstring("Upgrade completed"))
 				Expect(out).Should(ContainSubstring("Upgrading active partition"))

--- a/tests/upgrades-local/upgrade_test.go
+++ b/tests/upgrades-local/upgrade_test.go
@@ -37,14 +37,14 @@ var _ = Describe("cOS Upgrade tests - local upgrades", func() {
 
 				version := out
 
-				out, err = s.Command(fmt.Sprintf("mkdir /run/update && elemental pull-image %s:cos-system-%s /run/update", s.GreenRepo, s.TestVersion))
+				out, err = s.Command(fmt.Sprintf("mkdir /run/update && elemental --debug pull-image %s:cos-system-%s /run/update", s.GreenRepo, s.TestVersion))
 				if err != nil {
 					fmt.Fprintf(GinkgoWriter, "Error from elemental pull-image: %v\n", err)
 				}
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
 
-				out, err = s.Command("elemental upgrade --no-verify --directory /run/update")
+				out, err = s.Command("elemental --debug upgrade --no-verify --directory /run/update")
 				if err != nil {
 					fmt.Fprintf(GinkgoWriter, "Error from elemental upgrade: %v\n", err)
 				}


### PR DESCRIPTION
Bump it to use 1.0.3 at least, which has some fixes for efi firmware

also bumps packer to the latest version. Problem seems to be a combination of packer 1.8.0 + qemu plugin 1.0.2 (bundled)

Signed-off-by: Itxaka <igarcia@suse.com>