### PR TITLE
Bump cos and test helpers to fix arm64

### DIFF
--- a/packages/cos/collection.yaml
+++ b/packages/cos/collection.yaml
@@ -2,7 +2,7 @@ packages:
   - &cos
     name: "cos"
     category: "system"
-    version: "0.8.14-1"
+    version: "0.8.14-2"
     description: "cOS base image, used to build cOS live ISOs"
     brand_name: "cOS"
     labels:

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -5,5 +5,5 @@ go 1.14
 require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.17.0
-	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220527172218-91e4b18a1c7e
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220530120607-c0be46f669bd
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -54,6 +54,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220527172218-91e4b18a1c7e h1:R9dgCfDf0+ZKe5lPuFKmr22UTB7v0E7C2Nm4U3DTLtk=
 github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220527172218-91e4b18a1c7e/go.mod h1:VCKQij8+FXOxg0C9ivjdcdo5hBBfMBmk5Aa2gP421w0=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220530120607-c0be46f669bd h1:3CxBNUlwDW8GNNajpYKRNb5YDjU3oofxymvUrqCW4ZQ=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20220530120607-c0be46f669bd/go.mod h1:VCKQij8+FXOxg0C9ivjdcdo5hBBfMBmk5Aa2gP421w0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/tests/upgrades-images-unsigned/upgrade_test.go
+++ b/tests/upgrades-images-unsigned/upgrade_test.go
@@ -38,7 +38,7 @@ var _ = Describe("cOS Upgrade tests - Images unsigned", func() {
 				Expect(out).ToNot(Equal(""))
 
 				version := out
-				out, err = s.Command(fmt.Sprintf("elemental upgrade --system.uri docker:%s:cos-system-%s", s.ArtifactsRepo, s.TestVersion))
+				out, err = s.Command(fmt.Sprintf("elemental --debug --logfile /tmp/elemental.log upgrade --system.uri docker:%s:cos-system-%s", s.ArtifactsRepo, s.TestVersion))
 				Expect(err).ToNot(HaveOccurred(), out)
 				Expect(out).Should(ContainSubstring("Upgrade completed"))
 				By("rebooting")


### PR DESCRIPTION
As only the latest 0.8.14-1 version has a fixed kernel for arm64, any
upgrade jobs that "upgraded" to an older version would fail, as after
the upgrade the VM will fail to boot due to the kernel issue.

Now that the issue is fixed and packages are published, we can bump the
cos-version to be tested to a know working version.

Signed-off-by: Itxaka <igarcia@suse.com>