### PR TITLE
ci: fail during metadata packages retrieve

### DIFF
--- a/.github/build.go
+++ b/.github/build.go
@@ -45,7 +45,11 @@ func repositoryPackages(repo string) (searchResult client.SearchResult) {
 
 	if err != nil {
 		fmt.Println("No packages found")
-		fmt.Println(err)
+		if os.Getenv("DOWNLOAD_FATAL_MISSING_PACKAGES") == "true" {
+			checkErr(err)
+		} else {
+			fmt.Println(err)
+		}
 	} else {
 		for _, p := range re.GetTree().GetDatabase().World() {
 			searchResult.Packages = append(searchResult.Packages, client.Package{

--- a/.github/build.yaml.gomplate
+++ b/.github/build.yaml.gomplate
@@ -565,6 +565,7 @@
       FINAL_REPO: {{{$config.organization}}}/{{{$config.repository}}}-{{{ $flavor }}}{{{- if ne $config.arch "x86_64"}}}-{{{$config.arch}}}{{{end}}}
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       {{{- if has $config "luet_install_from_cos_repo" }}}
       LUET_INSTALL_FROM_COS_REPO: {{{ $config.luet_install_from_cos_repo }}}
       {{{- end }}}

--- a/.github/workflows/build-master-blue-arm64.yaml
+++ b/.github/workflows/build-master-blue-arm64.yaml
@@ -147,6 +147,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-blue-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-master-blue-x86_64.yaml
+++ b/.github/workflows/build-master-blue-x86_64.yaml
@@ -145,6 +145,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-master-green-arm64.yaml
+++ b/.github/workflows/build-master-green-arm64.yaml
@@ -147,6 +147,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-master-green-x86_64.yaml
+++ b/.github/workflows/build-master-green-x86_64.yaml
@@ -145,6 +145,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-master-orange-arm64.yaml
+++ b/.github/workflows/build-master-orange-arm64.yaml
@@ -149,6 +149,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-orange-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-master-orange-x86_64.yaml
+++ b/.github/workflows/build-master-orange-x86_64.yaml
@@ -145,6 +145,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-master-teal-arm64.yaml
+++ b/.github/workflows/build-master-teal-arm64.yaml
@@ -494,6 +494,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-teal-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-teal
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-master-teal-x86_64.yaml
+++ b/.github/workflows/build-master-teal-x86_64.yaml
@@ -718,6 +718,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-teal
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-teal
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-releases-blue-arm64.yaml
+++ b/.github/workflows/build-releases-blue-arm64.yaml
@@ -147,6 +147,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-blue-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-releases-blue-x86_64.yaml
+++ b/.github/workflows/build-releases-blue-x86_64.yaml
@@ -145,6 +145,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-blue
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-blue
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-releases-green-arm64.yaml
+++ b/.github/workflows/build-releases-green-arm64.yaml
@@ -147,6 +147,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-green-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-releases-green-x86_64.yaml
+++ b/.github/workflows/build-releases-green-x86_64.yaml
@@ -145,6 +145,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-green
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-green
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-releases-orange-arm64.yaml
+++ b/.github/workflows/build-releases-orange-arm64.yaml
@@ -149,6 +149,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-orange-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-releases-orange-x86_64.yaml
+++ b/.github/workflows/build-releases-orange-x86_64.yaml
@@ -145,6 +145,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-orange
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-orange
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-releases-teal-arm64.yaml
+++ b/.github/workflows/build-releases-teal-arm64.yaml
@@ -494,6 +494,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-teal-arm64
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-teal
       PUBLISH_ARGS: "--plugin luet-cosign"

--- a/.github/workflows/build-releases-teal-x86_64.yaml
+++ b/.github/workflows/build-releases-teal-x86_64.yaml
@@ -718,6 +718,7 @@ jobs:
       FINAL_REPO: quay.io/costoolkit/releases-teal
       DOWNLOAD_METADATA: true
       DOWNLOAD_ONLY: true
+      DOWNLOAD_FATAL_MISSING_PACKAGES: true
       COSIGN_EXPERIMENTAL: 1 # use keyless signing
       COSIGN_REPOSITORY: raccos/releases-teal
       PUBLISH_ARGS: "--plugin luet-cosign"


### PR DESCRIPTION
Keeping the switch in case of bootstrapping new repos

Signed-off-by: Ettore Di Giacinto <edigiacinto@suse.com>