### PR TITLE
Stop indexing all packages on publish

### DIFF
--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -564,7 +564,6 @@
       ARCH: {{{ $config.arch }}}
       FINAL_REPO: {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}{{{- if ne $config.arch "x86_64"}}}-{{{$config.arch}}}{{{end}}}
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       {{{- if has $config "luet_install_from_cos_repo" }}}
       LUET_INSTALL_FROM_COS_REPO: {{{ $config.luet_install_from_cos_repo }}}

--- a/.github/workflows/build-master-blue-arm64.yaml
+++ b/.github/workflows/build-master-blue-arm64.yaml
@@ -146,7 +146,6 @@ jobs:
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-blue-arm64
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -144,7 +144,6 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -493,7 +493,6 @@ jobs:
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -717,7 +717,6 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green

--- a/.github/workflows/build-master-orange-arm64.yaml
+++ b/.github/workflows/build-master-orange-arm64.yaml
@@ -148,7 +148,6 @@ jobs:
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-orange-arm64
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -144,7 +144,6 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange

--- a/.github/workflows/build-master-teal-arm64.yaml
+++ b/.github/workflows/build-master-teal-arm64.yaml
@@ -146,7 +146,6 @@ jobs:
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-teal-arm64
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-teal

--- a/.github/workflows/build-master-teal-x86_64.yaml
+++ b/.github/workflows/build-master-teal-x86_64.yaml
@@ -144,7 +144,6 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-teal
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-teal

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -146,7 +146,6 @@ jobs:
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-blue-arm64
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -144,7 +144,6 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -493,7 +493,6 @@ jobs:
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -717,7 +717,6 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -148,7 +148,6 @@ jobs:
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-orange-arm64
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -144,7 +144,6 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange

--- a/.github/workflows/build-releases-teal-arm64.yaml
+++ b/.github/workflows/build-releases-teal-arm64.yaml
@@ -146,7 +146,6 @@ jobs:
       ARCH: arm64
       FINAL_REPO: quay.io/costoolkit/releases-teal-arm64
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-teal

--- a/.github/workflows/build-releases-teal-x86_64.yaml
+++ b/.github/workflows/build-releases-teal-x86_64.yaml
@@ -144,7 +144,6 @@ jobs:
       ARCH: x86_64
       FINAL_REPO: quay.io/costoolkit/releases-teal
       DOWNLOAD_METADATA: true
-      DOWNLOAD_ALL: true
       DOWNLOAD_ONLY: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-teal


### PR DESCRIPTION
Rely into the snapshot repo in order to not publish the whole repo

Signed-off-by: Itxaka <igarcia@suse.com>