### PR TITLE
Disable mtree verify by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ isowork/
 *.iso.sha256
 iso-meta.json
 iso-meta.yaml
+.idea/
 .qemu/
 .vagrant/
 ^Vagrantfile

--- a/docs/content/en/docs/Creating derivatives/creating_bootable_images.md
+++ b/docs/content/en/docs/Creating derivatives/creating_bootable_images.md
@@ -133,7 +133,7 @@ The workflow would be then:
 
 1) `docker build` the image
 2) `docker push` the image to some registry
-3) `elemental upgrade --no-verify --docker-image $IMAGE` from a cOS machine or (`elemental reset` if bootstrapping a cloud image)
+3) `elemental upgrade --docker-image $IMAGE` from a cOS machine or (`elemental reset` if bootstrapping a cloud image)
 
 The following can be incorporated in any standard gitops workflow.
 

--- a/docs/content/en/docs/Getting started/booting.md
+++ b/docs/content/en/docs/Getting started/booting.md
@@ -36,7 +36,7 @@ See also [../install] for installation options.
 After the first boot you can also switch to a derivative by:
 
 ```bash
-elemental upgrade --no-verify --system.uri $IMAGE
+elemental upgrade --verify --system.uri $IMAGE
 ```
 
 ## Booting from network

--- a/docs/content/en/docs/Getting started/install.md
+++ b/docs/content/en/docs/Getting started/install.md
@@ -26,7 +26,7 @@ elemental install [options] <device>
 | --help                       | help for install                                                                                             |
 | --iso string                 | Performs an installation from the ISO url                                                                    |
 | --no-format                  | Don’t format disks. It is implied that COS_STATE, COS_RECOVERY, COS_PERSISTENT, COS_OEM are already existing |
-| --no-verify                  | Disable mtree checksum verification (requires images manifests generated with mtree separately)              |
+| --verify                     | Enable mtree checksum verification (requires images manifests generated with mtree separately)               |
 | --part-table string          | Partition table type to use (default "gpt")                                                                  |
 | --poweroff                   | Shutdown the system after install                                                                            |
 | --reboot                     | Reboot the system after install                                                                              |

--- a/docs/content/en/docs/Getting started/upgrading.md
+++ b/docs/content/en/docs/Getting started/upgrading.md
@@ -22,7 +22,7 @@ This will perform an upgrade based on the default derivative configuration for t
 
 To specify a specific container image to upgrade to instead of the regular upgrade channels, run `elemental upgrade --system.uri imagei-uri`.
 
-_Note_ by default `elemental upgrade --system.uri` runs an mtree checksum verificatiom (requires images manifests generated with mtree separately). To disable image checksum verification, run `elemental upgrade --no-verify --system.uri`.
+_Note_ by default `elemental upgrade --system.uri` runs an mtree checksum verificatiom (requires images manifests generated with mtree separately). To disable image checksum verification, run `elemental upgrade --verify --system.uri`.
 
 ## Integration with System Upgrade Controller
 

--- a/docs/content/en/docs/Reference/troubleshooting.md
+++ b/docs/content/en/docs/Reference/troubleshooting.md
@@ -67,7 +67,7 @@ $> docker push $NEW_IMAGE
 In the derivative then it's sufficient to upgrade to that image with `elemental upgrade`:
 
 ```bash
-$> elemental upgrade --no-verify --docker-image $NEW_IMAGE
+$> elemental upgrade --docker-image $NEW_IMAGE
 ```
 
 ## Adding login keys at boot

--- a/examples/cos-official/README.md
+++ b/examples/cos-official/README.md
@@ -9,5 +9,5 @@ $ docker build -t $IMAGE .
 Push to some registry and upgrade your `cOS` vm to it:
 
 ```bash
-cos-vm $ elemental upgrade --docker-image --no-verify $IMAGE
+cos-vm $ elemental upgrade --docker-image $IMAGE
 ```

--- a/examples/scratch/README.md
+++ b/examples/scratch/README.md
@@ -9,5 +9,5 @@ $ docker build -t scratch .
 Push to some registry and upgrade your `cOS` vm to it:
 
 ```bash
-cos-vm $ elemental upgrade --docker-image --no-verify $IMAGE
+cos-vm $ elemental upgrade --docker-image $IMAGE
 ```

