### PR TITLE
Revert "Disable arm64 tests for now"

### DIFF
--- a/.github/config/master.yaml
+++ b/.github/config/master.yaml
@@ -52,7 +52,7 @@ flavors:
         repository: "releases"
         cache_repository: "build"
         organization: "quay.io/costoolkit"
-        skip_tests: true
+        skip_tests: false
         run_tests: ["test-smoke", "test-upgrades-images-unsigned" ]
         flavor: "teal"
         skip_tests_flavor: [ "blue","orange", "green"]

--- a/.github/workflows/build-master-teal-arm64.yaml
+++ b/.github/workflows/build-master-teal-arm64.yaml
@@ -223,6 +223,70 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+  tests-squashfs-teal:
+    env:
+      ARCH: arm64
+      VAGRANT_CPU: 2
+      VAGRANT_MEMORY: 5120
+      VAGRANT_FIRMWARE: /usr/share/AAVMF/AAVMF_CODE.fd
+      COS_HOST: "192.168.122.50:22"
+      COS_TIMEOUT: 1800
+    runs-on: ubuntu-latest
+    needs: qemu-squashfs-teal
+    strategy:
+      matrix:
+        test: [test-smoke, test-upgrades-images-unsigned]
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+            go-version: '1.17'
+      - uses: actions/checkout@v2
+      - name: Download vagrant box
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-Packer-squashfs-teal-QEMU-arm64.box
+          path: packer
+      - name: Install deps
+        run: |
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get remove -y apparmor*
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 vagrant make libvirt-daemon-system bridge-utils ovmf
+      - name: Prepare libvirt
+        run: |
+          # Create bridge conf
+          sudo mkdir -p /etc/qemu/
+          echo "allow all" | sudo tee -a /etc/qemu/bridge.conf
+          sudo chmod u+r /etc/qemu/bridge.conf
+          sudo chmod u+s $(find /usr/ -name qemu-bridge-helper -print -quit|xargs)
+          # Set a static ip for our VM
+          sudo virsh net-update default add ip-dhcp-host "<host mac='52:54:00:00:00:01' name='jojo' ip='192.168.122.50' />" --live --config
+      - name: Enable serial for default vagrant-libvirt machine
+        run: |
+          # vagrant-libvirt does not support adding serials from config yet so we need to modify the default template directly
+          sudo sed -i "s|<serial type='pty'>|<serial type='file'><source path='$GITHUB_WORKSPACE/serial_log.log'/>|" $(sudo find /usr/share -name "domain.xml.erb" -print -quit|xargs)
+      - name: Prepare tests 🔧
+        run: |
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          make test-clean
+          make prepare-test
+      - name: Run tests 🔧
+        run: |
+          make ${{ matrix.test }}
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cOS-squashfs-${{ matrix.test }}.logs.zip
+          path: tests/**/logs/*
+          if-no-files-found: warn
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cOS-squashfs-${{ matrix.test }}.serial.zip
+          path: serial_log.log
+          if-no-files-found: warn
   qemu-nonsquashfs-teal:
     runs-on: ubuntu-latest
     needs: iso-nonsquashfs-teal
@@ -270,6 +334,70 @@ jobs:
           path: |
             packer/*.box
           if-no-files-found: error
+  tests-nonsquashfs-teal:
+    env:
+      ARCH: arm64
+      VAGRANT_CPU: 2
+      VAGRANT_MEMORY: 5120
+      VAGRANT_FIRMWARE: /usr/share/AAVMF/AAVMF_CODE.fd
+      COS_HOST: "192.168.122.50:22"
+      COS_TIMEOUT: 1800
+    runs-on: ubuntu-latest
+    needs: qemu-nonsquashfs-teal
+    strategy:
+      matrix:
+        test: [test-smoke, test-upgrades-images-unsigned]
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+            go-version: '1.17'
+      - uses: actions/checkout@v2
+      - name: Download vagrant box
+        uses: actions/download-artifact@v2
+        with:
+          name: cOS-Packer-nonsquashfs-teal-QEMU-arm64.box
+          path: packer
+      - name: Install deps
+        run: |
+          sudo -E make deps
+          sudo apt-get update
+          sudo apt-get remove -y apparmor*
+          sudo apt-get install -y qemu-system-arm qemu-efi-aarch64 vagrant make libvirt-daemon-system bridge-utils ovmf
+      - name: Prepare libvirt
+        run: |
+          # Create bridge conf
+          sudo mkdir -p /etc/qemu/
+          echo "allow all" | sudo tee -a /etc/qemu/bridge.conf
+          sudo chmod u+r /etc/qemu/bridge.conf
+          sudo chmod u+s $(find /usr/ -name qemu-bridge-helper -print -quit|xargs)
+          # Set a static ip for our VM
+          sudo virsh net-update default add ip-dhcp-host "<host mac='52:54:00:00:00:01' name='jojo' ip='192.168.122.50' />" --live --config
+      - name: Enable serial for default vagrant-libvirt machine
+        run: |
+          # vagrant-libvirt does not support adding serials from config yet so we need to modify the default template directly
+          sudo sed -i "s|<serial type='pty'>|<serial type='file'><source path='$GITHUB_WORKSPACE/serial_log.log'/>|" $(sudo find /usr/share -name "domain.xml.erb" -print -quit|xargs)
+      - name: Prepare tests 🔧
+        run: |
+          go get -u github.com/onsi/ginkgo/ginkgo
+          go get -u github.com/onsi/gomega/...
+          make test-clean
+          make prepare-test
+      - name: Run tests 🔧
+        run: |
+          make ${{ matrix.test }}
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cOS-nonsquashfs-${{ matrix.test }}.logs.zip
+          path: tests/**/logs/*
+          if-no-files-found: warn
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cOS-nonsquashfs-${{ matrix.test }}.serial.zip
+          path: serial_log.log
+          if-no-files-found: warn
   image-link-teal:
     runs-on: ubuntu-latest
     needs: publish-teal
@@ -292,9 +420,7 @@ jobs:
             images-teal-arm64.txt
   publish-teal:
     runs-on: ubuntu-latest
-    needs:
-    - build-teal-arm64
-    - iso-squashfs-teal
+    needs: tests-squashfs-teal
     permissions:
       id-token: write  # undocumented OIDC support.
     env:


### PR DESCRIPTION
Reverts rancher-sandbox/cOS-toolkit#1383

Once packages have been published for at least 2 different versions, we can merge this to re-enable tests for arm64