### PR TITLE
Fix tag and tag pushing for autorelease

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Get current tag
         id: current
         run: |
-          CURRENT_TAG=$(yq '.packages[]|select(.name=="cos" and .category =="system")|.version' packages/cos/collection.yaml)
+          CURRENT_TAG=$(yq '.packages[]|select(.name=="cos" and .category =="system")|.version|split("-")| .[0]' packages/cos/collection.yaml)
           echo "Current Tag: v$CURRENT_TAG"
           echo "::set-output name=tag::v$CURRENT_TAG"
       - name: Get previous tag
@@ -36,8 +36,15 @@ jobs:
             echo "Tag needs bump"
             echo "::set-output name=bumped::true"
           fi
-      - uses: rickstaa/action-create-tag@v1
+      - uses: actions/github-script@v6
         if: steps.check.outputs.bumped == 'true'
         with:
-          tag: ${{steps.current.outputs.tag}}
-          message: "Bump tag"
+          github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          script: |
+            console.log("Creating tag " + "${{steps.current.outputs.tag}}")
+            github.rest.git.createRef({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              ref: "refs/tags/${{steps.current.outputs.tag}}",
+              sha: context.sha
+            })


### PR DESCRIPTION
Ignore any build number (i.e. -NUMBER) that the bot auto pushes when
comparing version as we only want the semver to be pushed.

Also push the tag ourselves with the rest api so we can use the CiBot
PAT, which means that release jobs will be triggered on tag release.
Otherwise, because the tag cames from the github actions itself, the
jobs wont trigger. This is a deliberate decision from github in order to
avoid circular jobs.

Fixes: #1319

Signed-off-by: Itxaka <igarcia@suse.com>