### PR TITLE
Workaround for live packages on tumbleweed

### DIFF
--- a/packages/livecd/grub2/build.yaml
+++ b/packages/livecd/grub2/build.yaml
@@ -1,7 +1,14 @@
+{{ if .Values.arch }}
+  {{if and (eq .Values.arch "aarch64") (ne .Values.codename "green") }}
+image: {{ .Values.live_image }}
+  {{else}}
 requires:
 - name: "tool"
   category: "distro"
   version: ">=0"
+{{end}}
+{{end}}
+
 prelude:
 {{ if .Values.arch }}
   {{if eq .Values.arch "x86_64"}}

--- a/values/blue-arm64.yaml
+++ b/values/blue-arm64.yaml
@@ -5,6 +5,8 @@ arch: "aarch64"
 golang_arch: "arm64"
 skip_checksum: ["golang", "golang-fips"]
 
+# live_image is used to build live/* packages, which requires some x86+i386 packages
+live_image: opensuse/leap:15.3@sha256:74bf846453cef9eb12e22a7559580fd79673dcad85e5096b11379bee60c9518d
 tool_image: opensuse/tumbleweed:latest@sha256:017767fbf0778c00d3d5fa37cc16547f1a39e0e450a7c9086086f57f586363e9
 tool_image_distribution: "opensuse"
 tools_packages: >-

--- a/values/green-arm64.yaml
+++ b/values/green-arm64.yaml
@@ -5,6 +5,8 @@ arch: "aarch64"
 golang_arch: "arm64"
 skip_checksum: ["golang", "golang-fips"]
 
+# live_image is used to build live/* packages, which requires some x86+i386 packages
+live_image: opensuse/leap:15.3@sha256:74bf846453cef9eb12e22a7559580fd79673dcad85e5096b11379bee60c9518d
 tool_image: opensuse/tumbleweed:latest@sha256:017767fbf0778c00d3d5fa37cc16547f1a39e0e450a7c9086086f57f586363e9
 tool_image_distribution: "opensuse"
 tools_packages: >-

--- a/values/orange-arm64.yaml
+++ b/values/orange-arm64.yaml
@@ -5,6 +5,8 @@ arch: "aarch64"
 golang_arch: "arm64"
 skip_checksum: ["golang", "golang-fips"]
 
+# live_image is used to build live/* packages, which requires some x86+i386 packages
+live_image: opensuse/leap:15.3@sha256:74bf846453cef9eb12e22a7559580fd79673dcad85e5096b11379bee60c9518d
 tool_image: opensuse/tumbleweed:latest@sha256:017767fbf0778c00d3d5fa37cc16547f1a39e0e450a7c9086086f57f586363e9
 tool_image_distribution: "opensuse"
 tools_packages: >-


### PR DESCRIPTION
Current grub implementation for live isos requires several x86 AND i386 packages
which are no longer available under tumbleweed.

This patch works around it by using a leap image to build those grub
live packages if we are on aarch64+tumbleweed

Signed-off-by: Itxaka <igarcia@suse.com>