### PR TITLE
Publish a luet repo on release

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -621,6 +621,27 @@
 
 {{{ end }}}
 
+{{{define "generate_repo_files"}}}
+  {{{ $config := (datasource "config") }}}
+  {{{ $flavor := . }}}
+  generate-repo-files-{{{ $flavor }}}:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs:
+      - publish-{{{ $flavor }}}
+    env:
+      LUET_REPO_ARCH: {{{ if eq $config.arch "x86_64"}}}amd64{{{else}}}{{{$config.arch}}}{{{end}}}
+      FINAL_REPO: {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}{{{- if ne $config.arch "x86_64"}}}-{{{$config.arch}}}{{{end}}}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mikefarah/yq@v4.25.1
+      - run: |
+          yq ".urls = [${{ env.FINAL_REPO }}]" .github/cos.yaml.template | yq '.reference = "${{ github.ref_name }}-repository.yaml"' | yq '.arch = "${{ env.LUET_REPO_ARCH }}"'> cos-repo-{{{ $config.arch }}}.yaml
+      - name: upload repo file
+        uses: actions/upload-artifact@v2
+        with:
+          path: cos-{{{ $config.arch }}}.yaml
+{{{ end }}}
 
 
 {{{define "github_release"}}}
@@ -656,6 +677,7 @@
     {{{- if $config.publish_cloud }}}
     - publish-vanilla-ami
     {{{- end }}}
+    - generate-repo-files-{{{ $flavor }}}
     env:
       FLAVOR: {{{ $flavor }}}
       ARCH: {{{ $config.arch }}}
@@ -726,6 +748,10 @@
           name: ami-id-vanilla-${{ env.COS_VERSION }}.txt
           path: release
       {{{- end }}}
+      - uses: actions/download-artifact@v2
+        with:
+          name: cos-repo-{{{ $config.arch }}}.yaml
+          path: release
       - name: Release
         uses: fnkr/github-action-ghr@v1
         if: startsWith(github.ref, 'refs/tags/')
@@ -1123,6 +1149,7 @@ jobs:
   {{{tmpl.Exec "image_link" $flavor}}}
   {{{tmpl.Exec "publish_packages" $flavor}}}
   {{{- if has $config.release_flavor $flavor }}}
+  {{{tmpl.Exec "generate_repo_files" $flavor}}}
   {{{tmpl.Exec "github_release" $flavor}}}
   {{{- end }}}
   {{{- end }}}

--- a/.github/cos.yaml.template
+++ b/.github/cos.yaml.template
@@ -1,0 +1,8 @@
+name: "cos"
+description: "cOS official"
+type: "docker"
+cached: true
+priority: 1
+reference:
+arch:
+urls:

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -584,6 +584,23 @@ jobs:
           name: luetcosign.log.zip
           path: /tmp/luet-cosign.log
           if-no-files-found: warn
+  generate-repo-files-green:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs:
+      - publish-green
+    env:
+      LUET_REPO_ARCH: arm64
+      FINAL_REPO: quay.io/costoolkit/releases-green-arm64
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mikefarah/yq@v4.25.1
+      - run: |
+          yq ".urls = [${{ env.FINAL_REPO }}]" .github/cos.yaml.template | yq '.reference = "${{ github.ref_name }}-repository.yaml"' | yq '.arch = "${{ env.LUET_REPO_ARCH }}"'> cos-repo-arm64.yaml
+      - name: upload repo file
+        uses: actions/upload-artifact@v2
+        with:
+          path: cos-arm64.yaml
   github-release-green:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -595,6 +612,7 @@ jobs:
     - image-link-green
     - tests-nonsquashfs-green
     - tests-squashfs-green
+    - generate-repo-files-green
     env:
       FLAVOR: green
       ARCH: arm64
@@ -642,6 +660,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: images-green-arm64.txt
+          path: release
+      - uses: actions/download-artifact@v2
+        with:
+          name: cos-repo-arm64.yaml
           path: release
       - name: Release
         uses: fnkr/github-action-ghr@v1

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -808,6 +808,23 @@ jobs:
           name: luetcosign.log.zip
           path: /tmp/luet-cosign.log
           if-no-files-found: warn
+  generate-repo-files-green:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs:
+      - publish-green
+    env:
+      LUET_REPO_ARCH: amd64
+      FINAL_REPO: quay.io/costoolkit/releases-green
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mikefarah/yq@v4.25.1
+      - run: |
+          yq ".urls = [${{ env.FINAL_REPO }}]" .github/cos.yaml.template | yq '.reference = "${{ github.ref_name }}-repository.yaml"' | yq '.arch = "${{ env.LUET_REPO_ARCH }}"'> cos-repo-x86_64.yaml
+      - name: upload repo file
+        uses: actions/upload-artifact@v2
+        with:
+          path: cos-x86_64.yaml
   github-release-green:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -821,6 +838,7 @@ jobs:
     - tests-nonsquashfs-green
     - tests-squashfs-green
     - publish-vanilla-ami
+    - generate-repo-files-green
     env:
       FLAVOR: green
       ARCH: x86_64
@@ -882,6 +900,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: ami-id-vanilla-${{ env.COS_VERSION }}.txt
+          path: release
+      - uses: actions/download-artifact@v2
+        with:
+          name: cos-repo-x86_64.yaml
           path: release
       - name: Release
         uses: fnkr/github-action-ghr@v1


### PR DESCRIPTION
This generates a valid luet repo file with the proper reference for the
tag used on release, so you can download it directly into your
/etc/luet/repos.conf.d and start using it

Part of https://github.com/rancher-sandbox/cOS-toolkit/issues/1003

Signed-off-by: Itxaka <igarcia@suse.com>