### PR TITLE
bump k8s runners docker version

### DIFF
--- a/.github/docker/ghrunner/k8s.yaml
+++ b/.github/docker/ghrunner/k8s.yaml
@@ -61,7 +61,7 @@ spec:
         emptyDir: {}
       containers:
       - name: dind
-        image: docker:20.10.9-dind
+        image: docker:20.10.16-dind
         command:
         - /usr/local/bin/dockerd-entrypoint.sh
         - --mtu=1100


### PR DESCRIPTION
Was hitting an error with the older version when changing the tool/distro to tumbleweed, it will just not build and failed with a very wrong error. Redeployed with the latest version of docker and it worked as expected.