### PR TITLE
Fix Autorelease

### DIFF
--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -1,4 +1,4 @@
-name: autorelease
+name: Autorelease
 on:
   workflow_dispatch:
   schedule:
@@ -41,10 +41,11 @@ jobs:
         with:
           github-token: ${{ secrets.BOT_GITHUB_TOKEN }}
           script: |
+            console.log(context)
             console.log("Creating tag " + "${{steps.current.outputs.tag}}")
             github.rest.git.createRef({
-              owner: context.payload.repository.owner.login,
-              repo: context.payload.repository.name,
+              owner: "cOScibot@gmail.com",
+              repo: "rancher-sandbox/cos-toolkit",
               ref: "refs/tags/${{steps.current.outputs.tag}}",
               sha: context.sha
             })


### PR DESCRIPTION
Looks like scheduled events has minimal context so autoreleaser cannot infer the owner and the repo by itself

Signed-off-by: Itxaka <igarcia@suse.com>