--- a/examples/standard/README.md
+++ b/examples/standard/README.md
@@ -9,5 +9,5 @@ $ docker build -t $IMAGE .
 Push to some registry and upgrade your `cOS` vm to it:
 
 ```bash
-cos-vm $ elemental upgrade --docker-image --no-verify $IMAGE
+cos-vm $ elemental upgrade --docker-image $IMAGE
 ```

--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: 0.8.12-1
+    version: 0.8.13
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:
@@ -10,12 +10,12 @@ packages:
   - !!merge <<: *cos
     name: "cos-container"
     description: "cOS container image, used to build cOS derivatives from scratch"
-    version: 0.8.12-2
+    version: 0.8.13
   - !!merge <<: *cos
     category: "recovery"
     brand_name: "cOS recovery"
     description: "cOS recovery image, used to boot cOS for troubleshooting"
-    version: 0.8.12-1
+    version: 0.8.13
   - !!merge <<: *cos
     name: "cos-img"
     category: "recovery"

--- a/tests/fallback/fallback_test.go
+++ b/tests/fallback/fallback_test.go
@@ -46,7 +46,7 @@ var _ = Describe("cOS booting fallback tests", func() {
 			// Auto assessment was installed
 			bootAssessmentInstalled()
 
-			out, err := s.Command(fmt.Sprintf("elemental upgrade --no-verify --system.uri docker:%s:cos-system-%s", s.ArtifactsRepo, s.TestVersion))
+			out, err := s.Command(fmt.Sprintf("elemental upgrade --system.uri docker:%s:cos-system-%s", s.ArtifactsRepo, s.TestVersion))
 			Expect(err).ToNot(HaveOccurred(), out)
 			Expect(out).Should(ContainSubstring("Upgrade completed"))
 

--- a/tests/upgrades-images-signed/upgrade_test.go
+++ b/tests/upgrades-images-signed/upgrade_test.go
@@ -49,7 +49,7 @@ var _ = Describe("cOS Upgrade tests - Images signed", func() {
 
 				version := out
 				By(fmt.Sprintf("upgrading to an old image: %s:cos-system-%s", s.ArtifactsRepo, s.TestVersion))
-				out, err = s.Command(fmt.Sprintf("elemental upgrade --system.uri docker:%s:cos-system-%s", s.ArtifactsRepo, s.TestVersion))
+				out, err = s.Command(fmt.Sprintf("elemental upgrade --verify --system.uri docker:%s:cos-system-%s", s.ArtifactsRepo, s.TestVersion))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).Should(
 					And(

--- a/tests/upgrades-images-unsigned/upgrade_test.go
+++ b/tests/upgrades-images-unsigned/upgrade_test.go
@@ -23,7 +23,7 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 	})
 	Context("After install", func() {
 		When("images are not signed", func() {
-			It("upgrades with --no-verify", func() {
+			It("upgrades", func() {
 
 				if s.GetArch() == "aarch64" {
 					By("Upgrading aarch64 system")
@@ -38,7 +38,7 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 				Expect(out).ToNot(Equal(""))
 
 				version := out
-				out, err = s.Command(fmt.Sprintf("elemental upgrade --no-verify --system.uri docker:%s:cos-system-%s", s.ArtifactsRepo, s.TestVersion))
+				out, err = s.Command(fmt.Sprintf("elemental upgrade --system.uri docker:%s:cos-system-%s", s.ArtifactsRepo, s.TestVersion))
 				Expect(err).ToNot(HaveOccurred(), out)
 				Expect(out).Should(ContainSubstring("Upgrade completed"))
 				By("rebooting")

--- a/tests/upgrades-local/upgrade_test.go
+++ b/tests/upgrades-local/upgrade_test.go
@@ -44,7 +44,7 @@ var _ = Describe("cOS Upgrade tests - local upgrades", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).ToNot(Equal(""))
 
-				out, err = s.Command("elemental upgrade --no-verify --directory /run/update")
+				out, err = s.Command("elemental upgrade --directory /run/update")
 				if err != nil {
 					fmt.Fprintf(GinkgoWriter, "Error from elemental upgrade: %v\n", err)
 				}


### PR DESCRIPTION
We would like to disable mtree plugin by default,
which seems to not be used for now.

Fixes #183

Signed-off-by: Michal Jura <mjura@suse.com>

This PR depends on https://github.com/rancher-sandbox/elemental/pull/208