### PR TITLE
Revert tool_image change to tumbleweed

### DIFF
--- a/values/blue-arm64.yaml
+++ b/values/blue-arm64.yaml
@@ -5,7 +5,7 @@ arch: "aarch64"
 golang_arch: "arm64"
 skip_checksum: ["golang", "golang-fips"]
 
-tool_image: opensuse/tumbleweed:latest@sha256:017767fbf0778c00d3d5fa37cc16547f1a39e0e450a7c9086086f57f586363e9
+tool_image: opensuse/leap:15.3@sha256:30e1ea6881aaeefb8419a1295708fa523cdc089d1d38aa715552dc7feabbf8af
 tool_image_distribution: "opensuse"
 tools_packages: >-
     grub2-arm64-efi

--- a/values/blue-x86_64.yaml
+++ b/values/blue-x86_64.yaml
@@ -4,7 +4,7 @@ codename: "blue"
 arch: "x86_64"
 golang_arch: "amd64"
 
-tool_image: opensuse/tumbleweed:latest
+tool_image: opensuse/leap:15.3
 tool_image_distribution: "opensuse"
 tools_packages: >-
     grub2-i386-pc

--- a/values/green-arm64.yaml
+++ b/values/green-arm64.yaml
@@ -5,7 +5,7 @@ arch: "aarch64"
 golang_arch: "arm64"
 skip_checksum: ["golang", "golang-fips"]
 
-tool_image: opensuse/tumbleweed:latest@sha256:017767fbf0778c00d3d5fa37cc16547f1a39e0e450a7c9086086f57f586363e9
+tool_image: opensuse/leap:15.3@sha256:30e1ea6881aaeefb8419a1295708fa523cdc089d1d38aa715552dc7feabbf8af
 tool_image_distribution: "opensuse"
 tools_packages: >-
     grub2-arm64-efi

--- a/values/green-x86_64.yaml
+++ b/values/green-x86_64.yaml
@@ -4,7 +4,7 @@ codename: "green"
 arch: "x86_64"
 golang_arch: "amd64"
 
-tool_image: opensuse/tumbleweed:latest
+tool_image: opensuse/leap:15.3
 tool_image_distribution: "opensuse"
 tools_packages: >-
     grub2-i386-pc

--- a/values/orange-arm64.yaml
+++ b/values/orange-arm64.yaml
@@ -5,7 +5,7 @@ arch: "aarch64"
 golang_arch: "arm64"
 skip_checksum: ["golang", "golang-fips"]
 
-tool_image: opensuse/tumbleweed:latest@sha256:017767fbf0778c00d3d5fa37cc16547f1a39e0e450a7c9086086f57f586363e9
+tool_image: opensuse/leap:15.3@sha256:30e1ea6881aaeefb8419a1295708fa523cdc089d1d38aa715552dc7feabbf8af
 tool_image_distribution: "opensuse"
 tools_packages: >-
     grub2-arm64-efi

--- a/values/orange-x86_64.yaml
+++ b/values/orange-x86_64.yaml
@@ -4,7 +4,7 @@ codename: "orange"
 arch: "x86_64"
 golang_arch: "amd64"
 
-tool_image: opensuse/tumbleweed:latest
+tool_image: opensuse/leap:15.3
 tool_image_distribution: "opensuse"
 tools_packages: >-
     grub2-i386-pc


### PR DESCRIPTION
tool_image is used for static bin (golang) or artifacts (firmware, grub2
artifacts, live/grub artifacts) so it makes no sense to update it to
tumbleweed as that brings in more issues like missing packages

This patch reverts the tool_image to leap:15.3

Signed-off-by: Itxaka <igarcia@suse.com>